### PR TITLE
🔀 :: 재생 목록 > 편집 완료 시점에서 DB 업데이트 하도록 변경

### DIFF
--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistViewController.swift
@@ -94,7 +94,7 @@ extension ArtistViewController {
 //        layout.minimumLineSpacing = 15
         layout.minimumInteritemSpacing = 8 // 열 사이의 간격
         layout.headerHeight = 0
-        layout.footerHeight = 50.0
+        layout.footerHeight = 56.0
         
         self.collectionView.setCollectionViewLayout(layout, animated: false)
         self.collectionView.showsVerticalScrollIndicator = false

--- a/Projects/Features/CommonFeature/Resources/CommonUI.storyboard
+++ b/Projects/Features/CommonFeature/Resources/CommonUI.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -183,7 +183,7 @@
                                 </constraints>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="55y-I8-uJW">
-                                <rect key="frame" x="0.0" y="159" width="393" height="659"/>
+                                <rect key="frame" x="0.0" y="159" width="393" height="693"/>
                                 <color key="backgroundColor" name="gray100"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="CurrentPlayListTableViewCell" id="ibc-jy-gnQ" customClass="CurrentPlayListTableViewCell" customModule="CommonFeature">
@@ -253,7 +253,7 @@
                             <constraint firstAttribute="trailing" secondItem="fUZ-Dc-OJs" secondAttribute="trailing" id="fEx-jn-mh1"/>
                             <constraint firstItem="fUZ-Dc-OJs" firstAttribute="leading" secondItem="FR1-Wa-zfj" secondAttribute="leading" id="fr3-Eo-iGm"/>
                             <constraint firstItem="55y-I8-uJW" firstAttribute="top" secondItem="170-Tn-9JZ" secondAttribute="bottom" constant="12" id="jBV-Un-BK4"/>
-                            <constraint firstItem="FR1-Wa-zfj" firstAttribute="bottom" secondItem="55y-I8-uJW" secondAttribute="bottom" id="kQS-68-GKS"/>
+                            <constraint firstAttribute="bottom" secondItem="55y-I8-uJW" secondAttribute="bottom" id="kgN-Ra-Jdz"/>
                             <constraint firstItem="FR1-Wa-zfj" firstAttribute="trailing" secondItem="170-Tn-9JZ" secondAttribute="trailing" constant="20" id="of3-VI-Nle"/>
                             <constraint firstItem="55y-I8-uJW" firstAttribute="leading" secondItem="FR1-Wa-zfj" secondAttribute="leading" id="vQc-N5-AJ9"/>
                         </constraints>

--- a/Projects/Features/CommonFeature/Resources/CommonUI.storyboard
+++ b/Projects/Features/CommonFeature/Resources/CommonUI.storyboard
@@ -186,31 +186,37 @@
                                 <rect key="frame" x="0.0" y="159" width="393" height="693"/>
                                 <color key="backgroundColor" name="gray100"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="CurrentPlayListTableViewCell" id="ibc-jy-gnQ" customClass="CurrentPlayListTableViewCell" customModule="CommonFeature">
-                                        <rect key="frame" x="0.0" y="50" width="393" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="CurrentPlayListTableViewCell" rowHeight="60" id="ibc-jy-gnQ" customClass="CurrentPlayListTableViewCell" customModule="CommonFeature">
+                                        <rect key="frame" x="0.0" y="50" width="393" height="60"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ibc-jy-gnQ" id="Xlw-Xm-qxX">
-                                            <rect key="frame" x="0.0" y="0.0" width="393" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="393" height="60"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="l7W-VM-RKZ">
-                                                    <rect key="frame" x="20" y="2" width="40" height="40"/>
+                                                    <rect key="frame" x="20" y="10" width="40" height="40"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="40" id="5fq-FZ-LXe"/>
                                                         <constraint firstAttribute="width" constant="40" id="8r0-ch-uPv"/>
                                                     </constraints>
                                                 </imageView>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="g5t-PE-qYZ">
-                                                    <rect key="frame" x="68" y="1.6666666666666679" width="41.333333333333343" height="40.666666666666657"/>
+                                                    <rect key="frame" x="68" y="9" width="305" height="42"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EfG-aF-69w">
-                                                            <rect key="frame" x="0.0" y="0.0" width="41.333333333333336" height="20.333333333333332"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="305" height="24"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="24" id="58q-He-hCR"/>
+                                                            </constraints>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uEy-aO-aIe">
-                                                            <rect key="frame" x="0.0" y="20.333333333333336" width="41.333333333333336" height="20.333333333333336"/>
+                                                            <rect key="frame" x="0.0" y="24" width="305" height="18"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="18" id="uln-TK-gD1"/>
+                                                            </constraints>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -221,6 +227,7 @@
                                             <constraints>
                                                 <constraint firstItem="g5t-PE-qYZ" firstAttribute="centerY" secondItem="l7W-VM-RKZ" secondAttribute="centerY" id="3pZ-hC-Ij0"/>
                                                 <constraint firstItem="l7W-VM-RKZ" firstAttribute="leading" secondItem="Xlw-Xm-qxX" secondAttribute="leading" constant="20" id="lo1-qa-4sT"/>
+                                                <constraint firstAttribute="trailing" secondItem="g5t-PE-qYZ" secondAttribute="trailing" constant="20" id="sch-Tr-uUT"/>
                                                 <constraint firstItem="g5t-PE-qYZ" firstAttribute="leading" secondItem="l7W-VM-RKZ" secondAttribute="trailing" constant="8" id="wVy-WP-nK9"/>
                                                 <constraint firstItem="l7W-VM-RKZ" firstAttribute="centerY" secondItem="Xlw-Xm-qxX" secondAttribute="centerY" id="yqY-NE-pAn"/>
                                             </constraints>

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
@@ -125,14 +125,13 @@ extension PlayState {
             let movedData = list[from]
             list.remove(at: from)
             list.insert(movedData, at: to)
-            listReordered.send(list)
+            //Comment: 순서가 변경되어도 DB를 업데이트 하지 않음
+            //listReordered.send(list)
         }
         
         /// 해당 곡이 이미 재생목록에 있으면 재생목록 속 해당 곡의 index, 없으면 nil 리턴
         public func uniqueIndex(of item: PlayListItem) -> Int? {
             return list.firstIndex(where: { $0.item == item.item })
         }
-        
     }
