### PR TITLE
🔀 :: 좋아요 삭제 목록에 현재 재생 곡 포함 시 좋아요 상태 업데이트

### DIFF
--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
@@ -94,6 +94,7 @@ final class PlayerViewModel: ViewModelType {
         bindRepeatMode(output: output)
         bindShuffleMode(output: output)
         bindLoginStateChanged(output: output)
+        bindCurrentSongLikeStateChanged(output: output)
         
         return output
     }
@@ -224,6 +225,18 @@ final class PlayerViewModel: ViewModelType {
                 self?.fetchLikeState(for: song, output: output)
             }
         }.store(in: &subscription)
+    }
+    
+    private func bindCurrentSongLikeStateChanged(output: Output) {
+        NotificationCenter.default.publisher(for: .updateCurrentSongLikeState, object: nil)
+            .compactMap { notification in
+                return notification.object as? SongEntity
+            }
+            .sink { [weak self] currentSong in
+                guard let self else { return }
+                self.fetchLikeCount(for: currentSong, output: output)
+                self.fetchLikeState(for: currentSong, output: output)
+            }.store(in: &subscription)
     }
     
     private func bindProgress(output: Output) {

--- a/Projects/Features/StorageFeature/Sources/ViewModels/FavoriteViewModel.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewModels/FavoriteViewModel.swift
@@ -213,10 +213,11 @@ public final class FavoriteViewModel:ViewModelType {
                     output.showToast.accept("좋아요 리스트에서 삭제되었습니다.")
                     
                     //좋아요 삭제 시 > 노티피케이션
-                    let currentSongID: String = PlayState.shared.currentSong?.id ?? ""
+                    let currentSong: SongEntity? = PlayState.shared.currentSong
+                    let currentSongID: String = currentSong?.id ?? ""
                     if self.tempDeleteLikeListIds.contains(currentSongID) {
                         DEBUG_LOG("updateCurrentSongLikeState ID: \(currentSongID)")
-                        NotificationCenter.default.post(name: .updateCurrentSongLikeState, object: currentSongID)
+                        NotificationCenter.default.post(name: .updateCurrentSongLikeState, object: nil)
                     }
                 }else{
                     output.showToast.accept(model.description)


### PR DESCRIPTION
## 개요

## 작업사항
좋아요 삭제 목록에 현재 재생 곡 포함 시 노티피케이션 발송
플레이어에서 수신 및 좋아요 상태, 좋아요 수 업데이트

Closes #246 