### PR TITLE
🔀 :: 백그라운드 재생 로직 개선

### DIFF
--- a/Projects/App/Sources/Application/SceneDelegate.swift
+++ b/Projects/App/Sources/Application/SceneDelegate.swift
@@ -3,6 +3,7 @@ import RootFeature
 import Utility
 import NaverThirdPartyLogin
 import CommonFeature
+import Combine
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
@@ -28,13 +29,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillResignActive(_ scene: UIScene) {
 
     }
+    
+    private var statePublisher: AnyCancellable?
+    
     func sceneWillEnterForeground(_ scene: UIScene) {
-
+        statePublisher?.cancel()
     }
     func sceneDidEnterBackground(_ scene: UIScene) {
         let isPlayed = PlayState.shared.state
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            if isPlayed == .playing { PlayState.shared.play() }
+        statePublisher = PlayState.shared.$state.sink { state in
+            if state == .paused {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    if isPlayed == .playing { PlayState.shared.play() }
+                }
+            }
         }
     }
     


### PR DESCRIPTION
## 개요

## 작업사항
백그라운드 재생 로직을 개선하기 위해 기존 코드가 왜 동작했는지부터 분석을 시작했습니다.
분석 결과 재생, 일시정지는 웹뷰에게 자바스크립트 이벤트를 보내는 코드인 evaluate()로 동작한다는걸 알게 되었습니다.
```Swift
    self.webView.evaluate(
        javaScript: .player("playVideo()")

    self.webView.evaluate(
        javaScript: .player("pauseVideo()")
```
그리고 print를 찍어 상태 변화를  확인한 결과 
![스크린샷 2023-05-15 오후 2 24 09 중간](https://github.com/wakmusic/wakmusic-iOS/assets/60254939/ff8573d8-bde1-4ffe-9d50-9ab54573d862)
백그라운드에 진입 후, async하게 일시정지되는 것을 확인했습니다.

여기서 알 수 있는 점은 기존 코드에서 0.2 ~ 0.5초 후 play()를 호출하도록 했기때문에, paused 보다 play 의 결과가 늦게 도착하도록 임의로 조정하고 있었음을 알 수 있었습니다. 
```Swift
DispatchQueue.main.asyncAfter(deadline: .now() + 0.2)
```
<img width="950" alt="image" src="https://github.com/wakmusic/wakmusic-iOS/assets/60254939/414e97fa-9518-4ec0-a2a5-87f90383abe4">


그러면 임의의 시간만큼 play 를 늦게 호출 하지말고 paused되자마자 play를 호출하면 되겠다 생각해
백그라운드 진입 시 재생상태를 구독하고 재생상태가 paused가 되면 play를 호출하도록 로직을 변경했습니다.
<img width="735" alt="image" src="https://github.com/wakmusic/wakmusic-iOS/assets/60254939/baa0e546-4d90-4ee5-8b05-ef2220dc42fb">


Closes #191 