-    
 }

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState.swift
@@ -79,7 +79,7 @@ final public class PlayState {
         
     }
     
-    func fetchPlayListFromLocalDB() -> [PlayListItem] {
+    public func fetchPlayListFromLocalDB() -> [PlayListItem] {
         let playedList = RealmManager.shared.realm.objects(PlayedLists.self)
             .toArray(type: PlayedLists.self)
             .map { PlayListItem(item:

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -91,12 +91,11 @@ extension ContainSongsViewController {
             }.disposed(by: disposeBag)
         
         tableView.rx.itemSelected
-            .withLatestFrom(output.dataSource){ ($0,$1) }
-            .subscribe(onNext: { [weak self] (indexPath, models) in
-                guard let self  = self else{ return }
-                let model = models[indexPath.row]
-                self.output.containSongWithKey.onNext(model.key)
-            })
+            .withLatestFrom(output.dataSource){ ($0, $1) }
+            .map{ (indexPath, models) -> String in
+                return models[indexPath.row].key
+            }
+            .bind(to: input.containSongWithKey)
             .disposed(by: disposeBag)
                 
         output.showToastMessage

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -75,14 +75,16 @@ extension ContainSongsViewController {
                 self.tableView.tableFooterView = model.isEmpty ?  warningView : nil
                 self.indicator.stopAnimating()
             })
-            .bind(to: tableView.rx.items){ [weak self] (tableView,index,model) -> UITableViewCell in
-                guard let self = self else { return UITableViewCell() }
-                
+            .bind(to: tableView.rx.items){ (tableView,index,model) -> UITableViewCell in
                 let bgView = UIView()
                 bgView.backgroundColor = DesignSystemAsset.GrayColor.gray200.color.withAlphaComponent(0.6)
                 
-                guard let cell = tableView.dequeueReusableCell(withIdentifier: "CurrentPlayListTableViewCell",for: IndexPath(row: index, section: 0)) as? CurrentPlayListTableViewCell
-                else {return UITableViewCell()}
+                guard let cell = tableView.dequeueReusableCell(
+                    withIdentifier: "CurrentPlayListTableViewCell",
+                    for: IndexPath(row: index, section: 0)) as? CurrentPlayListTableViewCell
+                else {
+                    return UITableViewCell()
+                }
             
                 cell.backgroundColor = DesignSystemAsset.GrayColor.gray100.color
                 cell.selectedBackgroundView = bgView
@@ -152,9 +154,7 @@ extension ContainSongsViewController : UITableViewDelegate {
 
 extension ContainSongsViewController : ContainPlayListHeaderViewDelegate {
     public func action() {
-        let vc = multiPurposePopComponent.makeView(type: .creation) {[weak self]  (_:String) in
-            guard let self = self else {return}
-        }
+        let vc = multiPurposePopComponent.makeView(type: .creation)
         self.showPanModal(content: vc)
     }
 }

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -19,45 +19,100 @@ public final class ContainSongsViewController: BaseViewController,ViewController
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var indicator: NVActivityIndicatorView!
-    
     @IBOutlet weak var subTitleLabel: UILabel!
     @IBOutlet weak var songCountLabel: UILabel!
     
-    
     var multiPurposePopComponent : MultiPurposePopComponent!
-    
-    
-    
     var disposeBag = DisposeBag()
     var viewModel:ContainSongsViewModel!
     lazy var input = ContainSongsViewModel.Input()
     lazy var output = viewModel.transform(from: input)
     
-    
+    deinit { DEBUG_LOG("❌ \(Self.self) Deinit") }
+
     public override func viewDidLoad() {
         super.viewDidLoad()
-        
         configureUI()
-
-        // Do any additional setup after loading the view.
+        bindRx()
     }
     
-    public static func viewController(multiPurposePopComponent:MultiPurposePopComponent,viewModel:ContainSongsViewModel) -> ContainSongsViewController {
+    public static func viewController(
+        multiPurposePopComponent: MultiPurposePopComponent,
+        viewModel: ContainSongsViewModel
+    ) -> ContainSongsViewController {
         let viewController = ContainSongsViewController.viewController(storyBoardName: "CommonUI", bundle: Bundle.module)
-        
-        
         viewController.multiPurposePopComponent = multiPurposePopComponent
-    
         viewController.viewModel = viewModel
-    
-       
         return viewController
     }
-    
-
 }
 
 extension ContainSongsViewController {
+    
+    private func bindRx() {
+        tableView.rx.setDelegate(self).disposed(by: disposeBag)
+        
+        closeButton.rx.tap.subscribe(onNext: { [weak self] _ in
+            self?.dismiss(animated: true)
+        })
+        .disposed(by: disposeBag)
+        
+        output.dataSource
+            .skip(1)
+            .do(onNext: { [weak self] model in
+                guard let self = self else {
+                    return
+                }
+                let window: UIWindow? = UIApplication.shared.windows.first
+                let safeAreaInsetsTop: CGFloat = window?.safeAreaInsets.top ?? 0
+                let safeAreaInsetsBottom: CGFloat = window?.safeAreaInsets.bottom ?? 0
+                
+                let space = APP_HEIGHT() - 48 - 16 - 24 - 12 - 52 - 12 -  safeAreaInsetsTop - safeAreaInsetsBottom
+                let height = space / 3  * 2
+                
+                let warningView = WarningView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: height))
+                warningView.text = "내 리스트가 없습니다."
+                self.tableView.tableFooterView = model.isEmpty ?  warningView : nil
+                self.indicator.stopAnimating()
+            })
+            .bind(to: tableView.rx.items){ [weak self] (tableView,index,model) -> UITableViewCell in
+                guard let self = self else { return UITableViewCell() }
+                
+                let bgView = UIView()
+                bgView.backgroundColor = DesignSystemAsset.GrayColor.gray200.color.withAlphaComponent(0.6)
+                
+                guard let cell = tableView.dequeueReusableCell(withIdentifier: "CurrentPlayListTableViewCell",for: IndexPath(row: index, section: 0)) as? CurrentPlayListTableViewCell
+                else {return UITableViewCell()}
+            
+                cell.backgroundColor = DesignSystemAsset.GrayColor.gray100.color
+                cell.selectedBackgroundView = bgView
+                cell.update(model: model)
+                return cell
+            }.disposed(by: disposeBag)
+        
+        tableView.rx.itemSelected
+            .withLatestFrom(output.dataSource){ ($0,$1) }
+            .subscribe(onNext: { [weak self] (indexPath, models) in
+                guard let self  = self else{ return }
+                let model = models[indexPath.row]
+                self.output.containSongWithKey.onNext(model.key)
+            })
+            .disposed(by: disposeBag)
+                
+        output.showToastMessage
+            .subscribe(onNext: { [weak self] (text:String) in
+                guard let self = self else {return}
+                self.showToast(text: text, font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
+                NotificationCenter.default.post(name: .playListRefresh, object: nil) // 플리목록창 이름 변경하기 위함
+                self.dismiss(animated: true)
+            })
+            .disposed(by: disposeBag)
+        
+        NotificationCenter.default.rx.notification(.playListRefresh)
+            .map{ _ in () }
+            .bind(to: input.playListLoad)
+            .disposed(by: disposeBag)
+    }
     
     private func configureUI() {
         closeButton.setImage(DesignSystemAsset.Navigation.close.image, for: .normal)
@@ -76,103 +131,7 @@ extension ContainSongsViewController {
         indicator.type = .circleStrokeSpin
         indicator.color = DesignSystemAsset.PrimaryColor.point.color
         indicator.startAnimating()
-        bindRx()
-        
-        
     }
-    
-    private func bindRx() {
-        
-        tableView.rx.setDelegate(self).disposed(by: disposeBag)
-        
-        
-        closeButton.rx.tap.subscribe(onNext: {
-            
-            self.dismiss(animated: true)
-            
-        })
-        .disposed(by: disposeBag)
-        
-        
-        output.dataSource
-        .skip(1)
-        .do(onNext: { [weak self] model in
-            
-            guard let self = self else {
-                return
-            }
-            
-            let window: UIWindow? = UIApplication.shared.windows.first
-            let safeAreaInsetsTop: CGFloat = window?.safeAreaInsets.top ?? 0
-            let safeAreaInsetsBottom: CGFloat = window?.safeAreaInsets.bottom ?? 0
-            
-            let space = APP_HEIGHT() - 48 - 16 - 24 - 12 - 52 - 12 -  safeAreaInsetsTop - safeAreaInsetsBottom
-            
-            let height = space / 3  * 2
-            
-            let warningView = WarningView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: height))
-            warningView.text = "내 리스트가 없습니다."
-            
-            
-            self.tableView.tableFooterView = model.isEmpty ?  warningView : nil
-            self.indicator.stopAnimating()
-            
-            
-        })
-            .bind(to: tableView.rx.items){[weak self] (tableView,index,model) -> UITableViewCell in
-                guard let self = self else{return UITableViewCell()}
-                
-                let bgView = UIView()
-                bgView.backgroundColor = DesignSystemAsset.GrayColor.gray200.color.withAlphaComponent(0.6)
-                
-                
-                guard let cell = tableView.dequeueReusableCell(withIdentifier: "CurrentPlayListTableViewCell",for: IndexPath(row: index, section: 0)) as? CurrentPlayListTableViewCell
-                else {return UITableViewCell()}
-            
-                cell.backgroundColor = DesignSystemAsset.GrayColor.gray100.color
-                cell.selectedBackgroundView = bgView
-                cell.update(model: model)
-              
-                        
-             return cell
-            }.disposed(by: disposeBag)
-        
-        
-        
-    tableView.rx.itemSelected
-        .withLatestFrom(output.dataSource){ ($0,$1) }
-        .subscribe(onNext: { [weak self] (indexPath, models) in
-            
-            guard let self  = self else{
-                return
-            }
-            
-            
-            let model = models[indexPath.row]
-            
-            self.output.containSongWithKey.onNext(model.key)
-            
-            
-            
-        })
-        .disposed(by: disposeBag)
-        
-     
-        
-        output.showToastMessage
-            .subscribe(onNext: { [weak self] (text:String) in
-            
-            guard let self = self else {return}
-            
-            
-            self.showToast(text: text, font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
-            NotificationCenter.default.post(name: .playListRefresh, object: nil) // 플리목록창 이름 변경하기 위함
-            
-            self.dismiss(animated: true)
-        })
-        .disposed(by: disposeBag)
-    }
-    
 }
 
 extension ContainSongsViewController : UITableViewDelegate {
@@ -182,42 +141,21 @@ extension ContainSongsViewController : UITableViewDelegate {
     }
     
     public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-
-
         let header = ContainPlayListHeaderView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: 140))
-
-
         header.delegate = self
         return header
     }
     
     public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        
-        
         return 64
-        
-        
     }
 }
 
 extension ContainSongsViewController : ContainPlayListHeaderViewDelegate {
     public func action() {
-        DEBUG_LOG("추가추가")
-        
         let vc = multiPurposePopComponent.makeView(type: .creation) {[weak self]  (_:String) in
-            
             guard let self = self else {return}
-            
-            NotificationCenter.default.rx.notification(.playListRefresh)
-                .map({_ in () })
-                .bind(to: self.input.playListLoad)
-                .disposed(by: self.disposeBag)
-            
         }
         self.showPanModal(content: vc)
-        
-        
     }
-    
-    
 }

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -120,15 +120,19 @@ extension ContainSongsViewController {
         
         titleLabel.font = DesignSystemFontFamily.Pretendard.medium.font(size: 16)
         titleLabel.textColor = DesignSystemAsset.GrayColor.gray900.color
-        
+        titleLabel.text = "리스트에 담기"
+        titleLabel.setLineSpacing(kernValue: -0.5)
+
         subTitleLabel.font =  DesignSystemFontFamily.Pretendard.medium.font(size: 14)
         subTitleLabel.textColor = DesignSystemAsset.GrayColor.gray900.color
+        subTitleLabel.text = "담을곡"
+        subTitleLabel.setLineSpacing(kernValue: -0.5)
         
         songCountLabel.font = DesignSystemFontFamily.Pretendard.medium.font(size: 14)
         songCountLabel.textColor = DesignSystemAsset.PrimaryColor.point.color
-        
         songCountLabel.text = "\(viewModel.songs.count)곡"
-        
+        songCountLabel.setLineSpacing(kernValue: -0.5)
+
         indicator.type = .circleStrokeSpin
         indicator.color = DesignSystemAsset.PrimaryColor.point.color
         indicator.startAnimating()

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/PlayListDetailViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/PlayListDetailViewController.swift
@@ -156,10 +156,14 @@ extension PlayListDetailViewController{
         self.completeButton.backgroundColor = .clear
     
         self.editStateLabel.font = DesignSystemFontFamily.Pretendard.medium.font(size: 16)
-        
+        self.editStateLabel.setLineSpacing(kernValue: -0.5)
+
         self.playListCountLabel.font = DesignSystemFontFamily.Pretendard.light.font(size: 14)
         self.playListCountLabel.textColor =  DesignSystemAsset.GrayColor.gray900.color.withAlphaComponent(0.6) // opacity 60%
+        self.playListCountLabel.setLineSpacing(kernValue: -0.5)
+
         self.playListNameLabel.font  = DesignSystemFontFamily.Pretendard.bold.font(size: 20)
+        self.playListNameLabel.setLineSpacing(kernValue: -0.5)
         
         playListInfoView.layer.borderWidth = 1
         playListInfoView.layer.borderColor = colorFromRGB(0xFCFCFD).cgColor

--- a/Projects/Features/CommonFeature/Sources/ViewModels/ContainSongsViewModel.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewModels/ContainSongsViewModel.swift
@@ -12,26 +12,20 @@ import RxRelay
 import DomainModule
 import RxSwift
 
-public final class ContainSongsViewModel:ViewModelType {
-
-    
-    
+public final class ContainSongsViewModel: ViewModelType {
     var fetchPlayListUseCase:FetchPlayListUseCase!
     var addSongIntoPlayListUseCase:AddSongIntoPlayListUseCase!
     var songs:[String]!
-    
     let disposeBag = DisposeBag()
     
     public struct Input {
-        
-        let newPlayListTap:PublishSubject<Void> = PublishSubject()
-        let playListLoad:BehaviorRelay<Void> = BehaviorRelay(value: ())
-        
+        let newPlayListTap: PublishSubject<Void> = PublishSubject()
+        let playListLoad: BehaviorRelay<Void> = BehaviorRelay(value: ())
+        let containSongWithKey: PublishSubject<String> = PublishSubject()
     }
     
     public struct Output{
         let dataSource: BehaviorRelay<[PlayListEntity]> = BehaviorRelay(value: [])
-        let containSongWithKey: PublishSubject<String> = PublishSubject()
         let showToastMessage: PublishSubject<String> = PublishSubject()
     }
     
@@ -39,25 +33,16 @@ public final class ContainSongsViewModel:ViewModelType {
         self.fetchPlayListUseCase = fetchPlayListUseCase
         self.addSongIntoPlayListUseCase = addSongIntoPlayListUseCase
         self.songs = songs
-        
     }
     
     public func transform(from input: Input) -> Output {
-        
         let output = Output()
-        
-        
-        
         
         input.playListLoad
             .flatMap({ [weak self] () -> Observable<[PlayListEntity]> in
-
                 guard let self = self else{
                     return Observable.empty()
                 }
-                
-        
-
                 return self.fetchPlayListUseCase.execute()
                     .asObservable()
                     .catchAndReturn([])
@@ -65,44 +50,29 @@ public final class ContainSongsViewModel:ViewModelType {
             .bind(to: output.dataSource)
             .disposed(by: disposeBag)
         
-        output.containSongWithKey
+        input.containSongWithKey
             .flatMap({ [weak self] (key:String) -> Observable<AddSongEntity> in
-                
-                
                 guard let self = self else {
                     return Observable.empty()
                 }
-                
-                
                 return self.addSongIntoPlayListUseCase.execute(key: key, songs: self.songs)
                         .catchAndReturn(AddSongEntity(status: 400, added_songs_length: 0, duplicated: true))
                         .asObservable()
             })
             .map({ (entity:AddSongEntity) -> String in
-                
                 if entity.status == 200 {
-                    
                     if entity.duplicated {
                         return ("\(entity.added_songs_length)곡이 내 보관함에 담겼습니다. 중복 곡은 제외됩니다.")
-                    }
-                    
-                    else {
+                    }else {
                         return ("\(entity.added_songs_length)곡이 내 보관함에 담겼습니다.")
                     }
-                    
-                    
-                }
-                else {
+                }else {
                     return (" 이미 내 보관함에 담긴 곡들입니다.")
                 }
-                
             })
             .bind(to: output.showToastMessage)
             .disposed(by: disposeBag)
         
-        
         return output
     }
-    
-    
 }

--- a/Projects/Features/CommonFeature/Sources/Views/ContainPlayListHeaderView.swift
+++ b/Projects/Features/CommonFeature/Sources/Views/ContainPlayListHeaderView.swift
@@ -9,27 +9,20 @@
 import UIKit
 import DesignSystem
 
-
 public protocol ContainPlayListHeaderViewDelegate : AnyObject {
-    
     func action()
-    
 }
 
 class ContainPlayListHeaderView: UIView {
-
     @IBOutlet weak var superView: UIView!
     @IBOutlet weak var button: UIButton!
     @IBOutlet weak var buttonImageView: UIImageView!
     
-    
     weak var delegate:ContainPlayListHeaderViewDelegate?
-    
     
     @IBAction func buttonAction(_ sender: Any) {
         self.delegate?.action()
     }
-    
    
     override init(frame: CGRect) { //코드쪽에서 생성 시 호출
         super.init(frame: frame)
@@ -42,7 +35,6 @@ class ContainPlayListHeaderView: UIView {
         self.setupView()
     }
     
-    
     private func setupView()
     {
         if let view = Bundle.module.loadNibNamed("ContainPlayListHeaderView", owner: self,options: nil)!.first as? UIView{
@@ -53,19 +45,19 @@ class ContainPlayListHeaderView: UIView {
         
         self.buttonImageView.image = DesignSystemAsset.Storage.storageNewPlaylistAdd.image
        
-        let attr = NSMutableAttributedString(string: "새  리스트 만들기",
-                                             attributes: [.font: DesignSystemFontFamily.Pretendard.medium.font(size: 14),
-                                                          .foregroundColor:  DesignSystemAsset.GrayColor.gray900.color ])
- 
+        let attr = NSMutableAttributedString(
+            string: "새 리스트 만들기",
+            attributes: [
+                .font: DesignSystemFontFamily.Pretendard.medium.font(size: 14),
+                .foregroundColor:  DesignSystemAsset.GrayColor.gray900.color,
+                .kern: -0.5
+            ]
+        )
         
         superView.backgroundColor = .white.withAlphaComponent(0.4)
         superView.layer.cornerRadius = 8
         superView.layer.borderColor = DesignSystemAsset.GrayColor.gray200.color.cgColor
         superView.layer.borderWidth = 1
-        
         self.button.setAttributedTitle(attr, for: .normal)
-        
-        
     }
-
 }

--- a/Projects/Features/CommonFeature/Sources/Views/CurrentPlayListTableViewCell.swift
+++ b/Projects/Features/CommonFeature/Sources/Views/CurrentPlayListTableViewCell.swift
@@ -17,22 +17,16 @@ class CurrentPlayListTableViewCell: UITableViewCell {
     @IBOutlet weak var playListNameLabel: UILabel!
     @IBOutlet weak var playListCountLabel: UILabel!
     
-    
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
-        
         self.playListImageView.layer.cornerRadius = 4
         self.playListNameLabel.font = DesignSystemFontFamily.Pretendard.medium.font(size: 14)
         self.playListNameLabel.textColor = DesignSystemAsset.GrayColor.gray900.color
+        self.playListNameLabel.setLineSpacing(kernValue: -0.5)
         self.playListCountLabel.font = DesignSystemFontFamily.Pretendard.light.font(size: 12)
         self.playListCountLabel.textColor = DesignSystemAsset.GrayColor.gray900.color
-        
-        
+        self.playListCountLabel.setLineSpacing(kernValue: -0.5)
     }
-
-
-
 }
 
 extension CurrentPlayListTableViewCell {
@@ -41,9 +35,7 @@ extension CurrentPlayListTableViewCell {
             with: WMImageAPI.fetchPlayList(id: String(model.image),version: model.image_version).toURL,
             placeholder: nil,
             options: [.transition(.fade(0.2))])
-
         self.playListNameLabel.text = model.title
         self.playListCountLabel.text = "\(model.songlist.count)개"
-        
     }
 }

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -357,12 +357,12 @@ extension PlayerViewController: UITableViewDelegate, UITableViewDataSource, UISc
     }
     
     public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        
-        let textHeight:CGFloat = viewModel.sortedLyrics[indexPath.row].heightConstraintAt(width: (270 * APP_WIDTH())/375.0, font: DesignSystemFontFamily.Pretendard.medium.font(size: 14))
-                                                                                  
-        let yMargin:CGFloat = 7
-        
-        return max(24,textHeight + yMargin)
+        let textHeight: CGFloat = viewModel.sortedLyrics[indexPath.row].heightConstraintAt(
+            width: LyricsTableViewCell.lyricMaxWidth,
+            font: DesignSystemFontFamily.Pretendard.medium.font(size: 14)
+        )
+        let yMargin: CGFloat = 7
+        return max(24, textHeight + yMargin)
     }
     
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -357,12 +357,7 @@ extension PlayerViewController: UITableViewDelegate, UITableViewDataSource, UISc
     }
     
     public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        let textHeight: CGFloat = viewModel.sortedLyrics[indexPath.row].heightConstraintAt(
-            width: LyricsTableViewCell.lyricMaxWidth,
-            font: DesignSystemFontFamily.Pretendard.medium.font(size: 14)
-        )
-        let yMargin: CGFloat = 7
-        return max(24, textHeight + yMargin)
+        return LyricsTableViewCell.getCellHeight(lyric: viewModel.sortedLyrics[indexPath.row])
     }
     
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController+Delegate.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController+Delegate.swift
@@ -18,7 +18,7 @@ extension PlaylistViewController: SongCartViewDelegate {
         case let .allSelect(flag):
             self.isSelectedAllSongs.onNext(flag)
         case .addSong:
-            let songs: [String] = self.playState.playList.list.map { $0.item.id }
+            let songs: [String] = self.playState.playList.list.filter { $0.item.isSelected }.map { $0.item.id }
             let viewController = containSongsComponent.makeView(songs: songs)
             viewController.modalPresentationStyle = .overFullScreen
             self.present(viewController, animated: true) {

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -65,6 +65,13 @@ public class PlaylistViewController: UIViewController, SongCartViewType {
         bindViewModel()
         bindActions()
     }
+    
+    public override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        //Comment: 재생목록 화면이 사라지는 시점에서 곡 담기 팝업이 올라와 있는 상태면 제거
+        guard self.songCartView != nil else { return }
+        self.hideSongCart()
+    }
 }
 
 private extension PlaylistViewController {

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -65,11 +65,6 @@ public class PlaylistViewController: UIViewController, SongCartViewType {
         bindViewModel()
         bindActions()
     }
-    
-    public override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        DEBUG_LOG("\(Self.self) viewDidDisappear, isEditing: \(self.viewModel.isEditing)")
-    }
 }
 
 private extension PlaylistViewController {

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -58,9 +58,17 @@ public class PlaylistViewController: UIViewController, SongCartViewType {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
+        //Comment: 재생목록 화면이 로드되는 시점에서 DB에 저장된 리스트로 업데이트
+        //PlayState.shared.playList.list와 DB에 저장된 리스트로 동기화하기 위함
+        self.playState.playList.list = self.playState.fetchPlayListFromLocalDB()
         playlistView.playlistTableView.rx.setDelegate(self).disposed(by: disposeBag)
         bindViewModel()
         bindActions()
+    }
+    
+    public override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        DEBUG_LOG("\(Self.self) viewDidDisappear, isEditing: \(self.viewModel.isEditing)")
     }
 }
 
@@ -92,7 +100,6 @@ private extension PlaylistViewController {
         bindShuffleMode(output: output)
         bindPlayButtonImages(output: output)
         bindwaveStreamAnimationView(output: output)
-
     }
     
     private func bindPlaylistTableView(output: PlaylistViewModel.Output) {
@@ -117,20 +124,15 @@ private extension PlaylistViewController {
             .filter { $0.first?.items.isEmpty ?? true }
             .subscribe { [weak self] _ in
                 let space = APP_HEIGHT() - STATUS_BAR_HEGHIT() - 48 - 56 - SAFEAREA_BOTTOM_HEIGHT()
-                
                 let height = space / 3  * 2
-                
                 let warningView = WarningView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: height))
                 warningView.text = "곡이 없습니다."
-                
                 self?.playlistView.playlistTableView.tableFooterView = warningView
             }.disposed(by: disposeBag)
         
         output.dataSource
-            .subscribe(onNext: { [weak self] dataSource in
-                let isDataSourceEmpty = dataSource.first?.items.isEmpty ?? true
-                self?.playlistView.editButton.isHidden = isDataSourceEmpty
-            })
+            .map { return $0.first?.items.isEmpty ?? true }
+            .bind(to: playlistView.editButton.rx.isHidden)
             .disposed(by: disposeBag)
     }
     
@@ -247,7 +249,6 @@ private extension PlaylistViewController {
             }
             .store(in: &subscription)
     }
