### PR TITLE
🔀 :: Feature/fix keyboard modal

### DIFF
--- a/Projects/Features/CommonFeature/Resources/CommonUI.storyboard
+++ b/Projects/Features/CommonFeature/Resources/CommonUI.storyboard
@@ -972,23 +972,13 @@
                                     <constraint firstAttribute="bottom" secondItem="08R-AE-bpr" secondAttribute="bottom" constant="10" id="xOk-dY-Dx3"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tUl-QN-c2b">
-                                <rect key="frame" x="0.0" y="355" width="393" height="0.0"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" id="SPc-gh-6VT"/>
-                                </constraints>
-                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="ALf-P4-DHO"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="ALf-P4-DHO" firstAttribute="trailing" secondItem="Yxn-RK-R3n" secondAttribute="trailing" id="4dE-hJ-oMp"/>
-                            <constraint firstItem="tUl-QN-c2b" firstAttribute="leading" secondItem="ALf-P4-DHO" secondAttribute="leading" id="K8A-3f-uXe"/>
                             <constraint firstItem="Yxn-RK-R3n" firstAttribute="top" secondItem="ALf-P4-DHO" secondAttribute="top" id="Mpj-GW-OSk"/>
                             <constraint firstItem="Yxn-RK-R3n" firstAttribute="leading" secondItem="ALf-P4-DHO" secondAttribute="leading" id="T4z-Ox-GLz"/>
-                            <constraint firstItem="ALf-P4-DHO" firstAttribute="trailing" secondItem="tUl-QN-c2b" secondAttribute="trailing" id="kub-ma-LYm"/>
-                            <constraint firstItem="tUl-QN-c2b" firstAttribute="top" secondItem="Yxn-RK-R3n" secondAttribute="bottom" id="qam-54-Juy"/>
                         </constraints>
                     </view>
                     <connections>
@@ -999,7 +989,6 @@
                         <outlet property="confirmLabel" destination="pIf-kv-qe0" id="wFr-tq-eow"/>
                         <outlet property="countLabel" destination="MJU-v6-dX3" id="A97-vk-5cp"/>
                         <outlet property="dividerView" destination="42n-JF-5MI" id="6qq-yi-Rs1"/>
-                        <outlet property="fakeViewHeight" destination="SPc-gh-6VT" id="ZNe-Yi-7TI"/>
                         <outlet property="indicator" destination="EFr-kE-XRQ" id="770-ht-vpM"/>
                         <outlet property="limitLabel" destination="L4C-lz-s65" id="dvS-6o-qNm"/>
                         <outlet property="saveButton" destination="08R-AE-bpr" id="6CU-Zx-cmc"/>

