### PR TITLE
🔀 :: 플레이어가 닫힐때 duration이 초기화 되지 않도록 수정

### DIFF
--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+PlayProgress.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+PlayProgress.swift
@@ -17,5 +17,9 @@ extension PlayState {
             currentProgress = 0
             endProgress = 0
         }
+
+        public mutating func resetCurrentProgress() {
+            currentProgress = 0
+        }
     }
 }

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+YoutubePlayer.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+YoutubePlayer.swift
@@ -26,7 +26,7 @@ extension PlayState {
     public func stop() {
         self.player.stop() // stop만 하면 playbackState가 .cued로 들어감
         self.currentSong = nil
-        self.progress.clear()
+        self.progress.resetCurrentProgress()
         self.player.cue(source: .video(id: "")) // playbackState를 .unstarted로 바꿈
         //self.playList.removeAll()
     }


### PR DESCRIPTION
## 개요
#280

## 작업사항
플레이어가 닫힐 때 총 길이를 0으로 초기화하는 부분을 제거했습니다.

Closes #280