### PR TITLE
🔀 :: PlayState와 PlayList 간의 의존성 분리 및 테스트 코드 수정

### DIFF
--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+PlayProgress.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+PlayProgress.swift
@@ -8,18 +8,21 @@
 
 import Foundation
 
-extension PlayState {
-    public struct PlayProgress {
-        public var currentProgress: Double = 0
-        public var endProgress: Double = 0
-        
-        public mutating func clear() {
-            currentProgress = 0
-            endProgress = 0
-        }
-
-        public mutating func resetCurrentProgress() {
-            currentProgress = 0
-        }
+public struct PlayProgress {
+    public var currentProgress: Double
+    public var endProgress: Double
+    
+    public init(currentProgress: Double = 0, endProgress: Double = 0) {
+        self.currentProgress = currentProgress
+        self.endProgress = endProgress
+    }
+    
+    public mutating func clear() {
+        currentProgress = 0
+        endProgress = 0
+    }
+    
+    public mutating func resetCurrentProgress() {
+        currentProgress = 0
     }
 }

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
@@ -24,114 +24,115 @@ public struct PlayListItem: Equatable {
     }
 }
 
-extension PlayState {
-    public class PlayList {
-        public var list: [PlayListItem] {
-            didSet(oldValue) {
-                listChanged.send(list)
-                
-                let allItemsNotPlaying = list.allSatisfy { $0.isPlaying == false }
-                if oldValue.isEmpty && !list.isEmpty && allItemsNotPlaying {
-                    changeCurrentPlayIndex(to: 0)
-                }
-            }
-        }
-        public var listChanged = CurrentValueSubject<[PlayListItem], Never>([])
-        public var listAppended = CurrentValueSubject<[PlayListItem], Never>([])
-        public var listRemoved = CurrentValueSubject<[PlayListItem], Never>([])
-        public var listReordered = CurrentValueSubject<[PlayListItem], Never>([])
-        public var currentSongChanged = CurrentValueSubject<[PlayListItem], Never>([])
-        
-        init(list: [PlayListItem] = []) {
-            self.list = list
-        }
-        public var currentPlayIndex: Int? { return list.firstIndex(where: { $0.isPlaying == true }) }
-        public var currentPlaySong: SongEntity? { list[safe: currentPlayIndex ?? -1]?.item }
-        public var first: SongEntity? { return list.first?.item }
-        public var last: SongEntity? { return list.last?.item }
-        public var count: Int { return list.count }
-        public var lastIndex: Int { return list.count - 1 }
-        public var isEmpty: Bool { return list.isEmpty }
-        public var isFirst: Bool { return currentPlayIndex == 0 }
-        public var isLast: Bool { return currentPlayIndex == lastIndex }
-        
-        public func append(_ item: PlayListItem) {
-            list.append(item)
-            listAppended.send(list)
-        }
-        
-        public func append(_ items: [PlayListItem]) {
-            list.append(contentsOf: items)
-            listAppended.send(list)
-        }
-        
-        public func insert(_ newElement: PlayListItem, at: Int) {
-            list.insert(newElement, at: at)
-            listAppended.send(list)
-        }
-        
-        private func remove(at index: Int) {
-            // 재생중인 곡을 삭제하는 경우 CurrentPlayIndex를 다음으로 옮기고, 옮겨진 currentPlayIndex에 해당하는 곡을 재생
-            if let currentPlayIndex = currentPlayIndex, index == currentPlayIndex {
-                changeCurrentPlayIndexToNext()
-                if let currentPlayIndex = self.currentPlayIndex {
-                    PlayState.shared.currentSong = list[safe: currentPlayIndex]?.item
-                    PlayState.shared.loadInPlaylist(at: currentPlayIndex)
-                }
-            }
+
+public class PlayList {
+    public var list: [PlayListItem] {
+        didSet(oldValue) {
+            listChanged.send(list)
             
-            list.remove(at: index)
-        }
-        
-        public func remove(indexs: [Int]) {
-            let sortedIndexs = indexs.sorted(by: >) // 앞에서부터 삭제하면 인덱스 순서가 바뀜
-            sortedIndexs.forEach { index in
-                remove(at: index)
+            let allItemsNotPlaying = list.allSatisfy { $0.isPlaying == false }
+            if oldValue.isEmpty && !list.isEmpty && allItemsNotPlaying {
+                changeCurrentPlayIndex(to: 0)
             }
-            listRemoved.send(list)
-        }
-        
-        public func removeAll() {
-            list.removeAll()
-            PlayState.shared.stop()
-            PlayState.shared.switchPlayerMode(to: .mini)
-            listRemoved.send(list)
-        }
-        
-        public func contains(_ item: PlayListItem) -> Bool {
-            return list.contains(item)
-        }
-        
-        public func changeCurrentPlayIndex(to index: Int) {
-            let currentPlayIndex = currentPlayIndex ?? 0
-            list[currentPlayIndex].isPlaying = false
-            list[index].isPlaying = true
-            currentSongChanged.send(list)
-        }
-        
-        public func changeCurrentPlayIndexToPrevious() {
-            guard let currentPlayIndex = currentPlayIndex else { return }
-            let previousIndex = (currentPlayIndex - 1 + list.count) % list.count
-            changeCurrentPlayIndex(to: previousIndex)
-        }
-        
-        public func changeCurrentPlayIndexToNext() {
-            guard let currentPlayIndex = currentPlayIndex else { return }
-            let nextIndex = (currentPlayIndex + 1 + list.count) % list.count
-            changeCurrentPlayIndex(to: nextIndex)
-        }
-        
-        public func reorderPlaylist(from: Int, to: Int) {
-            let movedData = list[from]
-            list.remove(at: from)
-            list.insert(movedData, at: to)
-            //Comment: 순서가 변경되어도 DB를 업데이트 하지 않음
-            //listReordered.send(list)
-        }
-        
-        /// 해당 곡이 이미 재생목록에 있으면 재생목록 속 해당 곡의 index, 없으면 nil 리턴
-        public func uniqueIndex(of item: PlayListItem) -> Int? {
-            return list.firstIndex(where: { $0.item == item.item })
         }
     }
+    public var listChanged = PassthroughSubject<[PlayListItem], Never>()
+    public var listAppended = PassthroughSubject<[PlayListItem], Never>()
+    public var listRemoved = PassthroughSubject<[PlayListItem], Never>()
+    public var listReordered = PassthroughSubject<[PlayListItem], Never>()
+    public var currentPlayIndexChanged = PassthroughSubject<[PlayListItem], Never>()
+    public var currentPlaySongChanged = PassthroughSubject<SongEntity, Never>()
+    
+    public init(list: [PlayListItem] = []) {
+        self.list = list
+    }
+    public var currentPlayIndex: Int? { return list.firstIndex(where: { $0.isPlaying == true }) }
+    public var currentPlaySong: SongEntity? { list[safe: currentPlayIndex ?? -1]?.item }
+    public var first: SongEntity? { return list.first?.item }
+    public var last: SongEntity? { return list.last?.item }
+    public var count: Int { return list.count }
+    public var lastIndex: Int { return list.count - 1 }
+    public var isEmpty: Bool { return list.isEmpty }
+    public var isFirst: Bool { return currentPlayIndex == 0 }
+    public var isLast: Bool { return currentPlayIndex == lastIndex }
+    
+    public func append(_ item: PlayListItem) {
+        list.append(item)
+        listAppended.send(list)
+    }
+    
+    public func append(_ items: [PlayListItem]) {
+        list.append(contentsOf: items)
+        listAppended.send(list)
+    }
+    
+    public func insert(_ newElement: PlayListItem, at: Int) {
+        list.insert(newElement, at: at)
+        listAppended.send(list)
+    }
+    
+    private func remove(at index: Int) {
+        // 재생중인 곡을 삭제하는 경우 CurrentPlayIndex를 다음으로 옮기고, 옮겨진 currentPlayIndex에 해당하는 곡을 재생
+        if let currentPlayIndex = currentPlayIndex, index == currentPlayIndex {
+            changeCurrentPlayIndexToNext()
+            if let currentPlayIndex = self.currentPlayIndex,
+               let song = list[safe: currentPlayIndex]?.item {
+                currentPlaySongChanged.send(song)
+            }
+        }
+        
+        list.remove(at: index)
+    }
+    
+    public func remove(indexs: [Int]) {
+        let sortedIndexs = indexs.sorted(by: >) // 앞에서부터 삭제하면 인덱스 순서가 바뀜
+        sortedIndexs.forEach { index in
+            remove(at: index)
+        }
+        listRemoved.send(list)
+    }
+    
+    public func removeAll() {
+        list.removeAll()
+        PlayState.shared.stop()
+        PlayState.shared.switchPlayerMode(to: .mini)
+        listRemoved.send(list)
+    }
+    
+    public func contains(_ item: PlayListItem) -> Bool {
+        return list.contains(item)
+    }
+    
+    public func changeCurrentPlayIndex(to index: Int) {
+        let currentPlayIndex = currentPlayIndex ?? 0
+        list[currentPlayIndex].isPlaying = false
+        list[index].isPlaying = true
+        currentPlayIndexChanged.send(list)
+    }
+    
+    public func changeCurrentPlayIndexToPrevious() {
+        guard let currentPlayIndex = currentPlayIndex else { return }
+        let previousIndex = (currentPlayIndex - 1 + list.count) % list.count
+        changeCurrentPlayIndex(to: previousIndex)
+    }
+    
+    public func changeCurrentPlayIndexToNext() {
+        guard let currentPlayIndex = currentPlayIndex else { return }
+        let nextIndex = (currentPlayIndex + 1 + list.count) % list.count
+        changeCurrentPlayIndex(to: nextIndex)
+    }
+    
+    public func reorderPlaylist(from: Int, to: Int) {
+        let movedData = list[from]
+        list.remove(at: from)
+        list.insert(movedData, at: to)
+        //Comment: 순서가 변경되어도 DB를 업데이트 하지 않음
+        //listReordered.send(list)
+    }
+    
+    /// 해당 곡이 이미 재생목록에 있으면 재생목록 속 해당 곡의 index, 없으면 nil 리턴
+    public func uniqueIndex(of item: PlayListItem) -> Int? {
+        return list.firstIndex(where: { $0.item == item.item })
+    }
 }
+

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Playlist.swift
@@ -24,7 +24,6 @@ public struct PlayListItem: Equatable {
     }
 }
 
-
 public class PlayList {
     public var list: [PlayListItem] {
         didSet(oldValue) {
@@ -135,4 +134,3 @@ public class PlayList {
         return list.firstIndex(where: { $0.item == item.item })
     }
 }
-

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+Public.swift
@@ -47,21 +47,21 @@ public extension PlayState {
             self.switchPlayerMode(to: .mini)
             self.currentSong = self.playList.currentPlaySong
             if let currentSong = currentSong {
-                self.player.cue(source: .video(id: currentSong.id))
+                self.player?.cue(source: .video(id: currentSong.id))
             }
         }
     }
     
     /// 플레이어의 상태를 체크합니다.
     func checkForPlayerState(completion: ((YouTubePlayer.State) -> Void)? = nil) {
-        guard let playerState = self.player.state else { return }
+        guard let playerState = self.player?.state else { return }
         completion?(playerState)
     }
     
     /// 플레이어를 리셋합니다.
     func resetPlayer() {
         self.player = YouTubePlayer(configuration: .init(autoPlay: false, showControls: false, showRelatedVideos: false))
-        self.player.cue(source: .video(id: self.currentSong?.id ?? ""))
+        self.player?.cue(source: .video(id: self.currentSong?.id ?? ""))
         NotificationCenter.default.post(name: .resetYouTubePlayerHostingView, object: nil)
     }
 }

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState+YoutubePlayer.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState+YoutubePlayer.swift
@@ -15,20 +15,20 @@ extension PlayState {
     
     /// ⏯️ 현재 곡 재생
     public func play() {
-        self.player.play()
+        self.player?.play()
     }
     
     /// ⏸️ 일시정지
     public func pause() {
-        self.player.pause()
+        self.player?.pause()
     }
     
     /// ⏹️ 플레이어 닫기
     public func stop() {
-        self.player.stop() // stop만 하면 playbackState가 .cued로 들어감
+        self.player?.stop() // stop만 하면 playbackState가 .cued로 들어감
         self.currentSong = nil
         self.progress.resetCurrentProgress()
-        self.player.cue(source: .video(id: "")) // playbackState를 .unstarted로 바꿈
+        self.player?.cue(source: .video(id: "")) // playbackState를 .unstarted로 바꿈
         //self.playList.removeAll()
     }
     
@@ -37,7 +37,7 @@ extension PlayState {
         //requestPlaybackLog(current: song) // v2 api 완성 후 적용하기로 함.
         self.currentSong = song
         guard let currentSong = currentSong else { return }
-        self.player.load(source: .video(id: currentSong.id))
+        self.player?.load(source: .video(id: currentSong.id))
     }
     
     /// ▶️ 플레이리스트의 해당 위치의  곡 재생

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState.swift
@@ -74,14 +74,22 @@ final public class PlayState {
     /// 플레이리스트에 변경사항이 생겼을 때, 로컬 DB를 덮어씁니다.
     public func subscribePlayListChanges() {
         Publishers.Merge4(
-            playList.listAppended.dropFirst(),
-            playList.listRemoved.dropFirst(),
-            playList.listReordered.dropFirst(),
-            playList.currentSongChanged.dropFirst()
+            playList.listAppended,
+            playList.listRemoved,
+            playList.listReordered,
+            playList.currentPlayIndexChanged
         )
         .sink { [weak self] playListItems in
             guard let self else { return }
             self.updatePlayListChangesToLocalDB(playList: playListItems)
+        }.store(in: &subscription)
+        
+        playList.currentPlaySongChanged.sink { [weak self] song in
+            guard let self else { return }
+            self.currentSong = song
+            if let index = self.playList.currentPlayIndex {
+                loadInPlaylist(at: index)
+            }
         }.store(in: &subscription)
     }
     

--- a/Projects/Features/CommonFeature/Sources/PlayState/PlayState.swift
+++ b/Projects/Features/CommonFeature/Sources/PlayState/PlayState.swift
@@ -14,7 +14,7 @@ import Utility
 import AVFAudio
 
 final public class PlayState {
-    public static let shared = PlayState()
+    public static let shared = PlayState(player: YouTubePlayer(configuration: .init(autoPlay: false, showControls: false, showRelatedVideos: false)))
     
     @Published public var player: YouTubePlayer?
     @Published public var state: YouTubePlayer.PlaybackState = .unstarted
@@ -27,7 +27,11 @@ final public class PlayState {
 
     private var subscription = Set<AnyCancellable>()
     
-    public init(player: YouTubePlayer?, playList: PlayList, playProgress: PlayProgress, fetchPlayListFromLocalDB: () -> [PlayListItem]) {
+    public init(
+        player: YouTubePlayer?,
+        playList: PlayList = PlayList(),
+        playProgress: PlayProgress = PlayProgress())
+    {
         DEBUG_LOG("🚀:: \(Self.self) initialized")
         self.player = player
         self.playList = playList
@@ -40,13 +44,6 @@ final public class PlayState {
         subscribePlayPublisher()
         subscribePlayListChanges()
         registerAudioRouteChangeNotification()
-    }
-    
-    convenience public init() {
-        self.init(player: YouTubePlayer(configuration: .init(autoPlay: false, showControls: false, showRelatedVideos: false)), playList: PlayList(), playProgress: PlayProgress(), fetchPlayListFromLocalDB: { return [] })
-    }
-    convenience public init(player: YouTubePlayer?) {
-        self.init(player: player, playList: PlayList(), playProgress: PlayProgress(), fetchPlayListFromLocalDB: { return [] })
     }
     
     deinit {

--- a/Projects/Features/CommonFeature/Tests/PlaylistTests.swift
+++ b/Projects/Features/CommonFeature/Tests/PlaylistTests.swift
@@ -1,0 +1,82 @@
+//
+//  PlaylistTests.swift
+//  CommonFeature
+//
+//  Created by YoungK on 2023/09/25.
+//  Copyright © 2023 yongbeomkwak. All rights reserved.
+//
+
+import XCTest
+import DomainModule
+import CommonFeature
+
+final class PlaylistTests: XCTestCase {
+    let givenList = [
+        SongEntity(id: "", title: "제목1", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+        SongEntity(id: "", title: "제목2", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+        SongEntity(id: "", title: "제목3", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+        SongEntity(id: "", title: "제목4", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+        SongEntity(id: "", title: "제목5", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+        SongEntity(id: "", title: "제목6", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
+        SongEntity(id: "", title: "제목7", artist: "", remix: "", reaction: "", views: 0, last: 0, date: "")
+    ].map { PlayListItem(item: $0) }
+    
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testRemoveSong() {
+        // given
+        var playList = PlayList(list: givenList)
+        playList.changeCurrentPlayIndex(to: 2)
+
+        // when
+        playList.remove(indexs: [1, 2, 4, 5])
+
+        // then
+        var currentPlayIndex = playList.currentPlayIndex ?? -1
+        XCTAssertEqual(currentPlayIndex , 1)
+        XCTAssertEqual(playList.count, 3)
+        XCTAssertEqual(playList.list[0].item.title, "제목1")
+        XCTAssertEqual(playList.list[1].item.title, "제목4")
+
+        // given
+        playList = PlayList(list: givenList)
+        playList.changeCurrentPlayIndex(to: playList.lastIndex)
+
+        // when
+        playList.remove(indexs: [4, 5, 6])
+
+        // then
+        currentPlayIndex = playList.currentPlayIndex ?? -1
+        XCTAssertEqual(currentPlayIndex , 0)
+        XCTAssertEqual(playList.count, 4)
+        XCTAssertEqual(playList.list[0].item.title, "제목1")
+        XCTAssertEqual(playList.list[1].item.title, "제목2")
+    }
+
+    func testRorderSong() {
+        // given
+        var playList = PlayList(list: givenList)
+        playList.list[0].isPlaying = true
+        
+        // when
+        playList.reorderPlaylist(from: 2, to: 1)
+
+        // then
+        var currentPlayIndex = playList.currentPlayIndex ?? -1
+        XCTAssertEqual(currentPlayIndex, 0)
+
+        // when
+        playList.reorderPlaylist(from: 0, to: 6)
+
+        // then
+        currentPlayIndex = playList.currentPlayIndex ?? -1
+        XCTAssertEqual(currentPlayIndex, 6)
+    }
+
+}

--- a/Projects/Features/CommonFeature/Tests/TargetTests.swift
+++ b/Projects/Features/CommonFeature/Tests/TargetTests.swift
@@ -4,8 +4,6 @@ import DomainModule
 import Combine
 
 class TargetTests: XCTestCase {
-    var playState = PlayState.shared
-    var playlist = PlayState.shared.playList
     var subscription = Set<AnyCancellable>()
     let givenList = [
         SongEntity(id: "", title: "제목1", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
@@ -31,7 +29,9 @@ class TargetTests: XCTestCase {
     
     func testAppendSong() {
         // given
-        playlist.list = givenList
+        var playState = PlayState(player: nil)
+        var playList = playState.playList
+        playList.list = givenList
         
         // when
         let testList = [
@@ -43,63 +43,69 @@ class TargetTests: XCTestCase {
         playState.loadAndAppendSongsToPlaylist(testList)
         
         // then 147 3256
-        let currentPlayIndex = playlist.currentPlayIndex ?? -1
+        let currentPlayIndex = playList.currentPlayIndex ?? -1
         XCTAssertEqual(currentPlayIndex, 3)
-        XCTAssertEqual(playlist.list[2].item.title, "제목7")
-        XCTAssertEqual(playlist.list[3].item.title, "제목3")
-        XCTAssertEqual(playlist.list[4].item.title, "제목2")
-        XCTAssertEqual(playlist.list[5].item.title, "제목5")
-        XCTAssertEqual(playlist.list[6].item.title, "제목6")
+        XCTAssertEqual(playList.list[2].item.title, "제목7")
+        XCTAssertEqual(playList.list[3].item.title, "제목3")
+        XCTAssertEqual(playList.list[4].item.title, "제목2")
+        XCTAssertEqual(playList.list[5].item.title, "제목5")
+        XCTAssertEqual(playList.list[6].item.title, "제목6")
     }
     
     func testRemoveSong() {
         // given
-        playlist.list = givenList
-        playlist.changeCurrentPlayIndex(to: 2)
-        
+        var playState = PlayState(player: nil)
+        var playList = playState.playList
+        playList.list = givenList
+        playList.changeCurrentPlayIndex(to: 2)
+
         // when
-        playlist.remove(indexs: [1, 2, 4, 5])
-        
+        playList.remove(indexs: [1, 2, 4, 5])
+
         // then
-        var currentPlayIndex = playlist.currentPlayIndex ?? -1
+        var currentPlayIndex = playList.currentPlayIndex ?? -1
         XCTAssertEqual(currentPlayIndex , 1)
-        XCTAssertEqual(playlist.count, 3)
-        XCTAssertEqual(playlist.list[0].item.title, "제목1")
-        XCTAssertEqual(playlist.list[1].item.title, "제목4")
-        
+        XCTAssertEqual(playList.count, 3)
+        XCTAssertEqual(playList.list[0].item.title, "제목1")
+        XCTAssertEqual(playList.list[1].item.title, "제목4")
+
         // given
-        playlist.list = givenList
-        playlist.changeCurrentPlayIndex(to: playlist.lastIndex)
-        
+        playList.list = givenList
+        playList.changeCurrentPlayIndex(to: playList.lastIndex)
+
         // when
-        playlist.remove(indexs: [4, 5, 6])
-        
+        playList.remove(indexs: [4, 5, 6])
+
         // then
-        currentPlayIndex = playlist.currentPlayIndex ?? -1
+        currentPlayIndex = playList.currentPlayIndex ?? -1
         XCTAssertEqual(currentPlayIndex , 0)
-        XCTAssertEqual(playlist.count, 4)
-        XCTAssertEqual(playlist.list[0].item.title, "제목1")
-        XCTAssertEqual(playlist.list[1].item.title, "제목2")
+        XCTAssertEqual(playList.count, 4)
+        XCTAssertEqual(playList.list[0].item.title, "제목1")
+        XCTAssertEqual(playList.list[1].item.title, "제목2")
     }
-    
+
     func testRorderSong() {
         // given
-        playlist.list = givenList
-        
+//        var playState = PlayState.shared
+//        var playList = PlayState.shared.playList
+        var playState = PlayState(player: nil)
+        var playList = playState.playList
+        playList.list = givenList
+
         // when
-        playlist.reorderPlaylist(from: 2, to: 1)
-        
+        playList.reorderPlaylist(from: 2, to: 1)
+
         // then
-        var currentPlayIndex = playlist.currentPlayIndex ?? -1
+        var currentPlayIndex = playList.currentPlayIndex ?? -1
         XCTAssertEqual(currentPlayIndex, 0)
-        
+
         // when
-        playlist.reorderPlaylist(from: 0, to: 6)
-        
+        playList.reorderPlaylist(from: 0, to: 6)
+
         // then
-        currentPlayIndex = playlist.currentPlayIndex ?? -1
+        currentPlayIndex = playList.currentPlayIndex ?? -1
         XCTAssertEqual(currentPlayIndex, 6)
-        
+
     }
 
 }

--- a/Projects/Features/CommonFeature/Tests/TargetTests.swift
+++ b/Projects/Features/CommonFeature/Tests/TargetTests.swift
@@ -1,10 +1,8 @@
 import XCTest
 import CommonFeature
 import DomainModule
-import Combine
 
 class TargetTests: XCTestCase {
-    var subscription = Set<AnyCancellable>()
     let givenList = [
         SongEntity(id: "", title: "제목1", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
         SongEntity(id: "", title: "제목2", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
@@ -32,7 +30,7 @@ class TargetTests: XCTestCase {
         var playState = PlayState(player: nil)
         var playList = playState.playList
         playList.list = givenList
-        
+
         // when
         let testList = [
             SongEntity(id: "", title: "제목3", artist: "", remix: "", reaction: "", views: 0, last: 0, date: ""),
@@ -41,7 +39,7 @@ class TargetTests: XCTestCase {
             SongEntity(id: "", title: "제목6", artist: "", remix: "", reaction: "", views: 0, last: 0, date: "")
         ]
         playState.loadAndAppendSongsToPlaylist(testList)
-        
+
         // then 147 3256
         let currentPlayIndex = playList.currentPlayIndex ?? -1
         XCTAssertEqual(currentPlayIndex, 3)
@@ -50,62 +48,6 @@ class TargetTests: XCTestCase {
         XCTAssertEqual(playList.list[4].item.title, "제목2")
         XCTAssertEqual(playList.list[5].item.title, "제목5")
         XCTAssertEqual(playList.list[6].item.title, "제목6")
-    }
-    
-    func testRemoveSong() {
-        // given
-        var playState = PlayState(player: nil)
-        var playList = playState.playList
-        playList.list = givenList
-        playList.changeCurrentPlayIndex(to: 2)
-
-        // when
-        playList.remove(indexs: [1, 2, 4, 5])
-
-        // then
-        var currentPlayIndex = playList.currentPlayIndex ?? -1
-        XCTAssertEqual(currentPlayIndex , 1)
-        XCTAssertEqual(playList.count, 3)
-        XCTAssertEqual(playList.list[0].item.title, "제목1")
-        XCTAssertEqual(playList.list[1].item.title, "제목4")
-
-        // given
-        playList.list = givenList
-        playList.changeCurrentPlayIndex(to: playList.lastIndex)
-
-        // when
-        playList.remove(indexs: [4, 5, 6])
-
-        // then
-        currentPlayIndex = playList.currentPlayIndex ?? -1
-        XCTAssertEqual(currentPlayIndex , 0)
-        XCTAssertEqual(playList.count, 4)
-        XCTAssertEqual(playList.list[0].item.title, "제목1")
-        XCTAssertEqual(playList.list[1].item.title, "제목2")
-    }
-
-    func testRorderSong() {
-        // given
-//        var playState = PlayState.shared
-//        var playList = PlayState.shared.playList
-        var playState = PlayState(player: nil)
-        var playList = playState.playList
-        playList.list = givenList
-
-        // when
-        playList.reorderPlaylist(from: 2, to: 1)
-
-        // then
-        var currentPlayIndex = playList.currentPlayIndex ?? -1
-        XCTAssertEqual(currentPlayIndex, 0)
-
-        // when
-        playList.reorderPlaylist(from: 0, to: 6)
-
-        // then
-        currentPlayIndex = playList.currentPlayIndex ?? -1
-        XCTAssertEqual(currentPlayIndex, 6)
-
     }
 
 }

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -27,7 +27,7 @@ public class PlayerViewController: UIViewController {
     var playerView: PlayerView!
     var miniPlayerView: MiniPlayerView!
     
-    lazy var youtubePlayerView = YouTubePlayerHostingView(player: playState.player).then {
+    lazy var youtubePlayerView = YouTubePlayerHostingView(player: playState.player ?? YouTubePlayer()).then {
         $0.isHidden = true
     }
     
@@ -100,7 +100,7 @@ private extension PlayerViewController {
     
     private func resetYouTubePlayerHostingView() {
         self.youtubePlayerView.removeFromSuperview()
-        self.youtubePlayerView = YouTubePlayerHostingView(player: self.playState.player)
+        self.youtubePlayerView = YouTubePlayerHostingView(player: self.playState.player ?? YouTubePlayer())
         self.youtubePlayerView.isHidden = true
         self.view.addSubview(self.youtubePlayerView)
         self.youtubePlayerView.snp.makeConstraints {
@@ -447,7 +447,7 @@ extension PlayerViewController: UITableViewDelegate, UITableViewDataSource, UISc
             findCenterCellIndexPath { centerCellIndexPath in
                 if viewModel.lyricsDict.isEmpty { return }
                 let start = viewModel.lyricsDict.keys.sorted()[centerCellIndexPath.row]
-                playState.player.seek(to: Double(start), allowSeekAhead: true)
+                playState.player?.seek(to: Double(start), allowSeekAhead: true)
                 viewModel.isLyricsScrolling = false
             }
         }
@@ -458,7 +458,7 @@ extension PlayerViewController: UITableViewDelegate, UITableViewDataSource, UISc
         findCenterCellIndexPath { centerCellIndexPath in
             if viewModel.lyricsDict.isEmpty { return }
             let start = viewModel.lyricsDict.keys.sorted()[centerCellIndexPath.row]
-            playState.player.seek(to: Double(start), allowSeekAhead: true)
+            playState.player?.seek(to: Double(start), allowSeekAhead: true)
             viewModel.isLyricsScrolling = false
         }
     }

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
@@ -167,7 +167,7 @@ final class PlayerViewModel: ViewModelType {
         
         input.sliderValueChangedEvent.subscribe { [weak self] value in
             guard let self else { return }
-            self.playState.player.seek(to: Double(value), allowSeekAhead: true)
+            self.playState.player?.seek(to: Double(value), allowSeekAhead: true)
         }.disposed(by: disposeBag)
         
         input.likeButtonDidTapEvent

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
@@ -346,7 +346,7 @@ final class PlayerViewModel: ViewModelType {
         
     }
     
-    private func handleProgress(progress: PlayState.PlayProgress, output: Output) {
+    private func handleProgress(progress: PlayProgress, output: Output) {
         output.playTimeText.send(self.formatTime(progress.currentProgress))
         output.totalTimeText.send(self.formatTime(progress.endProgress))
         output.playTimeValue.send(Float(progress.currentProgress))

--- a/Projects/Modules/Utility/Sources/Utils/Secrets.swift
+++ b/Projects/Modules/Utility/Sources/Utils/Secrets.swift
@@ -8,114 +8,70 @@
 
 import Foundation
 
-//MARK: - BASE_IMAGE_URL
-public func BASE_IMAGE_URL() -> String {
+public func config(key: String) -> String {
     guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
         return ""
     }
-    return secrets["BASE_IMAGE_URL"] as? String ?? "not found key"
+    return secrets[key] as? String ?? "not found key"
+}
+
+//MARK: - BASE_IMAGE_URL
+public func BASE_IMAGE_URL() -> String {
+    return config(key: "BASE_IMAGE_URL")
 }
 
 //MARK: - WMDomain > Image
 public func WMDOMAIN_IMAGE_NEWS() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_IMAGE_NEWS"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_IMAGE_NEWS")
 }
 public func WMDOMAIN_IMAGE_ARTIST_ROUND() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_IMAGE_ARTIST_ROUND"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_IMAGE_ARTIST_ROUND")
 }
 public func WMDOMAIN_IMAGE_ARTIST_SQUARE() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_IMAGE_ARTIST_SQUARE"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_IMAGE_ARTIST_SQUARE")
 }
 public func WMDOMAIN_IMAGE_PROFILE() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_IMAGE_PROFILE"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_IMAGE_PROFILE")
 }
 public func WMDOMAIN_IMAGE_PLAYLIST() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_IMAGE_PLAYLIST"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_IMAGE_PLAYLIST")
 }
 public func WMDOMAIN_IMAGE_RECOMMEND_PLAYLIST_SQUARE() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_IMAGE_RECOMMEND_PLAYLIST_SQUARE"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_IMAGE_RECOMMEND_PLAYLIST_SQUARE")
 }
 public func WMDOMAIN_IMAGE_RECOMMEND_PLAYLIST_ROUND() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_IMAGE_RECOMMEND_PLAYLIST_ROUND"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_IMAGE_RECOMMEND_PLAYLIST_ROUND")
 }
 public func WMDOMAIN_IMAGE_NOTICE() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_IMAGE_NOTICE"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_IMAGE_NOTICE")
 }
 
 //MARK: - NAVER
 public func NAVER_URL_SCHEME() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["NAVER_URL_SCHEME"] as? String ?? "not found key"
+    return config(key: "NAVER_URL_SCHEME")
 }
 public func NAVER_CONSUMER_KEY() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["NAVER_CONSUMER_KEY"] as? String ?? "not found key"
+    return config(key: "NAVER_CONSUMER_KEY")
 }
 public func NAVER_CONSUMER_SECRET() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["NAVER_CONSUMER_SECRET"] as? String ?? "not found key"
+    return config(key: "NAVER_CONSUMER_SECRET")
 }
 public func NAVER_APP_NAME() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["NAVER_APP_NAME"] as? String ?? "not found key"
+    return config(key: "NAVER_APP_NAME")
 }
 
 //MARK: - GOOGLE
 public func GOOGLE_URL_SCHEME() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["GOOGLE_URL_SCHEME"] as? String ?? "not found key"
+    return config(key: "GOOGLE_URL_SCHEME")
 }
 public func GOOGLE_CLIENT_ID() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["GOOGLE_CLIENT_ID"] as? String ?? "not found key"
+    return config(key: "GOOGLE_CLIENT_ID")
 }
 public func GOOGLE_SECRET_KEY() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["GOOGLE_SECRET_KEY"] as? String ?? "not found key"
+    return config(key: "GOOGLE_SECRET_KEY")
 }
 
 //WAKTAVERSEMUSIC
 public func WM_APP_ID() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WM_APP_ID"] as? String ?? ""
+    return config(key: "WM_APP_ID")
 }

--- a/Projects/Services/APIKit/Sources/Secrets/SecretURL.swift
+++ b/Projects/Services/APIKit/Sources/Secrets/SecretURL.swift
@@ -8,96 +8,61 @@
 
 import Foundation
 
-//MARK: - BASE_URL
-public func BASE_URL() -> String {
+public func config(key: String) -> String {
     guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
         return ""
     }
+    return secrets[key] as? String ?? "not found key"
+}
+
+//MARK: - BASE_URL
+public func BASE_URL() -> String {
     #if DEBUG
-    return secrets["BASE_DEV_URL"] as? String ?? "not found key"
+    return config(key: "BASE_DEV_URL")
     #else
-    return secrets["BASE_PROD_URL"] as? String ?? "not found key"
+    return config(key: "BASE_PROD_URL")
     #endif
 }
 
 //MARK: - WAKENTER_BASE_URL
 public func WAKENTER_BASE_URL() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WAKENTER_BASE_URL"] as? String ?? "not found key"
+    return config(key: "WAKENTER_BASE_URL")
 }
 
 //MARK: - WMDomain
 public func WMDOMAIN_AUTH() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_AUTH"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_AUTH")
 }
 public func WMDOMAIN_CHARTS() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_CHARTS"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_CHARTS")
 }
 public func WMDOMAIN_SONGS() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_SONGS"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_SONGS")
 }
 public func WMDOMAIN_ARTIST() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_ARTIST"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_ARTIST")
 }
 public func WMDOMAIN_USER() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_USER"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_USER")
 }
 public func WMDOMAIN_PLAYLIST() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_PLAYLIST"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_PLAYLIST")
 }
 public func WMDOMAIN_LIKE() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_LIKE"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_LIKE")
 }
 public func WMDOMAIN_QNA() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_QNA"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_QNA")
 }
 public func WMDOMAIN_NOTICE() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_NOTICE"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_NOTICE")
 }
 public func WMDOMAIN_SUGGEST() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_SUGGEST"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_SUGGEST")
 }
 public func WMDOMAIN_APP() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_APP"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_APP")
 }
 public func WMDOMAIN_PLAY() -> String {
-    guard let secrets = Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: Any] else {
-        return ""
-    }
-    return secrets["WMDOMAIN_PLAY"] as? String ?? "not found key"
+    return config(key: "WMDOMAIN_PLAY")
 }


