### PR TITLE
🔀 :: 현재재생목록 드래그 제스처로 닫기 기능 추가

### DIFF
--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -88,9 +88,9 @@ private extension PlaylistViewController {
             
         case .changed:
             let distanceY = max(distance.y, 0)
-            let opacity = 1 - (distanceY / screenHeight)
             view.frame = CGRect(x: 0, y: distanceY, width: view.frame.width, height: screenHeight)
-            updateOpacity(value: Float(opacity))
+            //let opacity = 1 - (distanceY / screenHeight)
+            //updateOpacity(value: Float(opacity))
             
         case .ended:
             let velocity = gestureRecognizer.velocity(in: self.view)

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -36,6 +36,8 @@ public class PlaylistViewController: UIViewController, SongCartViewType {
     public var songCartView: CommonFeature.SongCartView!
     public var bottomSheetView: CommonFeature.BottomSheetView!
     
+    private var panGestureRecognizer: UIPanGestureRecognizer!
+    
     init(viewModel: PlaylistViewModel, containSongsComponent: ContainSongsComponent) {
         self.viewModel = viewModel
         self.containSongsComponent = containSongsComponent
@@ -59,6 +61,7 @@ public class PlaylistViewController: UIViewController, SongCartViewType {
     public override func viewDidLoad() {
         super.viewDidLoad()
         playlistView.playlistTableView.rx.setDelegate(self).disposed(by: disposeBag)
+        bindGesture()
         bindViewModel()
         bindActions()
     }
@@ -75,6 +78,55 @@ public class PlaylistViewController: UIViewController, SongCartViewType {
 }
 
 private extension PlaylistViewController {
+    @objc func handlePanGesture(_ gestureRecognizer: UIPanGestureRecognizer) {
+        let distance = gestureRecognizer.translation(in: self.view)
+        let screenHeight = Utility.APP_HEIGHT()
+        
+        switch gestureRecognizer.state {
+        case .began:
+            return
+            
+        case .changed:
+            let distanceY = max(distance.y, 0)
+            let opacity = 1 - (distanceY / screenHeight)
+            view.frame = CGRect(x: 0, y: distanceY, width: view.frame.width, height: screenHeight)
+            updateOpacity(value: Float(opacity))
+            
+        case .ended:
+            let velocity = gestureRecognizer.velocity(in: self.view)
+            
+            // 빠르게 드래그하거나 화면의 40% 이상 드래그 했을 경우 dismiss
+            if velocity.y > 1000 || view.frame.origin.y > (screenHeight * 0.4) {
+                dismiss(animated: true)
+            } else {
+                UIView.animate(withDuration: 0.35,
+                               delay: 0.0,
+                               usingSpringWithDamping: 0.8,
+                               initialSpringVelocity: 0.8,
+                               options: [.curveEaseInOut],
+                               animations: {
+                    self.view.frame = CGRect(x: 0, y: 0, width: self.view.frame.width, height: screenHeight)
+                    self.updateOpacity(value  : 1)
+                })
+            }
+            
+        default:
+            break
+        }
+    }
+    
+    func updateOpacity(value: Float) {
+        playlistView.layer.opacity = value
+    }
+}
+
+private extension PlaylistViewController {
+    private func bindGesture() {
+        panGestureRecognizer = UIPanGestureRecognizer(target: self,
+                                                      action: #selector(handlePanGesture(_:)))
+        self.playlistView.titleBarView.addGestureRecognizer(panGestureRecognizer)
+    }
+    
     private func bindViewModel() {
         let input = PlaylistViewModel.Input(
             closeButtonDidTapEvent: playlistView.closeButton.tapPublisher,

--- a/Projects/Features/PlayerFeature/Sources/Views/PlaylistView.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/PlaylistView.swift
@@ -20,7 +20,7 @@ public final class PlaylistView: UIView {
     
     private lazy var contentView = UIView()
     
-    private lazy var titleBarView: UIView = UIView()
+    internal lazy var titleBarView: UIView = UIView()
     
     internal lazy var closeButton = UIButton().then {
         $0.setImage(DesignSystemAsset.Navigation.close.image, for: .normal)


### PR DESCRIPTION
## 개요
크게 중요한 기능은 아닌데 닫을 수 있는 방법이 only 버튼에서 버튼 or 제스처 두개로 늘어났다고 보면 됩니다.
dismiss되는 트리거는 유튜브 영상 느낌을 참고했습니다.

## 작업사항
- 현재재생목록 드래그해서 닫기 기능

~~https://github.com/wakmusic/wakmusic-iOS/assets/60254939/7dbe365a-b6b2-4fc1-bcdf-b9a59ff13124~~

https://github.com/wakmusic/wakmusic-iOS/assets/60254939/6a5767d7-9683-4da4-aead-84f5c03e273f

