### PR TITLE
🔀 :: 마이너 수정

### DIFF
--- a/Projects/App/Support/Info.plist
+++ b/Projects/App/Support/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<string>ko_KR</string>
 	<key>CFBundleDisplayName</key>
 	<string>왁타버스 뮤직</string>
 	<key>CFBundleExecutable</key>

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
@@ -327,20 +327,18 @@ extension MultiPurposePopupViewController{
             )
             self.view.endEditing(true)
             
+            // 토스트도 EntryKit을 사용하기 때문에 토스트만 띄워도 떠있던 팝업이 자동으로 내려감.
             if res.status == 200 {
-                SwiftEntryKit.dismiss()
-            }
-            
-            else if res.status == 401 {
+                self.showToast(text: "리스트를 가져왔습니다.", font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
+                
+            }else if res.status == 401 {
                 self.showToast(text: res.description, font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
                 LOGOUT()
-
-                if self.viewModel.type == .edit || self.viewModel.type == .creation {                   
+                if self.viewModel.type == .edit || self.viewModel.type == .creation {
                     self.delegate?.didTokenExpired()
                 }
-            }
-            
-            else {
+                
+            }else {
                 self.showToast(text: res.description, font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
             }
         })

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/NoticePopupViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/NoticePopupViewController.swift
@@ -106,7 +106,7 @@ extension NoticePopupViewController {
         ignoreButton.setAttributedTitle(ignoreButtonAttributedString, for: .normal)
 
 
-        let confirmButtonAttributedString = NSMutableAttributedString.init(string: "확인")
+        let confirmButtonAttributedString = NSMutableAttributedString.init(string: "닫기")
         confirmButtonAttributedString.addAttributes([.font: DesignSystemFontFamily.Pretendard.medium.font(size: 18),
                                                      .foregroundColor: DesignSystemAsset.GrayColor.gray25.color,
                                                      .kern: -0.5],
@@ -126,6 +126,7 @@ extension NoticePopupViewController {
         collectionView.register(UINib(nibName: "NoticeCollectionViewCell", bundle: Bundle.module), forCellWithReuseIdentifier: "NoticeCollectionViewCell")
         collectionView.isPagingEnabled = true
         collectionView.rx.setDelegate(self).disposed(by: disposeBag)
+        collectionView.bounces = false
     }
 }
 

--- a/Projects/Features/MainTabFeature/Sources/ViewModels/MainTabBarViewModel.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewModels/MainTabBarViewModel.swift
@@ -39,7 +39,6 @@ public class MainTabBarViewModel {
         self.fetchNoticeUseCase.execute(type: .currently)
             .catchAndReturn([])
             .asObservable()
-            .map { $0.sorted { $0.id > $1.id } }
             .map{ (entities) in
                 guard !igoredNoticeIds.isEmpty else { return entities }
                 return entities.filter { entity in

--- a/Projects/Features/RootFeature/Sources/ViewControllers/IntroViewController.swift
+++ b/Projects/Features/RootFeature/Sources/ViewControllers/IntroViewController.swift
@@ -94,7 +94,7 @@ extension IntroViewController {
                         
                     case .event:
                         textPopupVc = TextPopupViewController.viewController(
-                            text:"\(entity.title)\n\(entity.description)",
+                            text:"\(entity.title)\(entity.description.isEmpty ? "" : "\n")\(entity.description)",
                             cancelButtonIsHidden: true,
                             allowsDragAndTapToDismiss: false,
                             completion: {

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/BugReportViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/BugReportViewController.swift
@@ -73,6 +73,7 @@ public final class BugReportViewController: UIViewController,ViewControllerFromS
     lazy var input = BugReportViewModel.Input()
     lazy var output = viewModel.transform(from: input)
     var keyboardHeight:CGFloat = 267
+    var maxAttachedSize: Double = 100
     
     deinit {
         DEBUG_LOG("❌ \(Self.self) Deinit")
@@ -391,9 +392,10 @@ extension BugReportViewController {
     }
     
     private func showToastWithMaxSize() {
+        let doubleToInt: Int = Int(self.maxAttachedSize)
         DispatchQueue.main.async {
             self.showToast(
-                text: "첨부 파일의 용량은 최대 100MB 까지입니다.",
+                text: "첨부 파일의 용량은 최대 \(doubleToInt)MB 까지입니다.",
                 font: DesignSystemFontFamily.Pretendard.light.font(size: 14)
             )
         }
@@ -441,7 +443,7 @@ extension BugReportViewController: UIImagePickerControllerDelegate, UINavigation
         
         let imageToData: Data = image.pngData() ?? Data()
         let sizeMB: Double = Double(imageToData.count).megabytes
-        guard sizeMB <= 100 else {
+        guard sizeMB <= self.maxAttachedSize else {
             self.showToastWithMaxSize()
             return
         }
@@ -459,7 +461,8 @@ extension BugReportViewController: UIImagePickerControllerDelegate, UINavigation
 extension BugReportViewController: PHPickerViewControllerDelegate {
     public func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         picker.dismiss(animated: true)
-
+        let maxAttachedSize: Double = self.maxAttachedSize
+        
         results.forEach {
             let provider = $0.itemProvider
 
@@ -476,7 +479,7 @@ extension BugReportViewController: PHPickerViewControllerDelegate {
                                 let data = try Data(contentsOf: url)
                                 DEBUG_LOG("Video: \(data)")
                                 let sizeMB: Double = Double(data.count).megabytes
-                                guard sizeMB <= 100 else {
+                                guard sizeMB <= maxAttachedSize else {
                                     self.showToastWithMaxSize()
                                     return
                                 }
@@ -503,7 +506,7 @@ extension BugReportViewController: PHPickerViewControllerDelegate {
                                   let imageToData = image.pngData() else { return }
                             DEBUG_LOG("Image: \(imageToData)")
                             let sizeMB: Double = Double(imageToData.count).megabytes
-                            guard sizeMB <= 100 else {
+                            guard sizeMB <= maxAttachedSize else {
                                 self.showToastWithMaxSize()
                                 return
                             }

--- a/Projects/Features/StorageFeature/Sources/ViewModels/NoticeViewModel.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewModels/NoticeViewModel.swift
@@ -36,7 +36,6 @@ public class NoticeViewModel {
         self.fetchNoticeUseCase.execute(type: .all)
             .catchAndReturn([])
             .asObservable()
-            .map { $0.sorted { $0.id > $1.id } }
             .bind(to: output.dataSource)
             .disposed(by: disposeBag)
     }

--- a/Tuist/ProjectDescriptionHelpers/Environment.swift
+++ b/Tuist/ProjectDescriptionHelpers/Environment.swift
@@ -9,8 +9,8 @@ public enum Environment {
     public static let deploymentTarget: DeploymentTarget = .iOS(targetVersion: "14.0", devices: [.iphone])
     public static let platform = Platform.iOS
     public static let baseSetting: SettingsDictionary = SettingsDictionary()
-        .marketingVersion("2.0.0")
-        .currentProjectVersion("43")
+        .marketingVersion("2.0.1")
+        .currentProjectVersion("0")
         .debugInformationFormat(DebugInformationFormat.dwarfWithDsym)
         .otherLinkerFlags(["-ObjC"])
         .bitcodeEnabled(false)


### PR DESCRIPTION
## 개요
버그는 아니지만, 짜잘하게 반영할 사항이 보여서 수정하였습니다.

## 작업사항
1. 공지 리스트 내림차순 정렬 로직 제거 (백엔드 단의 정렬을 그대로 따라감)
2. 공지 팝업 '확인' 버튼의 문구를 '닫기'로 , collectionView.bounds 설정을 false로 변경
3. 앱 스토어 검색 시 앱 기본 언어가 '영어'로 설정된 것을 '한국어'로 변경
4. 플레이 리스트 가져오기 성공 시에도 토스트 팝업을 추가 (기존에 아무런 메세지가 안나와서 플레이 리스트가 많을 경우 피드백이 없는 것 처럼 보임)
5. Tuist 환경 설정에서 앱 버전 2.0.1, 빌드 번호 0으로 변경

Closes #343 