### PR TITLE
🔀 :: 12미니에서 레이아웃이 틀어지는 문제 수정

### DIFF
--- a/Projects/Features/PlayerFeature/Sources/Views/PlayerView.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlayerView.swift
@@ -309,14 +309,14 @@ private extension PlayerView {
         thumbnailImageView.backgroundColor = .white
     }
     private func configureLyrics() {
-        let isNotch = Utility.APP_HEIGHT() >= 812 // iPhone X 이상 기종
-        self.lyricsTableView.tableHeaderView = UIView(frame: CGRect(x: 0, y: 0, width: lyricsTableView.frame.width, height: isNotch ? 48 : 24))
-        self.lyricsTableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: lyricsTableView.frame.width, height: isNotch ? 48 : 24))
+        let isIPhoneXOrAbove = Utility.APP_HEIGHT() >= 812 // iPhone X 이상 기종
+        self.lyricsTableView.tableHeaderView = UIView(frame: CGRect(x: 0, y: 0, width: lyricsTableView.frame.width, height: isIPhoneXOrAbove ? 48 : 24))
+        self.lyricsTableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: lyricsTableView.frame.width, height: isIPhoneXOrAbove ? 48 : 24))
         lyricsTableView.snp.makeConstraints {
             $0.top.equalTo(thumbnailImageView.snp.bottom).offset(firstSpacing)
             $0.centerX.equalTo(self.snp.centerX)
             $0.width.equalTo(LyricsTableViewCell.lyricMaxWidth)
-            $0.height.equalTo(isNotch ? 120 : 72)
+            $0.height.equalTo(isIPhoneXOrAbove ? 120 : 72)
         }
     }
     private func configurePlayTimeSlider() {
@@ -397,7 +397,7 @@ private extension PlayerView {
         let safeAreaWidth: CGFloat = Utility.APP_WIDTH() - left - right
         let safeAreaheight: CGFloat = Utility.APP_HEIGHT() - top - bottom
         var x: CGFloat = 0
-        if safeAreaheight >= 728 { // 12미니 safeArea height를 마지노선으로 설정
+        if Utility.SAFEAREA_BOTTOM_HEIGHT() > 0 {
             x = ((safeAreaheight - (safeAreaWidth - 50) / (16/9) - 334 - 18) / 20)
         } else {
             x = ((safeAreaheight - (safeAreaWidth - 50) / (16/9) - 286 - 18) / 20)

--- a/Projects/Features/PlayerFeature/Sources/Views/PlayerView.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlayerView.swift
@@ -342,9 +342,9 @@ private extension PlayerView {
     }
     private func configureButtonBar() {
         buttonBarView.snp.makeConstraints {
-            $0.top.equalTo(playTimeView.snp.bottom).offset(secondSpacing)
-            $0.horizontalEdges.equalTo(self.snp.horizontalEdges).inset(UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 12))
             $0.height.equalTo(80)
+            $0.top.equalTo(playTimeView.snp.bottom).offset(secondSpacing)
+            $0.horizontalEdges.equalTo(self.snp.horizontalEdges).inset(UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20))
         }
         playButton.snp.makeConstraints {
             $0.centerX.centerY.equalToSuperview()
@@ -352,23 +352,23 @@ private extension PlayerView {
         }
         prevButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.right.equalTo(playButton.snp.left).offset(-24)
-            $0.width.height.equalTo(48)
+            $0.right.equalTo(playButton.snp.left).offset(-32)
+            $0.width.height.equalTo(32)
         }
         nextButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.left.equalTo(playButton.snp.right).offset(24)
-            $0.width.height.equalTo(48)
+            $0.left.equalTo(playButton.snp.right).offset(32)
+            $0.width.height.equalTo(32)
         }
         repeatButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.right.equalTo(prevButton.snp.left).offset(-24)
-            $0.width.height.equalTo(48)
+            $0.right.equalTo(prevButton.snp.left).offset(-32)
+            $0.width.height.equalTo(32)
         }
         shuffleButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.left.equalTo(nextButton.snp.right).offset(24)
-            $0.width.height.equalTo(48)
+            $0.left.equalTo(nextButton.snp.right).offset(32)
+            $0.width.height.equalTo(32)
         }
     }
     private func configureBottomBar() {

--- a/Projects/Features/PlayerFeature/Sources/Views/PlayerView.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlayerView.swift
@@ -394,14 +394,13 @@ private extension PlayerView {
         let bottom: CGFloat = window?.safeAreaInsets.bottom ?? 0
         let left: CGFloat = window?.safeAreaInsets.left ?? 0
         let right: CGFloat = window?.safeAreaInsets.right ?? 0
-        let width: CGFloat = Utility.APP_WIDTH() - left - right
-        let height: CGFloat = Utility.APP_HEIGHT() - top - bottom
+        let safeAreaWidth: CGFloat = Utility.APP_WIDTH() - left - right
+        let safeAreaheight: CGFloat = Utility.APP_HEIGHT() - top - bottom
         var x: CGFloat = 0
-        
-        if height >= 732 {
-            x = ((height - (width - 50) / (16/9) - 334 - 18) / 20)
+        if safeAreaheight >= 728 { // 12미니 safeArea height를 마지노선으로 설정
+            x = ((safeAreaheight - (safeAreaWidth - 50) / (16/9) - 334 - 18) / 20)
         } else {
-            x = ((height - (width - 50) / (16/9) - 286 - 18) / 20)
+            x = ((safeAreaheight - (safeAreaWidth - 50) / (16/9) - 286 - 18) / 20)
         }
         return CGFloat(floorf(Float(x)))
     }


### PR DESCRIPTION
## 개요

## 작업사항

11프로와 12미니의 스크린 사이즈는 375 × 812 px로 같지만 11프로에선 정상적으로 출력되고 12미니에선 다르게 나오는 문제가 있었습니다.
확인 결과 11프로와 12미니의 스크린 사이즈는 같지만 11프로의 스테이터스바의 높이는 44, 12미니의 스테이터스바의 높이는 50이라서 safeArea Height가 달랐고 아래 코드에서 12미니의 경우 else로 빠지는 문제였습니다.
```Swift
if Utility.SAFEAREA_BOTTOM_HEIGHT() > 0 {
    x = ((safeAreaheight - (safeAreaWidth - 50) / (16/9) - 334 - 18) / 20)
} else {
    x = ((height - (width - 50) / (16/9) - 286 - 18) / 20)
    x = ((safeAreaheight - (safeAreaWidth - 50) / (16/9) - 286 - 18) / 20)
}
```


수정전
![IMG_4287 중간](https://github.com/wakmusic/wakmusic-iOS/assets/60254939/17dd98e0-06ae-45f8-876f-c5c5275e4e60)
수정후
![Simulator Screenshot - iPhone 12 mini - 2023-05-22 at 17 47 35 중간](https://github.com/wakmusic/wakmusic-iOS/assets/60254939/227f7260-774f-4778-ab87-d53be838561e)

Closes #이슈번호