### PR TITLE
🔀 :: 플레이어 > 재생목록 > 현재 재생 곡으로 포커싱

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/Environment.swift
+++ b/Tuist/ProjectDescriptionHelpers/Environment.swift
@@ -10,7 +10,7 @@ public enum Environment {
     public static let platform = Platform.iOS
     public static let baseSetting: SettingsDictionary = SettingsDictionary()
         .marketingVersion("2.0.0")
-        .currentProjectVersion("10")
+        .currentProjectVersion("11")
         .debugInformationFormat(DebugInformationFormat.dwarfWithDsym)
         .otherLinkerFlags(["-ObjC"])
 }


### PR DESCRIPTION
## 개요

## 작업사항
[wakmusic-iOS] New discussion #318: 재생목록 포커싱 기능

![스크린샷 2023-06-08 오전 11 31 54](https://github.com/wakmusic/wakmusic-iOS/assets/37323252/816744fa-c1ef-4328-a512-5d68c6dd00ce)


1. 테이블 뷰의 리로드 이벤트를 수신하는 Rx 문법 바인딩. 
2. 테이블뷰 리로드가 여러번 들어가는것 같습니다. 3번이나 꽂혀서 1초 내의 이벤트는 스킵하도록 합니다.
3. 재생목록에서 다른 곡을 선택할때도 리로드가 들어와서 이벤트는 1회만 수신하도록 합니다.
4. 재생목록이 없거나, 현재 포커스 하려는 인덱스가 데이터의 범위에 있는지 확인합니다.
5. 테이블뷰의 센터위치로 스크롤을 이동합니다. 애니메이션은 false입니다. + 딜레이 0.1초를 안주면 UI 갱신이 충돌나서 제대로 포커싱이 되지않아서 넣었습니다.


Closes #318 