### PR TITLE
🔀 :: 곡 리스트 순서 변경이 가능한 화면의 성능 개선

### DIFF
--- a/Projects/App/Sources/Application/NeedleGenerated.swift
+++ b/Projects/App/Sources/Application/NeedleGenerated.swift
@@ -321,9 +321,6 @@ private class MyPlayListDependency067bbf42b28f80e413acProvider: MyPlayListDepend
     var deletePlayListUseCase: any DeletePlayListUseCase {
         return appComponent.deletePlayListUseCase
     }
-    var fetchPlayListDetailUseCase: any FetchPlayListDetailUseCase {
-        return appComponent.fetchPlayListDetailUseCase
-    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -961,7 +958,6 @@ extension MyPlayListComponent: Registration {
         keyPathToName[\MyPlayListDependency.fetchPlayListUseCase] = "fetchPlayListUseCase-any FetchPlayListUseCase"
         keyPathToName[\MyPlayListDependency.editPlayListOrderUseCase] = "editPlayListOrderUseCase-any EditPlayListOrderUseCase"
         keyPathToName[\MyPlayListDependency.deletePlayListUseCase] = "deletePlayListUseCase-any DeletePlayListUseCase"
-        keyPathToName[\MyPlayListDependency.fetchPlayListDetailUseCase] = "fetchPlayListDetailUseCase-any FetchPlayListDetailUseCase"
     }
 }
 extension AfterLoginComponent: Registration {

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/PlayListDetailViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/PlayListDetailViewController.swift
@@ -63,6 +63,7 @@ public class PlayListDetailViewController: BaseViewController,ViewControllerFrom
                 }
                 self.input.state.accept(EditState(isEditing: false, force: true))
                 self.input.cancelEdit.onNext(())
+                self.input.runEditing.onNext(())
             })
             self.showPanModal(content: vc)
             

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/PlayListDetailViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/PlayListDetailViewController.swift
@@ -57,13 +57,12 @@ public class PlayListDetailViewController: BaseViewController,ViewControllerFrom
                 self.input.runEditing.onNext(())
                 self.navigationController?.popViewController(animated: true)
                 
-            },cancelCompletion: { [weak self] in
+            }, cancelCompletion: { [weak self] in
                 guard let self =  self else {
                     return
                 }
                 self.input.state.accept(EditState(isEditing: false, force: true))
                 self.input.cancelEdit.onNext(())
-                self.input.runEditing.onNext(())
             })
             self.showPanModal(content: vc)
             

--- a/Projects/Features/CommonFeature/Sources/ViewModels/PlayListDetailViewModel.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewModels/PlayListDetailViewModel.swift
@@ -102,7 +102,7 @@ public final class PlayListDetailViewModel: ViewModelType {
                     })
                 })
             .map { [PlayListDetailSectionModel(model: 0, items: $0.songs)] }
-            .bind(to: output.dataSource,output.backUpdataSource)
+            .bind(to: output.dataSource, output.backUpdataSource)
             .disposed(by: disposeBag)
         
         input.playListNameLoad
