### PR TITLE
🔀 :: 미니플레이어가 안올라오는 문제 및 재생이 안되던 문제 수정

### DIFF
--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
@@ -46,6 +46,7 @@ extension PlayState {
             self.list = list
         }
         public var currentPlayIndex: Int? { return list.firstIndex(where: { $0.isPlaying == true }) }
+        public var currentPlaySong: SongEntity? { list[safe: currentPlayIndex ?? -1]?.item }
         public var first: SongEntity? { return list.first?.item }
         public var last: SongEntity? { return list.last?.item }
         public var count: Int { return list.count }

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState.swift
@@ -35,7 +35,9 @@ final public class PlayState {
         
         let playedList = fetchPlayListFromLocalDB()
         playList.list = playedList
+        
         currentSong = playList.list[safe: playList.currentPlayIndex ?? -1]?.item
+        player.cue(source: .video(id: currentSong?.id ?? "")) // 곡이 있으면 .cued 없으면 .unstarted
         
         player.playbackStatePublisher.sink { [weak self] state in
             guard let self = self else { return }

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState.swift
@@ -33,10 +33,8 @@ final public class PlayState {
         shuffleMode = .off
         player = YouTubePlayer(configuration: .init(autoPlay: false, showControls: false, showRelatedVideos: false))
         
-        let playedList = fetchPlayListFromLocalDB()
-        playList.list = playedList
-        
-        currentSong = playList.list[safe: playList.currentPlayIndex ?? -1]?.item
+        playList.list = fetchPlayListFromLocalDB()
+        currentSong = playList.currentPlaySong
         player.cue(source: .video(id: currentSong?.id ?? "")) // 곡이 있으면 .cued 없으면 .unstarted
         
         player.playbackStatePublisher.sink { [weak self] state in

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
@@ -172,6 +172,7 @@ final class PlaylistViewModel: ViewModelType {
             .subscribe(onNext: { [weak self] selectedIndexs in
                 if selectedIndexs.count == self?.playState.playList.count {
                     self?.playState.playList.removeAll()
+                    self?.playState.switchPlayerMode(to: .close)
                     output.willClosePlaylist.send()
                 } else {
                     self?.playState.playList.remove(indexs: selectedIndexs)


### PR DESCRIPTION
## 개요

## 작업사항

**미니플레이어가 안올라오는 문제** #236
```Swift
player = YouTubePlayer(configuration: .init(autoPlay: false, showControls: false, showRelatedVideos: false))
```
PlayState init 에서 YoutubePlayer를 위 코드처럼 초기화해주고있는데 언뜻보면 source가 nil이니까 .unstarted 일 것같지만 .cued로 변경되고 있었습니다.
```Swift
player.cue(source: .video(id: ""))
```
그래서 source에 빈 문자열을 id로 넘겨주면 .unstarted로 변경된다는 점을 이용해 PlayState init시 .unstarted 상태가 유지되도록 했습니다.

**재생이 안되던 문제**
확인해보니 realmDB에서 플레이리스트는 불러왔지만 YoutubePlayer에 cue가 되지않아 재생버튼을 눌러도 동작하지 않는 문제였습니다.
```Swift
player.cue(source: .video(id: currentSong?.id ?? ""))
```
realmDB에서 불러온 곡이 있으면 cue에 넣고, 없으면 id로 빈문자열을 넘겨 .unstarted 상태를 유지하도록 했습니다. 

Closes #236