### PR TITLE
🔀 :: 썸네일 검은 줄 해결 및 이미지 품질 향상

### DIFF
--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -161,20 +161,54 @@ private extension PlayerViewController {
     private func bindThumbnail(output: PlayerViewModel.Output) {
         output.thumbnailImageURL.sink { [weak self] thumbnailImageURL in
             guard let self else { return }
+            
+            let placeholderImage = DesignSystemAsset.Logo.placeHolderLarge.image
+            let transitionOptions: KingfisherOptionsInfo = [.transition(.fade(0.2))]
+            
+            let hdURL = URL(string: thumbnailImageURL.hdQuality)
+            let sdURL = URL(string: thumbnailImageURL.sdQuality)
+            
             self.playerView.thumbnailImageView.kf.setImage(
-                with: URL(string: thumbnailImageURL),
-                placeholder: DesignSystemAsset.Logo.placeHolderLarge.image,
-                options: [.transition(.fade(0.2))]
+                with: hdURL,
+                placeholder: placeholderImage,
+                options: transitionOptions,
+                completionHandler: { [weak self] result in
+                    guard let self = self else { return }
+                    switch result {
+                    case .success:
+                        break
+                    case .failure(let error):
+                        self.playerView.thumbnailImageView.kf.setImage(
+                            with: sdURL,
+                            placeholder: placeholderImage,
+                            options: transitionOptions
+                        )
+                    }
+                }
             )
+            
             self.playerView.backgroundImageView.kf.setImage(
-                with: URL(string: thumbnailImageURL),
-                placeholder: DesignSystemAsset.Logo.placeHolderLarge.image,
-                options: [.transition(.fade(0.2))]
+                with: sdURL,
+                placeholder: placeholderImage,
+                options: transitionOptions,
+                completionHandler: { [weak self] result in
+                    guard let self = self else { return }
+                    switch result {
+                    case .success:
+                        break
+                    case .failure:
+                        self.playerView.backgroundImageView.kf.setImage(
+                            with: sdURL,
+                            placeholder: placeholderImage,
+                            options: transitionOptions
+                        )
+                    }
+                }
             )
             self.miniPlayerView.thumbnailImageView.kf.setImage(
-                with: URL(string: thumbnailImageURL),
-                placeholder: DesignSystemAsset.Logo.placeHolderLarge.image,
-                options: [.transition(.fade(0.2))]
+                with: sdURL,
+                placeholder: placeholderImage,
+                options: transitionOptions
             )
         }.store(in: &subscription)
     }

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
@@ -37,7 +37,7 @@ final class PlayerViewModel: ViewModelType {
         var playerState = CurrentValueSubject<YouTubePlayer.PlaybackState, Never>(.unstarted)
         var titleText = CurrentValueSubject<String, Never>("")
         var artistText = CurrentValueSubject<String, Never>("")
-        var thumbnailImageURL = CurrentValueSubject<String, Never>("")
+        var thumbnailImageURL = CurrentValueSubject<(sdQuality: String, hdQuality: String), Never>(("", ""))
         var playTimeValue = CurrentValueSubject<Float, Never>(0.0)
         var totalTimeValue = CurrentValueSubject<Float, Never>(0.0)
         var playTimeText = CurrentValueSubject<String, Never>("0:00")
@@ -294,15 +294,16 @@ final class PlayerViewModel: ViewModelType {
         sortedLyrics.removeAll()
         
         if let song = song {
-            let thumbnailURL = Utility.WMImageAPI.fetchYoutubeThumbnail(id: song.id).toString
-            output.thumbnailImageURL.send(thumbnailURL)
+            let thumbnailSDURL = Utility.WMImageAPI.fetchYoutubeThumbnail(id: song.id).toString
+            let thumbnailHDURL = Utility.WMImageAPI.fetchYoutubeThumbnailHD(id: song.id).toString
+            output.thumbnailImageURL.send((thumbnailSDURL, thumbnailHDURL))
             output.titleText.send(song.title)
             output.artistText.send(song.artist)
             output.viewsCountText.send(self.formatNumber(song.views))
             output.likeCountText.send("준비중")
             sortedLyrics.append("가사를 불러오는 중입니다.")
         } else {
-            output.thumbnailImageURL.send("")
+            output.thumbnailImageURL.send(("", ""))
             output.titleText.send("")
             output.artistText.send("")
             output.viewsCountText.send("조회수")

--- a/Projects/Modules/Utility/Sources/API/WMImageAPI.swift
+++ b/Projects/Modules/Utility/Sources/API/WMImageAPI.swift
@@ -17,6 +17,7 @@ public enum WMImageAPI {
     case fetchRecommendPlayListWithRound(id: String, version: Int)
     case fetchRecommendPlayListWithSquare(id: String, version: Int)
     case fetchYoutubeThumbnail(id: String)
+    case fetchYoutubeThumbnailHD(id: String)
     case fetchNotice(id: String)
 }
 
@@ -53,7 +54,10 @@ extension WMImageAPI {
             return WMDOMAIN_IMAGE_RECOMMEND_PLAYLIST_ROUND() + "/\(id).png?v=\(version)"
             
         case let .fetchYoutubeThumbnail(id):
-            return "vi/\(id)/hqdefault.jpg"
+            return "vi/\(id)/mqdefault.jpg"
+            
+        case let .fetchYoutubeThumbnailHD(id):
+            return "vi/\(id)/maxresdefault.jpg"
             
         case let .fetchNotice(id):
             return WMDOMAIN_IMAGE_NOTICE() + "/\(id)"
@@ -64,6 +68,8 @@ extension WMImageAPI {
         switch self {
         case .fetchYoutubeThumbnail:
             return youtubeBaseURLString + "/" + path
+        case .fetchYoutubeThumbnailHD:
+            return youtubeBaseURLString + "/" + path
         default:
             return baseURLString + "/" + path
         }
@@ -72,6 +78,8 @@ extension WMImageAPI {
     public var toURL: URL? {
         switch self {
         case .fetchYoutubeThumbnail:
+            return URL(string: youtubeBaseURLString + "/" + path)
+        case .fetchYoutubeThumbnailHD:
             return URL(string: youtubeBaseURLString + "/" + path)
         default:
             return URL(string: baseURLString + "/" + path)


### PR DESCRIPTION
## 개요
#306

## 작업사항
기존 이미지에 상하 레터박스가 존재해 화면 크기에 맞게 16:9 비율로 변환 시 썸네일 상하에 검은 줄이 보이는 문제였습니다.  
고화질 이미지(1280*720)를 먼저 불러오고 실패 시, 저화질 이미지(320*180)를 불러오도록 변경