### PR DESCRIPTION
## 개요
유지보수를 하며 플레이어 로직 관련 코드를 수정하는 경우가 생겼고, 수정한 코드가 이전 코드와 같게 동작할거란 보장이 없었습니다. 
이를 위해서 콘솔에 직접 찍어가며 디버깅 했으나 놓치는 부분이 생길 수 있기에 테스트코드를 통해 검증할 수 있도록 했습니다.

그러나 초기 PlayState를 설계할때 테스트를 고려하지 않았고, PlayState와 PlayList 간의 상호 의존성이 생겼습니다.
따라서 PlayState와 PlayList 간의 의존성을 분리하고 테스트 코드를 추가하기로 했습니다.

## 작업사항
PlayList에서 PlayState를 참조하던 메소드들을 퍼블리셔로 방출하도록 수정하고, PlayState에서 이를 구독하는 방식으로 PlayList에서 PlayState를 참조하지 않도록 변경했습니다.

예시
``` Swift
private func remove(at index: Int) {
  // PlayList에서 PlayState 싱글톤에 직접 접근 (테스트 어려움)
  PlayState.shared.currentSong = list[safe: currentPlayIndex]?.item
  PlayState.shared.loadInPlaylist(at: currentPlayIndex)
}
```

``` Swift
public var currentPlaySongChanged = PassthroughSubject<SongEntity, Never>()
// PlayList에서 변경사항 방출
private func remove(at index: Int) {
   currentPlaySongChanged.send(song)
}

// PlayState에서 변경사항을 구독
playList.currentPlaySongChanged.sink { song in
  loadInPlaylist(at: index)
}
```

<br>
조회수 이슈가 급한 것 같아 테스트 코드는 후추수정으로..