--- a/Projects/Features/CommonFeature/Sources/Components/MultiPurposePopComponent.swift
+++ b/Projects/Features/CommonFeature/Sources/Components/MultiPurposePopComponent.swift
@@ -11,8 +11,6 @@ import NeedleFoundation
 import DomainModule
 
 public protocol MultiPurposePopDependency: Dependency {
-  
-    
     var createPlayListUseCase : any CreatePlayListUseCase {get}
     var loadPlayListUseCase : any LoadPlayListUseCase {get}
     var setUserNameUseCase: any SetUserNameUseCase {get}

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -156,6 +156,6 @@ extension ContainSongsViewController : UITableViewDelegate {
 extension ContainSongsViewController : ContainPlayListHeaderViewDelegate {
     public func action() {
         let vc = multiPurposePopComponent.makeView(type: .creation)
-        self.showPanModal(content: vc)
+        self.showEntryKitModal(content: vc, height: 296)
     }
 }

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
@@ -8,12 +8,12 @@
 
 import UIKit
 import Utility
-import PanModal
 import RxCocoa
 import RxSwift
 import RxKeyboard
 import DesignSystem
 import NVActivityIndicatorView
+import SwiftEntryKit
 
 public enum PurposeType{
     case creation
@@ -107,85 +107,66 @@ public final class  MultiPurposePopupViewController: UIViewController, ViewContr
     @IBOutlet weak var cancelButtonWidth: NSLayoutConstraint!
     
     @IBAction func cancelAction(_ sender: UIButton) {
-        
-        
-
-        
-        if viewModel.type == .share
-        {
+        if viewModel.type == .share{
             UIPasteboard.general.string = input.textString.value //클립보드 복사
             self.showToast(text: "복사가 완료되었습니다.", font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
-        }
-        
-        else
-        {
+            
+        }else{
             textField.rx.text.onNext("")
             input.textString.accept("")
         }
-        
-        
     }
     
-    
     var viewModel:MultiPurposePopupViewModel!
-    var limitCount:Int = 12
     lazy var input = MultiPurposePopupViewModel.Input()
     lazy var output = viewModel.transform(from: input)
+    
+    var limitCount: Int = 12
     var creationCompletion: ((String) -> Void)?
     
     public var disposeBag = DisposeBag()
-    
-   
-   
-    
-    
+
     public override func viewDidLoad() {
         super.viewDidLoad()
-
         configureUI()
-        //bindRx()
-        // Do any additional setup after loading the view.
     }
     
-    public static func viewController(viewModel:MultiPurposePopupViewModel,completion: ((String) -> Void)? = nil ) -> MultiPurposePopupViewController {
+    public static func viewController(
+        viewModel: MultiPurposePopupViewModel,
+        completion: ((String) -> Void)? = nil
+    ) -> MultiPurposePopupViewController {
         let viewController = MultiPurposePopupViewController.viewController(storyBoardName: "CommonUI", bundle: Bundle.module)
-        
         viewController.viewModel = viewModel
         viewController.creationCompletion = completion
-       
         return viewController
     }
-    
-
-
-
 }
-
 
 extension MultiPurposePopupViewController{
     private func configureUI() {
-
+        self.view.layer.cornerRadius = 24
+        self.view.clipsToBounds = true
+        
         titleLabel.text = viewModel.type.title
         titleLabel.font = DesignSystemFontFamily.Pretendard.medium.font(size: 18)
         titleLabel.textColor = DesignSystemAsset.GrayColor.gray900.color
-        
         
         subTitleLabel.text = viewModel.type.subTitle
         subTitleLabel.font = DesignSystemFontFamily.Pretendard.light.font(size: 16)
         subTitleLabel.textColor = DesignSystemAsset.GrayColor.gray400.color
         
-    
-        
         let headerFontSize:CGFloat = 20
-        
         let focusedplaceHolderAttributes = [
             NSAttributedString.Key.foregroundColor: DesignSystemAsset.GrayColor.gray400.color,
             NSAttributedString.Key.font : DesignSystemFontFamily.Pretendard.medium.font(size: headerFontSize)
         ] // 포커싱 플레이스홀더 폰트 및 color 설정
         
-        textField.becomeFirstResponder()
-        self.textField.attributedPlaceholder = NSAttributedString(string: viewModel.type == .creation || viewModel.type == .edit ?
-                                                                  "리스트 제목을 입력하세요." : viewModel.type == .nickname ? "닉네임을 입력하세요." : "코드를 입력해주세요."  ,attributes:focusedplaceHolderAttributes) //플레이스 홀더 설정
+//        textField.becomeFirstResponder()
+        self.textField.attributedPlaceholder = NSAttributedString(
+            string: viewModel.type == .creation || viewModel.type == .edit ?
+                    "리스트 제목을 입력하세요." : viewModel.type == .nickname ? "닉네임을 입력하세요." : "코드를 입력해주세요.",
+            attributes: focusedplaceHolderAttributes
+        ) //플레이스 홀더 설정
         self.textField.font = DesignSystemFontFamily.Pretendard.medium.font(size: headerFontSize)
         
         if viewModel.type == .share { //공유는 오직 읽기 전용
@@ -194,18 +175,14 @@ extension MultiPurposePopupViewController{
             self.textField.text = viewModel.key
         }
         
-       
-        
         self.dividerView.backgroundColor = DesignSystemAsset.GrayColor.gray200.color
         
-        if viewModel.type == .share
-        {
+        if viewModel.type == .share{
             self.cancelButtonWidth.constant = 32
             self.cancelButtonHeight.constant = 32
             self.cancelButton.setImage(DesignSystemAsset.Storage.copy.image, for: .normal)
-        }
-        else
-        {
+            
+        }else{
             self.cancelButton.layer.cornerRadius = 12
             self.cancelButton.titleLabel?.text = "취소"
             self.cancelButton.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 12)
@@ -216,8 +193,9 @@ extension MultiPurposePopupViewController{
             self.cancelButton.isHidden = true
         }
         
-        if (viewModel.type == .creation || viewModel.type == .edit || viewModel.type == .nickname)
-        {
+        switch viewModel.type {
+            
+        case .creation, .edit, .nickname:
             self.confirmLabel.font = DesignSystemFontFamily.Pretendard.light.font(size: 12)
             self.confirmLabel.isHidden = true
             
@@ -226,173 +204,117 @@ extension MultiPurposePopupViewController{
             
             self.countLabel.font = DesignSystemFontFamily.Pretendard.light.font(size: 12)
             self.countLabel.textColor = DesignSystemAsset.PrimaryColor.point.color
-        }
-        
-        else
-        {
-         
+            bindRxCreationOrEditOrNickName()
+
+        case .load, .share:
             self.confirmLabel.font = DesignSystemFontFamily.Pretendard.light.font(size: 12)
             self.confirmLabel.textColor = DesignSystemAsset.GrayColor.gray500.color
             self.confirmLabel.isHidden = false
             self.confirmLabel.text =  viewModel.type == .load ?  "· 리스트 코드로 리스트를 가져올 수 있습니다." : "· 리스트 코드로 리스트를 공유할 수 있습니다."
             self.confireLabelGap.constant = 12
             
-            
             self.limitLabel.isHidden = true
             self.countLabel.isHidden = true
-    
-        }
-        
-        if viewModel.type == .creation || viewModel.type == .edit || viewModel.type == .nickname{
-            bindRxCreationOrEditOrNickName()
-        }
-        else{
             bindRxLoadOrShare()
         }
         
         bindRxEvent()
         
-        
-        
-        
-        
         saveButton.layer.cornerRadius = 12
         saveButton.clipsToBounds = true
-        saveButton.setAttributedTitle(NSMutableAttributedString(string:viewModel.type.btnText,
-                                                                attributes: [.font: DesignSystemFontFamily.Pretendard.medium.font(size: 18),
-                                                                             .foregroundColor: DesignSystemAsset.GrayColor.gray25.color ]), for: .normal)
-        
+        saveButton.setAttributedTitle(NSMutableAttributedString(
+            string: viewModel.type.btnText,
+            attributes: [.font: DesignSystemFontFamily.Pretendard.medium.font(size: 18),
+                         .foregroundColor: DesignSystemAsset.GrayColor.gray25.color ]
+        ), for: .normal)
 
         saveButton.setBackgroundColor(DesignSystemAsset.PrimaryColor.point.color, for: .normal)
         saveButton.setBackgroundColor(DesignSystemAsset.GrayColor.gray300.color, for: .disabled)
         
         self.indicator.type = .circleStrokeSpin
         self.indicator.color = .white
-        
     }
     
-    
-    private func bindRxCreationOrEditOrNickName()
-    {
-        
+    private func bindRxCreationOrEditOrNickName(){
         limitCount = viewModel.type == .nickname ? 8 : 12
         limitLabel.text = "/\(limitCount)"
+                
+        input.textString
+            .subscribe { [weak self] (str: String) in
+                guard let self = self else{
+                    return
+                }
+                
+                let errorColor = DesignSystemAsset.PrimaryColor.increase.color
+                let passColor = DesignSystemAsset.PrimaryColor.decrease.color
+                
+                self.countLabel.text = "\(str.count)자"
+                
+                if str.count == 0{
+                    self.cancelButton.isHidden = true
+                    self.confirmLabel.isHidden = true
+                    self.saveButton.isEnabled = false
+                    self.dividerView.backgroundColor = DesignSystemAsset.GrayColor.gray200.color
+                    self.countLabel.textColor = DesignSystemAsset.PrimaryColor.point.color
+                    return
+                    
+                }else{
+                    self.cancelButton.isHidden = false
+                    self.confirmLabel.isHidden = false
+                    self.countLabel.isHidden = false
+                }
+                
+                if str.isWhiteSpace {
+                    self.dividerView.backgroundColor = errorColor
+                    self.confirmLabel.text = "제목이 비어있습니다."
+                    self.confirmLabel.textColor = errorColor
+                    self.countLabel.textColor = errorColor
+                    self.saveButton.isEnabled = false
+                    
+                }else if str.count > self.limitCount {
+                    self.dividerView.backgroundColor = errorColor
+                    self.confirmLabel.text = "글자 수를 초과하였습니다."
+                    self.confirmLabel.textColor = errorColor
+                    self.countLabel.textColor = errorColor
+                    self.saveButton.isEnabled = false
+                    
+                }else {
+                    self.dividerView.backgroundColor = passColor
+                    self.confirmLabel.text =  self.viewModel.type == .nickname ? "사용할 수 있는 닉네임입니다." : "사용할 수 있는 제목입니다."
+                    self.confirmLabel.textColor = passColor
+                    self.countLabel.textColor = DesignSystemAsset.PrimaryColor.point.color
+                    self.saveButton.isEnabled = true
+                }
+                
+            }.disposed(by: disposeBag)
         
-        
-        
-        self.input.textString.subscribe { [weak self] (str:String) in
-            
-            guard let self = self else{
-                return
-            }
-            
-            let errorColor = DesignSystemAsset.PrimaryColor.increase.color
-            let passColor = DesignSystemAsset.PrimaryColor.decrease.color
-            
-            self.countLabel.text = "\(str.count)자"
-            if str.count == 0
-            {
-                self.cancelButton.isHidden = true
-                self.confirmLabel.isHidden = true
-                self.saveButton.isEnabled = false
-                self.dividerView.backgroundColor = DesignSystemAsset.GrayColor.gray200.color
-                self.countLabel.textColor = DesignSystemAsset.PrimaryColor.point.color
-                return
-            }
-            
-            else
-            {
-                self.cancelButton.isHidden = false
-                self.confirmLabel.isHidden = false
-                self.countLabel.isHidden = false
-            }
-            
-            if  str.isWhiteSpace
-            {
-                self.dividerView.backgroundColor = errorColor
-                self.confirmLabel.text = "제목이 비어있습니다."
-                self.confirmLabel.textColor = errorColor
-                self.countLabel.textColor = errorColor
-                self.saveButton.isEnabled = false
-            }
-            else if str.count > self.limitCount {
-                self.dividerView.backgroundColor = errorColor
-                self.confirmLabel.text = "글자 수를 초과하였습니다."
-                self.confirmLabel.textColor = errorColor
-                self.countLabel.textColor = errorColor
-                self.saveButton.isEnabled = false
-            }
-            
-            else
-            {
-                self.dividerView.backgroundColor = passColor
-                self.confirmLabel.text =  self.viewModel.type == .nickname ? "사용할 수 있는 닉네임입니다." : "사용할 수 있는 제목입니다."
-                self.confirmLabel.textColor = passColor
-                self.countLabel.textColor = DesignSystemAsset.PrimaryColor.point.color
-                self.saveButton.isEnabled = true
-            }
-            
-            
-          
-            
-        }.disposed(by: disposeBag)
-        
-        
-      //  keyboardBinding()
-        
-        
-        output.newPlayListKey.subscribe(onNext: { [weak self] (str:String) in
-            
-            guard let self = self else{return}
-            
-            DEBUG_LOG("키키키 \(str)")
-            
-            self.creationCompletion?(str)
-        })
-        .disposed(by: disposeBag)
+        output.newPlayListKey
+            .subscribe(onNext: { [weak self] (str: String) in
+                guard let self = self else{return}
+                self.creationCompletion?(str)
+            })
+            .disposed(by: disposeBag)
     }
     
     private func bindRxLoadOrShare() {
-        
-        self.input.textString.subscribe { [weak self] (str:String) in
-            
-            guard let self = self else{
-                return
-            }
-            
-            
-            
-            if str.count == 0
-            {
-                self.cancelButton.isHidden = true
-                self.saveButton.isEnabled = false
-
-            }
-            else
-            {
-                self.cancelButton.isHidden =  false
-                if str.isWhiteSpace
-                {
-                    self.saveButton.isEnabled = false
+        input.textString
+            .subscribe { [weak self] (str: String) in
+                guard let self = self else{
+                    return
                 }
                 
-                else
-                {
-                    self.saveButton.isEnabled = true
+                if str.count == 0 {
+                    self.cancelButton.isHidden = true
+                    self.saveButton.isEnabled = false
+                }else {
+                    self.cancelButton.isHidden =  false
+                    if str.isWhiteSpace {
+                        self.saveButton.isEnabled = false
+                    }else{
+                        self.saveButton.isEnabled = true
+                    }
                 }
-            }
-            
-
-            
-            
-            
-          
-            
-        }.disposed(by: disposeBag)
-        
-        
-        //keyboardBinding()
-        
+            }.disposed(by: disposeBag)
     }
     
     private func bindRxEvent(){
@@ -401,126 +323,46 @@ extension MultiPurposePopupViewController{
             .bind(to: input.textString)
             .disposed(by: self.disposeBag)
         
-        
         output.result.subscribe(onNext: { [weak self] res in
-            
             guard let self = self else{
                 return
             }
             
-            
             self.indicator.stopAnimating()
             self.saveButton.setAttributedTitle(
                 NSMutableAttributedString(
-                    string:"완료",
+                    string: "완료",
                     attributes: [.font: DesignSystemFontFamily.Pretendard.medium.font(size: 18),
                                  .foregroundColor: DesignSystemAsset.GrayColor.gray25.color]
                 ), for: .normal
             )
-            
             self.view.endEditing(true)
             
-            
             if res.status == 200 {
-                self.dismiss(animated: true)
-            } else {
+                SwiftEntryKit.dismiss()
+                
+            }else {
                 self.showToast(text: res.description, font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
             }
-            
-            
-            
-           
-        }).disposed(by: disposeBag)
+        })
+        .disposed(by: disposeBag)
         
-        saveButton.rx.tap.subscribe(onNext: {[weak self] in
-           
+        saveButton.rx.tap.subscribe(onNext: { [weak self] in
             guard let self = self else {
                 return
             }
-            
             if self.viewModel.type != .share {
                 self.indicator.startAnimating()
                 self.saveButton.setAttributedTitle(
                     NSMutableAttributedString(
-                        string:"",
+                        string: "",
                         attributes: [.font: DesignSystemFontFamily.Pretendard.medium.font(size: 18),
                                      .foregroundColor: DesignSystemAsset.GrayColor.gray25.color]
                     ), for: .normal
                 )
             }
-           
             self.input.pressConfirm.onNext(())
-            
-           
-            
         })
         .disposed(by: disposeBag)
-        
-        
-      
-    }
-    
-    private func keyboardBinding()
-    {
-        //키보드 바인딩 작업
-        RxKeyboard.instance.visibleHeight //드라이브: 무조건 메인쓰레드에서 돌아감
-            .skip(1)
-            .drive(onNext: { [weak self] keyboardVisibleHeight in
-                
-                guard let self = self else {
-                    return
-                }
-                
-                
-                //키보드는 바텀 SafeArea부터 계산되므로 빼야함
-                let window: UIWindow? = UIApplication.shared.windows.first
-                let safeAreaInsetsBottom: CGFloat = window?.safeAreaInsets.bottom ?? 0
-                
-               
-                self.fakeViewHeight.constant = keyboardVisibleHeight - safeAreaInsetsBottom
-                self.panModalSetNeedsLayoutUpdate()
-                self.panModalTransition(to: .longForm)
-                self.view.layoutIfNeeded()
-                
-                
-                
-                
-            }).disposed(by: disposeBag)
-            
-        
-    }
-}
-
-
-extension MultiPurposePopupViewController: PanModalPresentable {
-
-    public override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
-    }
-
-    public var panModalBackgroundColor: UIColor {
-        return colorFromRGB(0x000000, alpha: 0.4)
-    }
-
-    public var panScrollable: UIScrollView? {
-      return nil
-    }
-
-    public var longFormHeight: PanModalHeight {
-    
-   
-        return viewModel.type == .share ? PanModalHeight.contentHeight(296 + 0 ) : PanModalHeight.contentHeight(296 + 350 )
-     }
-
-    public var cornerRadius: CGFloat {
-        return 24.0
-    }
-
-    public var allowsExtendedPanScrolling: Bool {
-        return true
-    }
-
-    public var showDragIndicator: Bool {
-        return false
     }
 }

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
@@ -82,7 +82,6 @@ public final class  MultiPurposePopupViewController: UIViewController, ViewContr
     @IBOutlet weak var confirmLabel: UILabel!
     
     @IBOutlet weak var indicator: NVActivityIndicatorView!
-    @IBOutlet weak var fakeViewHeight: NSLayoutConstraint!
     
     @IBOutlet weak var confireLabelGap: NSLayoutConstraint!
     

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
@@ -24,10 +24,8 @@ public enum PurposeType{
 }
 
 extension PurposeType{
-    
     var title:String{
         switch self{
-            
         case .creation:
             return "리스트 만들기"
         case .edit:
@@ -36,19 +34,13 @@ extension PurposeType{
             return "리스트 가져오기"
         case .share:
             return "리스트 공유하기"
-        
         case .nickname:
             return "닉네임 수정"
-            
         }
-        
-        
     }
     
     var subTitle:String{
-        
         switch self{
-            
         case .creation:
             return "리스트 제목"
         case .edit:
@@ -59,9 +51,7 @@ extension PurposeType{
             return "리스트 코드"
         case .nickname:
             return "닉네임"
-            
         }
-    
     }
     
     var btnText:String{
@@ -77,17 +67,11 @@ extension PurposeType{
         case .nickname:
             return "완료"
         }
-        
     }
 }
 
-
-
-
 public final class  MultiPurposePopupViewController: UIViewController, ViewControllerFromStoryBoard {
-
     @IBOutlet weak var saveButton: UIButton!
-    
     @IBOutlet weak var cancelButton: UIButton!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var subTitleLabel: UILabel!

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/PlayListDetailViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/PlayListDetailViewController.swift
@@ -88,8 +88,8 @@ public class PlayListDetailViewController: BaseViewController,ViewControllerFrom
     }
     
     @IBAction func pressEditNameAction(_ sender: UIButton) {
-        let multiPurposePopVc = multiPurposePopComponent.makeView(type: .edit,key: viewModel.key!)
-        self.showPanModal(content: multiPurposePopVc)
+        let multiPurposePopVc = multiPurposePopComponent.makeView(type: .edit, key: viewModel.key!)
+        self.showEntryKitModal(content: multiPurposePopVc, height: 296)
     }
     
     public override func viewDidLoad() {
@@ -485,8 +485,8 @@ extension PlayListDetailViewController:EditSheetViewDelegate {
             
         case .share:
             let vc = multiPurposePopComponent.makeView(type: .share,key: viewModel?.key ?? "")
-            self.showPanModal(content: vc)
-            
+            self.showEntryKitModal(content: vc, height: 296)
+
         case .profile:
             return
             

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/AfterLoginViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/AfterLoginViewController.swift
@@ -272,7 +272,7 @@ extension AfterLoginViewController:EditSheetViewDelegate {
             self.showPanModal(content: profile)
         case .nickname:
             let nickname = self.multiPurposePopComponent.makeView(type: .nickname)
-            self.showPanModal(content: nickname)
+            self.showEntryKitModal(content: nickname, height: 296)
         default:
             return
         }

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/MyPlayListViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/MyPlayListViewController.swift
@@ -292,6 +292,6 @@ extension MyPlayListViewController: UITableViewDelegate{
 extension MyPlayListViewController: MyPlayListHeaderViewDelegate{
     public func action(_ type: PurposeType) {
         let vc =  multiPurposePopComponent.makeView(type: type)
-        self.showPanModal(content: vc)
+        self.showEntryKitModal(content: vc, height: 296)
     }    
 }

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
@@ -44,6 +44,41 @@ public extension UIViewController {
         self.presentPanModal(viewController)
     }
     
+    func showEntryKitModal(content: UIViewController, height: CGFloat) {
+        var attributes: EKAttributes
+        attributes = .bottomFloat
+        attributes.displayDuration = .infinity
+        attributes.screenBackground = .color(color: EKColor(rgb: 0x000000).with(alpha: 0.4))
+        attributes.entryBackground = .color(color: EKColor(rgb: 0xffffff))
+        attributes.screenInteraction = .dismiss
+        attributes.entryInteraction = .absorbTouches
+        attributes.positionConstraints.verticalOffset = 0
+        attributes.positionConstraints.safeArea = .empty(fillSafeArea: true)
+        attributes.roundCorners = .top(radius: 24)
+        attributes.positionConstraints.keyboardRelation = .bind(offset: .none)
+        attributes.entranceAnimation = .init(
+            translate: .init(
+                duration: 0.4,
+                spring: .init(damping: 0.8, initialVelocity: 0)
+            )
+        )
+        attributes.exitAnimation = .init(
+            translate: .init(
+                duration: 0.4,
+                spring: .init(damping: 0.8, initialVelocity: 0)
+            )
+        )
+        attributes.positionConstraints.size = .init(
+            width: .offset(value: 0),
+            height: .constant(value: height)
+        )
+        attributes.positionConstraints.maxSize = .init(
+            width: .offset(value: 0),
+            height: .constant(value: height)
+        )
+        SwiftEntryKit.display(entry: content, using: attributes)
+    }
+    
     func showToast(text: String, font: UIFont) {
         var attributes = EKAttributes.bottomFloat
         attributes.displayDuration = 2


### PR DESCRIPTION
## 개요
PanModal 라이브러리를 통해 구현한 키보드 포함 모달 화면이 
릴리즈 모드 한정으로 런타임에서 동적으로 뷰 높이 변경이 불가한 문제로 인해 
SwiftEntryKit을 통해 구현합니다.

## 작업사항
MultiPurposePopupViewController는 SwiftEntryKit을 통해 모달화면으로 등장하도록 변경
<img width="1202" alt="스크린샷 2023-05-28 오전 4 15 28" src="https://github.com/wakmusic/wakmusic-iOS/assets/37323252/8b4f028b-8e5c-453b-8243-86748a25e234">

ㄴ 릴리즈 모드 시뮬레이터 동작 확인. 


Closes #258 