-    
 }
 
 private extension PlaylistViewController {

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
@@ -51,7 +51,7 @@ final class PlaylistViewModel: ViewModelType {
     }
     
     private let playState = PlayState.shared
-    private var isEditing = false
+    var isEditing = false
     internal var countOfSelectedSongs = 0
     private var subscription = Set<AnyCancellable>()
     private var disposeBag = DisposeBag()
@@ -259,7 +259,10 @@ final class PlaylistViewModel: ViewModelType {
             .sink { [weak self] _ in
                 guard let self else { return }
                 output.indexOfSelectedSongs.accept([])
-        }.store(in: &subscription)
+                //Comment: 편집모드가 완료 된 시점에서 list를 가져와서 listReordered.send > DB 업데이트
+                let list = self.playState.playList.list
+                self.playState.playList.listReordered.send(list)
+            }.store(in: &subscription)
     }
     
     private func bindPlayStateChanged(output: Output) {

--- a/Projects/Features/PlayerFeature/Sources/Views/LyricsTabelViewCell.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/LyricsTabelViewCell.swift
@@ -55,4 +55,13 @@ internal class LyricsTableViewCell: UITableViewCell {
     internal func highlight(_ isCurrent: Bool) {
         lyricsLabel.textColor = isCurrent ? DesignSystemAsset.PrimaryColor.point.color : DesignSystemAsset.GrayColor.gray500.color
     }
+    
+    static public func getCellHeight(lyric: String) -> CGFloat {
+        let textHeight: CGFloat = lyric.heightConstraintAt(
+            width: LyricsTableViewCell.lyricMaxWidth,
+            font: DesignSystemFontFamily.Pretendard.medium.font(size: 14)
+        )
+        let yMargin: CGFloat = 7
+        return max(24, textHeight + yMargin)
+    }
 }

--- a/Projects/Features/PlayerFeature/Sources/Views/LyricsTabelViewCell.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/LyricsTabelViewCell.swift
@@ -56,7 +56,7 @@ internal class LyricsTableViewCell: UITableViewCell {
         lyricsLabel.textColor = isCurrent ? DesignSystemAsset.PrimaryColor.point.color : DesignSystemAsset.GrayColor.gray500.color
     }
     
-    static public func getCellHeight(lyric: String) -> CGFloat {
+    static func getCellHeight(lyric: String) -> CGFloat {
         let textHeight: CGFloat = lyric.heightConstraintAt(
             width: LyricsTableViewCell.lyricMaxWidth,
             font: DesignSystemFontFamily.Pretendard.medium.font(size: 14)

--- a/Projects/Features/PlayerFeature/Sources/Views/LyricsTabelViewCell.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/LyricsTabelViewCell.swift
@@ -14,14 +14,15 @@ import Utility
 
 internal class LyricsTableViewCell: UITableViewCell {
     static let identifier = "LyricsTableViewCell"
-    
+    static let lyricMaxWidth: CGFloat = (270 * APP_WIDTH())/375.0
+
     private lazy var lyricsLabel = UILabel().then {
         $0.font = .init(font: DesignSystemFontFamily.Pretendard.medium, size: 14)
         $0.textColor = DesignSystemAsset.GrayColor.gray500.color
         $0.setLineSpacing(kernValue: -0.5, lineHeightMultiple: 1.44)
         $0.text = ""
         $0.numberOfLines = 0
-        $0.preferredMaxLayoutWidth = (270 * APP_WIDTH())/375.0
+        $0.preferredMaxLayoutWidth = LyricsTableViewCell.lyricMaxWidth
         $0.textAlignment = .center
     }
 

--- a/Projects/Features/PlayerFeature/Sources/Views/PlayerView.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlayerView.swift
@@ -315,7 +315,7 @@ private extension PlayerView {
         lyricsTableView.snp.makeConstraints {
             $0.top.equalTo(thumbnailImageView.snp.bottom).offset(firstSpacing)
             $0.centerX.equalTo(self.snp.centerX)
-            $0.width.equalTo((270 * APP_WIDTH())/375.0)
+            $0.width.equalTo(LyricsTableViewCell.lyricMaxWidth)
             $0.height.equalTo(isNotch ? 120 : 72)
         }
     }


### PR DESCRIPTION
## 개요
재생 목록 > 편집 완료 시점에서 DB 업데이트 하도록 변경

## 작업사항
@youn9k 
//Comment  << 로 검색하여 프로젝트 내 주석 확인해주세요.

1. 리스트에서 순서를 변경하면 reorderPlaylist()가 호출되고, 그 안에서 listReordered.send(list) 로직이 호출되고 DB 업데이트가 이뤄졌는데 이 로직은 일단 제거합니다.

단, DB 업데이트가 안들어갈뿐 PlayState 싱글톤이 가지고 있는 list는 변경됩니다. 그래서 재생목록 화면에 머무르는 동안은 리스트 자체는 변경이 된 것 처럼 보입니다.

![스크린샷 2023-05-14 오전 1 12 07](https://github.com/wakmusic/wakmusic-iOS/assets/37323252/205f4c4c-2f1f-433f-8c77-7857a7ec7fc7)

2. 이러면 PlayState.shared.playList.list와 DB에 저장된 리스트가 일치하지 않습니다. 
그래서 재생목록 화면에 진입하는 시점에서 DB 재생목록 리스트를 가져와서 PlayState.shared.playList.list와 동기화 시킵니다. 

![스크린샷 2023-05-14 오전 1 16 23](https://github.com/wakmusic/wakmusic-iOS/assets/37323252/1670b757-8062-4bb0-8865-d5c674d9a844)


3. 편집모드가 완료 된 시점에서 list를 가져와서 listReordered.send > DB 업데이트 하도록 변경합니다.

![스크린샷 2023-05-14 오전 1 13 34](https://github.com/wakmusic/wakmusic-iOS/assets/37323252/1e32466a-e912-40e1-ae91-e4409c416740)


4. 그러면 순번을 변경하고 편집 완료를 누르지않고 나가 버린다음에, 재생 화면(풀 스크린)에서 다음곡을 누르면 순번이 꼬이지 않을까?

Publishers.Merge4(
            playList.listAppended.dropFirst(),
            playList.listRemoved.dropFirst(),
            playList.listReordered.dropFirst(),
            playList.currentSongChanged.dropFirst()
        )
여기 Merge4에 currentSongChanged에 걸리게되어, DB가 업데이트 되어서 동기화 문제는 없는 것으로 확인했습니다.


코드 분석이 완벽하지 않아 놓친 부분이 있을 수 있으니, 읽어보시고 판단해주세요.

5. 추가 버그 수정 

1) 선택하지 않는 곡도 노래 담기가 되는 오류 
[이전] let songs: [String] = self.playState.playList.list.map { $0.item.id }
[수정 후] let songs: [String] = self.playState.playList.list.filter { $0.item.isSelected }.map { $0.item.id }

![스크린샷 2023-05-14 오전 4 07 18](https://github.com/wakmusic/wakmusic-iOS/assets/37323252/6971279f-c40e-4b05-8595-a9ef83832890)

2) 곡 담기 팝업을 띄워 놓고 닫을경우 플레이어가 보이지 않는 오류
> 곡 담기 팝업과 플레이어는 공존 할 수 없는 구조입니다. 반드시 지워야합니다. 
![스크린샷 2023-05-14 오전 4 18 09](https://github.com/wakmusic/wakmusic-iOS/assets/37323252/df78c1cd-4203-4702-b6c5-e7b039dae111)

Closes #이슈번호