### PR TITLE
🔀 :: 재생목록 내 곡 삭제 로직 수정

### DIFF
--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
@@ -71,16 +71,16 @@ extension PlayState {
         }
         
         private func remove(at index: Int) {
+            // 재생중인 곡을 삭제하는 경우 CurrentPlayIndex를 다음으로 옮기고, 옮겨진 currentPlayIndex에 해당하는 곡을 재생
             if let currentPlayIndex = currentPlayIndex, index == currentPlayIndex {
                 changeCurrentPlayIndexToNext()
+                if let currentPlayIndex = self.currentPlayIndex {
+                    PlayState.shared.currentSong = list[safe: currentPlayIndex]?.item
+                    PlayState.shared.loadInPlaylist(at: currentPlayIndex)
+                }
             }
             
             list.remove(at: index)
-            
-            if let currentPlayIndex = currentPlayIndex, index == currentPlayIndex {
-                PlayState.shared.currentSong = list[safe: currentPlayIndex]?.item
-                PlayState.shared.loadInPlaylist(at: currentPlayIndex)
-            }
         }
         
         public func remove(indexs: [Int]) {


### PR DESCRIPTION
## 개요
#290

## 작업사항
현재 재생중인 곡의 이전 곡을 포함한 삭제 형태가 되면 현재 재생중인 곡이 다시 처음부터 재생되는 문제
1번째 인덱스의 곡이 재생 중일 때, 0번째 인덱스의 곡을 삭제하면 1번째 곡이 0번째로 변경되고 다시 재생되는 문제가 있었습니다.
