### PR TITLE
🔀 :: 재생목록 담기 시 재생중이던 곡이 멈추는 문제 수정

### DIFF
--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
@@ -45,11 +45,12 @@ public extension PlayState {
         }
         self.playList.append(notDuplicatedSongs)
         
-        if self.state == .unstarted { self.switchPlayerMode(to: .mini) }
-        
-        self.currentSong = self.playList.currentPlaySong
-        if let currentSong {
-            self.player.cue(source: .video(id: currentSong.id))
+        if self.state == .unstarted {
+            self.switchPlayerMode(to: .mini)
+            self.currentSong = self.playList.currentPlaySong
+            if let currentSong = currentSong {
+                self.player.cue(source: .video(id: currentSong.id))
+            }
         }
     }
 }


### PR DESCRIPTION
## 개요
#293 

## 작업사항

수정 전
self.currentSong = self.playList.currentPlaySong 부터의 코드는 플레이어가 닫혀있는 상태에서 재생목록 담기 시, 
빈 미니플레이어가 올라오는 것을 막기 위해 추가한 코드였지만(#282) 플레이어의 상태에 따른 분기처리가 안되어있었습니다.
```Swift
    /// 주어진 곡들을 재생목록에 추가합니다.
    /// - Parameter duplicateAllowed: 재생목록 추가 시 중복 허용 여부 (기본값: false)
    func appendSongsToPlaylist(_ songs: [SongEntity], duplicateAllowed: Bool = false) {
        let notDuplicatedSongs = songs.compactMap { song in
            return self.playList.uniqueIndex(of:PlayListItem(item: song)) == nil ? PlayListItem(item: song) : nil
        }
        self.playList.append(notDuplicatedSongs)
        
        if self.state == .unstarted {
            self.switchPlayerMode(to: .mini)
        }
        self.currentSong = self.playList.currentPlaySong
        if let currentSong = currentSong {
            self.player.cue(source: .video(id: currentSong.id))
        }
    }
```
수정 후
 if self.state == .unstarted 대신 if PlayerMode == . close 로 바꾸면 플레이어가 닫혀있음을 구분하기 위함이 명확해질 것 같은데 PlayerMode 를 PlayState에서 기억하고 있지 않고, 로직에 문제는 없다고 판단해 if self.state == .unstarted 로 유지했습니다.
```Swift
    /// 주어진 곡들을 재생목록에 추가합니다.
    /// - Parameter duplicateAllowed: 재생목록 추가 시 중복 허용 여부 (기본값: false)
    func appendSongsToPlaylist(_ songs: [SongEntity], duplicateAllowed: Bool = false) {
        let notDuplicatedSongs = songs.compactMap { song in
            return self.playList.uniqueIndex(of:PlayListItem(item: song)) == nil ? PlayListItem(item: song) : nil
        }
        self.playList.append(notDuplicatedSongs)
        
        if self.state == .unstarted {
            self.switchPlayerMode(to: .mini)
            self.currentSong = self.playList.currentPlaySong
            if let currentSong = currentSong {
                self.player.cue(source: .video(id: currentSong.id))
            }
        }
    }
```


Closes #이슈번호