### PR TITLE
🔀 ::재생목록에 추가 시에도 currentSong 업데이트

### DIFF
--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
@@ -46,5 +46,10 @@ public extension PlayState {
         self.playList.append(notDuplicatedSongs)
         
         if self.state == .unstarted { self.switchPlayerMode(to: .mini) }
+        
+        self.currentSong = self.playList.currentPlaySong
+        if let currentSong {
+            self.player.cue(source: .video(id: currentSong.id))
+        }
     }
 }


### PR DESCRIPTION
## 개요
#282 
## 작업사항
재생목록 추가 시에 재생목록의 currentPlaySong을 currentSong에 넣어 플레이어가 준비되도록 변경했습니다.
