### PR TITLE
🔀 :: 재생목록 추가 기능 개선

### DIFF
--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
@@ -17,44 +17,39 @@ public extension PlayState {
     /// - 먼저 주어진 곡들의 첫번째 곡을 재생하며, 이후의 곡들은 재생목록의 마지막에 추가합니다.
     /// - Parameter duplicateAllowed: 재생목록 추가 시 중복 허용 여부 (기본값: false)
     func loadAndAppendSongsToPlaylist(_ songs: [SongEntity], duplicateAllowed: Bool = false) {
-        guard let firstSong = songs.first else { return }
-        let uniqueIndex = self.playList.uniqueIndex(of: PlayListItem(item: firstSong))
+        if songs.isEmpty { return }
+        // 1. 이미 있는 곡들 인덱스 찾기
+        // 2. 리스트에서 해당 인덱스들 곡 삭제
+        // 3. 리스트 뒤에 곡들 추가
+        // 4. currentPlayIndex 변경
+        // 5. 주어진 첫번째 곡 재생
+        let existSongIndexs = songs.uniqueElements.compactMap { self.playList.uniqueIndex(of: PlayListItem(item: $0)) }
+        self.playList.remove(indexs: existSongIndexs)
+        let mappedSongs = songs.uniqueElements.map { PlayListItem(item: $0) }
+        self.playList.append(mappedSongs)
         
-        if let uniqueIndex {
-            self.playList.changeCurrentPlayIndex(to: uniqueIndex)
-        } else {
-            self.playList.append(PlayListItem(item: firstSong))
-            self.playList.changeCurrentPlayIndex(to: self.playList.lastIndex)
+        if let firstSong = mappedSongs.first, let playSongIndex = self.playList.uniqueIndex(of: firstSong) {
+            if self.playerMode == .close { self.switchPlayerMode(to: .mini) }
+            self.playList.changeCurrentPlayIndex(to: playSongIndex)
+            self.load(at: mappedSongs.first!.item)
         }
-        
-        if self.playerMode == .close {
-            self.switchPlayerMode(to: .mini)
-        }
-        self.load(at: firstSong)
-        
-        let songsWithoutFirst = songs.dropFirst()
-        if songsWithoutFirst.isEmpty { return }
-        
-        let notDuplicatedSongs = songsWithoutFirst.uniqueElements.compactMap { song in
-            return self.playList.uniqueIndex(of:PlayListItem(item: song)) == nil ? PlayListItem(item: song) : nil
-        }
-        self.playList.append(notDuplicatedSongs)
-        
     }
     
     /// 주어진 곡들을 재생목록에 추가합니다.
     /// - Parameter duplicateAllowed: 재생목록 추가 시 중복 허용 여부 (기본값: false)
     func appendSongsToPlaylist(_ songs: [SongEntity], duplicateAllowed: Bool = false) {
-        let notDuplicatedSongs = songs.uniqueElements.compactMap { song in
-            return self.playList.uniqueIndex(of:PlayListItem(item: song)) == nil ? PlayListItem(item: song) : nil
-        }
-        self.playList.append(notDuplicatedSongs)
+        let existSongIndexs = songs.uniqueElements.compactMap { self.playList.uniqueIndex(of: PlayListItem(item: $0)) }
+        self.playList.remove(indexs: existSongIndexs)
+        let mappedSongs = songs.uniqueElements.map { PlayListItem(item: $0) }
+        self.playList.append(mappedSongs)
         
-        if self.playerMode == .close {
-            self.switchPlayerMode(to: .mini)
-            self.currentSong = self.playList.currentPlaySong
-            if let currentSong = currentSong {
-                self.player.cue(source: .video(id: currentSong.id))
+        if let firstSong = mappedSongs.first, let playSongIndex = self.playList.uniqueIndex(of: firstSong) {
+            if self.playerMode == .close {
+                self.switchPlayerMode(to: .mini)
+                self.currentSong = self.playList.currentPlaySong
+                if let currentSong = currentSong {
+                    self.player.cue(source: .video(id: currentSong.id))
+                }
             }
         }
     }

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
@@ -31,7 +31,7 @@ public extension PlayState {
         if let firstSong = mappedSongs.first, let playSongIndex = self.playList.uniqueIndex(of: firstSong) {
             if self.playerMode == .close { self.switchPlayerMode(to: .mini) }
             self.playList.changeCurrentPlayIndex(to: playSongIndex)
-            self.load(at: mappedSongs.first!.item)
+            self.load(at: firstSong.item)
         }
     }
     
@@ -43,13 +43,11 @@ public extension PlayState {
         let mappedSongs = songs.uniqueElements.map { PlayListItem(item: $0) }
         self.playList.append(mappedSongs)
         
-        if let firstSong = mappedSongs.first, let playSongIndex = self.playList.uniqueIndex(of: firstSong) {
-            if self.playerMode == .close {
-                self.switchPlayerMode(to: .mini)
-                self.currentSong = self.playList.currentPlaySong
-                if let currentSong = currentSong {
-                    self.player.cue(source: .video(id: currentSong.id))
-                }
+        if self.playerMode == .close {
+            self.switchPlayerMode(to: .mini)
+            self.currentSong = self.playList.currentPlaySong
+            if let currentSong = currentSong {
+                self.player.cue(source: .video(id: currentSong.id))
             }
         }
     }

--- a/Projects/Features/CommonFeature/Tests/TargetTests.swift
+++ b/Projects/Features/CommonFeature/Tests/TargetTests.swift
@@ -7,6 +7,15 @@ class TargetTests: XCTestCase {
     var playState = PlayState.shared
     var playlist = PlayState.shared.playList
     var subscription = Set<AnyCancellable>()
+    let givenList = [
+        SongEntity(id: "", title: "제목1", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+        SongEntity(id: "", title: "제목2", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+        SongEntity(id: "", title: "제목3", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+        SongEntity(id: "", title: "제목4", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+        SongEntity(id: "", title: "제목5", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+        SongEntity(id: "", title: "제목6", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+        SongEntity(id: "", title: "제목7", artist: "", remix: "", reaction: "", views: 0, last: 0, date: "")
+    ].map { PlayListItem(item: $0) }
     
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -20,19 +29,32 @@ class TargetTests: XCTestCase {
         XCTAssertEqual("A", "A")
     }
     
+    func testAppendSong() {
+        // given
+        playlist.list = givenList
+        
+        // when
+        let testList = [
+            SongEntity(id: "", title: "제목3", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+            SongEntity(id: "", title: "제목2", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+            SongEntity(id: "", title: "제목5", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+            SongEntity(id: "", title: "제목6", artist: "", remix: "", reaction: "", views: 0, last: 0, date: "")
+        ]
+        playState.loadAndAppendSongsToPlaylist(testList)
+        
+        // then 147 3256
+        let currentPlayIndex = playlist.currentPlayIndex ?? -1
+        XCTAssertEqual(currentPlayIndex, 3)
+        XCTAssertEqual(playlist.list[2].item.title, "제목7")
+        XCTAssertEqual(playlist.list[3].item.title, "제목3")
+        XCTAssertEqual(playlist.list[4].item.title, "제목2")
+        XCTAssertEqual(playlist.list[5].item.title, "제목5")
+        XCTAssertEqual(playlist.list[6].item.title, "제목6")
+    }
+    
     func testRemoveSong() {
         // given
-        let list = [
-            SongEntity(id: "", title: "제목1", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
-            SongEntity(id: "", title: "제목2", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
-            SongEntity(id: "", title: "제목3", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
-            SongEntity(id: "", title: "제목4", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
-            SongEntity(id: "", title: "제목5", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
-            SongEntity(id: "", title: "제목6", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
-            SongEntity(id: "", title: "제목7", artist: "", remix: "", reaction: "", views: 0, last: 0, date: "")
-        ].map { PlayListItem(item: $0) }
-        
-        playlist.list = list
+        playlist.list = givenList
         playlist.changeCurrentPlayIndex(to: 2)
         
         // when
@@ -46,7 +68,7 @@ class TargetTests: XCTestCase {
         XCTAssertEqual(playlist.list[1].item.title, "제목4")
         
         // given
-        playlist.list = list
+        playlist.list = givenList
         playlist.changeCurrentPlayIndex(to: playlist.lastIndex)
         
         // when
@@ -62,16 +84,7 @@ class TargetTests: XCTestCase {
     
     func testRorderSong() {
         // given
-        let list = [
-            SongEntity(id: "", title: "제목1", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
-            SongEntity(id: "", title: "제목2", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
-            SongEntity(id: "", title: "제목3", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
-            SongEntity(id: "", title: "제목4", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
-            SongEntity(id: "", title: "제목5", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
-            SongEntity(id: "", title: "제목6", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
-            SongEntity(id: "", title: "제목7", artist: "", remix: "", reaction: "", views: 0, last: 0, date: "")
-        ].map { PlayListItem(item: $0) }
-        playlist.list = list
+        playlist.list = givenList
         
         // when
         playlist.reorderPlaylist(from: 2, to: 1)

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -108,7 +108,7 @@ private extension PlayerViewController {
             $0.width.equalTo(self.playerView.thumbnailImageView.snp.width)
             $0.height.equalTo(self.playerView.thumbnailImageView.snp.height)
         }
-        PlayState.shared.reSubscriptionPlayPublisher()
+        PlayState.shared.subscribePlayPublisher()
     }
     
     private func bindViewModel() {


### PR DESCRIPTION
## 개요
기존엔 재생목록에 a-b-c-d-e 라는 곡이 있을 때 a, c, e, f 를 선택 재생 하면
재생목록에 이미 있는 곡은 변화가 일어나지 않고 a-b-c-d-e-**f** 가 됨

## 작업사항
사용자가 선택한 곡을 순서대로 들을 수 있도록 
b-d-**a-c-e-f** 가 되도록 변경

<img width="605" alt="image" src="https://github.com/wakmusic/wakmusic-iOS/assets/60254939/b5cc0d67-633d-42ed-b3be-4ff4f088fd2d">


Closes #373 