@@ -116,6 +116,12 @@ public final class PlayListDetailViewModel: ViewModelType {
             .withLatestFrom(output.dataSource)
             .filter { !($0.first?.items ?? []).isEmpty }
             .map { $0.first?.items.map { $0.id } ?? [] }
+            .filter{ (ids: [String]) -> Bool in
+                let beforeIds: [String] = output.backUpdataSource.value.first?.items.map { $0.id } ?? []
+                let elementsEqual: Bool = beforeIds.elementsEqual(ids)
+                DEBUG_LOG(elementsEqual ? "❌ 변경된 내용이 없습니다." : "✅ 리스트가 변경되었습니다.")
+                return elementsEqual == false
+            }
             .flatMap{ [weak self] (songs: [String]) -> Observable<BaseEntity> in
                 guard let self = self, let key = self.key else {
                     return Observable.empty()

--- a/Projects/Features/CommonFeature/Sources/ViewModels/PlayListDetailViewModel.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewModels/PlayListDetailViewModel.swift
@@ -116,6 +116,10 @@ public final class PlayListDetailViewModel: ViewModelType {
             .withLatestFrom(output.dataSource)
             .filter { !($0.first?.items ?? []).isEmpty }
             .map { $0.first?.items.map { $0.id } ?? [] }
+            .do(onNext: { _ in
+                output.indexOfSelectedSongs.accept([]) //  바텀 Tab 내려가게 하기 위해
+                output.songEntityOfSelectedSongs.accept([]) //  바텀 Tab 내려가게 하기 위해
+            })
             .filter{ (ids: [String]) -> Bool in
                 let beforeIds: [String] = output.backUpdataSource.value.first?.items.map { $0.id } ?? []
                 let elementsEqual: Bool = beforeIds.elementsEqual(ids)
@@ -152,8 +156,6 @@ public final class PlayListDetailViewModel: ViewModelType {
                     return
                 }
                 output.refreshPlayList.accept(())
-                output.indexOfSelectedSongs.accept([]) //  바텀 Tab 내려가게 하기 위해
-                output.songEntityOfSelectedSongs.accept([]) //  바텀 Tab 내려가게 하기 위해
                 NotificationCenter.default.post(name: .playListRefresh, object: nil) // 바깥 플리 업데이트
             }).disposed(by: disposeBag)
                 

--- a/Projects/Features/StorageFeature/Sources/Components/MyPlayListComponent.swift
+++ b/Projects/Features/StorageFeature/Sources/Components/MyPlayListComponent.swift
@@ -17,7 +17,6 @@ public protocol MyPlayListDependency: Dependency {
     var fetchPlayListUseCase: any FetchPlayListUseCase {get}
     var editPlayListOrderUseCase: any EditPlayListOrderUseCase {get}
     var deletePlayListUseCase: any DeletePlayListUseCase {get}
-    var fetchPlayListDetailUseCase: any FetchPlayListDetailUseCase {get}
 }
 
 public final class MyPlayListComponent: Component<MyPlayListDependency> {
@@ -26,8 +25,7 @@ public final class MyPlayListComponent: Component<MyPlayListDependency> {
             viewModel: .init(
                 fetchPlayListUseCase: dependency.fetchPlayListUseCase,
                 editPlayListOrderUseCase: dependency.editPlayListOrderUseCase,
-                deletePlayListUseCase: dependency.deletePlayListUseCase,
-                fetchPlayListDetailUseCase: dependency.fetchPlayListDetailUseCase
+                deletePlayListUseCase: dependency.deletePlayListUseCase
             ),
             multiPurposePopComponent: dependency.multiPurposePopComponent,
             playListDetailComponent: dependency.playListDetailComponent

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/MyPlayListViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/MyPlayListViewController.swift
@@ -200,12 +200,6 @@ extension MyPlayListViewController{
                     text: result.description,
                     font: DesignSystemFontFamily.Pretendard.light.font(size: 14)
                 )
-            }).disposed(by: disposeBag)
-        
-        output.immediatelyPlaySongs
-            .subscribe(onNext: { [weak self] songs in
-                guard let self = self else {return}
-                self.playState.loadAndAppendSongsToPlaylist(songs)
             })
             .disposed(by: disposeBag)
     }
@@ -279,8 +273,16 @@ extension MyPlayListViewController: MyPlayListTableViewCellDelegate {
         switch type {
         case let .listTapped(indexPath):
             input.itemSelected.onNext(indexPath)
-        case let .playTapped(key):
-            input.getPlayListDetail.onNext(key)
+        case let .playTapped(indexPath):
+            let songs: [SongEntity] = output.dataSource.value[indexPath.section].items[indexPath.row].songlist
+            guard !songs.isEmpty else {
+                self.showToast(
+                    text: "리스트에 곡이 없습니다.",
+                    font: DesignSystemFontFamily.Pretendard.light.font(size: 14)
+                )
+                return
+            }
+            self.playState.loadAndAppendSongsToPlaylist(songs)
         }
     }
 }

--- a/Projects/Features/StorageFeature/Sources/ViewModels/FavoriteViewModel.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewModels/FavoriteViewModel.swift
@@ -145,6 +145,12 @@ public final class FavoriteViewModel:ViewModelType {
             .do(onNext: { _ in
                 output.indexPathOfSelectedLikeLists.accept([])
             })
+            .filter{ (ids: [String]) -> Bool in
+                let beforeIds: [String] = output.backUpdataSource.value.first?.items.map { $0.song.id } ?? []
+                let elementsEqual: Bool = beforeIds.elementsEqual(ids)
+                DEBUG_LOG(elementsEqual ? "❌ 변경된 내용이 없습니다." : "✅ 리스트가 변경되었습니다.")
+                return elementsEqual == false
+            }
             .flatMap{ [weak self] (ids: [String]) -> Observable<BaseEntity> in
                 guard let self = self else{
                     return Observable.empty()

--- a/Projects/Features/StorageFeature/Sources/ViewModels/MyPlayListViewModel.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewModels/MyPlayListViewModel.swift
@@ -15,11 +15,10 @@ import DomainModule
 import Utility
 import CommonFeature
 
-public final class MyPlayListViewModel:ViewModelType {
+public final class MyPlayListViewModel: ViewModelType {
     var fetchPlayListUseCase: FetchPlayListUseCase!
     var editPlayListOrderUseCase: EditPlayListOrderUseCase!
     var deletePlayListUseCase: DeletePlayListUseCase!
-    var fetchPlayListDetailUseCase: FetchPlayListDetailUseCase!
     var disposeBag = DisposeBag()
 
     public struct Input {
@@ -30,7 +29,6 @@ public final class MyPlayListViewModel:ViewModelType {
         let addPlayList: PublishSubject<Void> = PublishSubject()
         let deletePlayList: PublishSubject<Void> = PublishSubject()
         let runEditing: PublishSubject<Void> = PublishSubject()
-        let getPlayListDetail:PublishSubject<String> = PublishSubject()
     }
 
     public struct Output {
@@ -40,19 +38,16 @@ public final class MyPlayListViewModel:ViewModelType {
         let indexPathOfSelectedPlayLists: BehaviorRelay<[IndexPath]> = BehaviorRelay(value: [])
         let willAddPlayList: BehaviorRelay<[SongEntity]> = BehaviorRelay(value: [])
         let showToast: PublishRelay<BaseEntity> = PublishRelay()
-        let immediatelyPlaySongs:PublishSubject<[SongEntity]> = PublishSubject()
     }
 
     init(
         fetchPlayListUseCase: FetchPlayListUseCase,
         editPlayListOrderUseCase: EditPlayListOrderUseCase,
-        deletePlayListUseCase: DeletePlayListUseCase,
-        fetchPlayListDetailUseCase: FetchPlayListDetailUseCase
+        deletePlayListUseCase: DeletePlayListUseCase
     ) {
         self.fetchPlayListUseCase = fetchPlayListUseCase
         self.editPlayListOrderUseCase = editPlayListOrderUseCase
         self.deletePlayListUseCase = deletePlayListUseCase
-        self.fetchPlayListDetailUseCase = fetchPlayListDetailUseCase
         DEBUG_LOG("✅ \(Self.self) 생성")
     }
     
@@ -258,17 +253,6 @@ public final class MyPlayListViewModel:ViewModelType {
                 return newModel
             }
             .bind(to: output.dataSource)
-            .disposed(by: disposeBag)
-        
-        input.getPlayListDetail
-            .flatMap{ [weak self] (key) -> Observable<[SongEntity]> in
-                guard let `self` = self else { return Observable.empty() }
-                return self.fetchPlayListDetailUseCase
-                    .execute(id: key, type: .custom)
-                    .asObservable()
-                    .map { $0.songs }
-            }
-            .bind(to: output.immediatelyPlaySongs)
             .disposed(by: disposeBag)
 
         return output

--- a/Projects/Features/StorageFeature/Sources/ViewModels/MyPlayListViewModel.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewModels/MyPlayListViewModel.swift
@@ -148,6 +148,12 @@ public final class MyPlayListViewModel:ViewModelType {
             .do(onNext: { _ in
                 output.indexPathOfSelectedPlayLists.accept([])
             })
+            .filter{ (ids: [String]) -> Bool in
+                let beforeIds: [String] = output.backUpdataSource.value.first?.items.map { $0.key } ?? []
+                let elementsEqual: Bool = beforeIds.elementsEqual(ids)
+                DEBUG_LOG(elementsEqual ? "❌ 변경된 내용이 없습니다." : "✅ 리스트가 변경되었습니다.")
+                return elementsEqual == false
+            }
             .flatMap{ [weak self] (ids: [String]) -> Observable<BaseEntity> in
                 guard let self = self else{
                     return Observable.empty()

--- a/Projects/Features/StorageFeature/Sources/Views/MyPlayListTableViewCell.swift
+++ b/Projects/Features/StorageFeature/Sources/Views/MyPlayListTableViewCell.swift
@@ -18,7 +18,7 @@ public protocol MyPlayListTableViewCellDelegate: AnyObject {
 
 public enum MyPlayListTableViewCellDelegateConstant {
     case listTapped(indexPath: IndexPath)
-    case playTapped(key: String)
+    case playTapped(indexPath: IndexPath)
 }
 
 class MyPlayListTableViewCell: UITableViewCell {
@@ -31,7 +31,7 @@ class MyPlayListTableViewCell: UITableViewCell {
     @IBOutlet weak var listSelectButton: UIButton!
     
     @IBAction func playButtonAction(_ sender: UIButton) {
-        delegate?.buttonTapped(type: .playTapped(key: passToModel.1))
+        delegate?.buttonTapped(type: .playTapped(indexPath: passToModel.0))
     }
     
     @IBAction func listSelectButtonAction(_ sender: Any) {


### PR DESCRIPTION
## 개요
곡 리스트 순서 변경이 가능한 화면 성능 개선(내 플리상세, 내 리스트, 좋아요)

## 작업사항
1. 편집 완료 시, 순서가 변경되지 않았음에도 api 요청이 들어가는 부분 개선

2. 보관함 > '내 리스트' 에서 재생 버튼 누를 때, 플레이 리스트 상세 api를 요청하여 재생 리스트를 받아오는 부분 제거.

Closes #이슈번호