### PR TITLE
🔀 :: 미니 플레이어 UI 변경 및 재생목록에 곡 수 표기

### DIFF
--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -115,18 +115,25 @@ private extension PlayerViewController {
         let input = PlayerViewModel.Input(
             viewWillAppearEvent: self.rx.methodInvoked(#selector(UIViewController.viewWillAppear)).map {_ in },
             closeButtonDidTapEvent: self.playerView.closeButton.tapPublisher(),
-            playButtonDidTapEvent: self.playerView.playButton.tapPublisher(),
+            playButtonDidTapEvent: Publishers.Merge(
+                self.playerView.playButton.tapPublisher(),
+                self.miniPlayerView.playButton.tapPublisher()
+            ).eraseToAnyPublisher(),
             prevButtonDidTapEvent: self.playerView.prevButton.rx.tap.asObservable(),
-            nextButtonDidTapEvent: self.playerView.nextButton.rx.tap.asObservable(),
+            nextButtonDidTapEvent: Observable.merge(
+                self.playerView.nextButton.rx.tap.asObservable(),
+                self.miniPlayerView.nextButton.rx.tap.asObservable()
+            ),
             sliderValueChangedEvent: self.playerView.playTimeSlider.rx.value.changed.asObservable(),
             repeatButtonDidTapEvent: self.playerView.repeatButton.tapPublisher(),
             shuffleButtonDidTapEvent: self.playerView.shuffleButton.tapPublisher(),
             likeButtonDidTapEvent: self.playerView.likeButton.tapPublisher(),
             addPlaylistButtonDidTapEvent: self.playerView.addPlayistButton.tapPublisher(),
-            playlistButtonDidTapEvent: self.playerView.playistButton.tapPublisher(),
-            miniExtendButtonDidTapEvent: self.miniPlayerView.extendButton.tapPublisher(),
-            miniPlayButtonDidTapEvent: self.miniPlayerView.playButton.tapPublisher(),
-            miniCloseButtonDidTapEvent: self.miniPlayerView.closeButton.tapPublisher()
+            playlistButtonDidTapEvent: Publishers.Merge(
+                self.playerView.playistButton.tapPublisher(),
+                self.miniPlayerView.playlistButton.tapPublisher()
+            ).eraseToAnyPublisher(),
+            miniExtendButtonDidTapEvent: self.miniPlayerView.extendButton.tapPublisher()
         )
         let output = self.viewModel.transform(from: input)
         
@@ -210,11 +217,6 @@ private extension PlayerViewController {
                 }
             )
             self.playerView.backgroundImageView.kf.setImage(
-                with: sdURL,
-                placeholder: placeholderImage,
-                options: transitionOptions
-            )
-            self.miniPlayerView.thumbnailImageView.kf.setImage(
                 with: sdURL,
                 placeholder: placeholderImage,
                 options: transitionOptions

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -129,6 +129,7 @@ private extension PlaylistViewController {
     
     private func bindViewModel() {
         let input = PlaylistViewModel.Input(
+            viewWillAppearEvent: self.rx.methodInvoked(#selector(UIViewController.viewWillAppear)).map { _ in },
             closeButtonDidTapEvent: playlistView.closeButton.tapPublisher,
             editButtonDidTapEvent: playlistView.editButton.tapPublisher,
             repeatButtonDidTapEvent: playlistView.repeatButton.tapPublisher,
@@ -160,7 +161,6 @@ private extension PlaylistViewController {
     private func bindCountOfSongs(output: PlaylistViewModel.Output) {
         output.countOfSongs.sink { [weak self] count in
             guard let self else { return }
-            print("🚀 카운트:", count)
             self.playlistView.titleLabel.text = count == 0 ? "재생목록" : "재생목록 " + String(count)
         }.store(in: &subscription)
     }
@@ -197,7 +197,8 @@ private extension PlaylistViewController {
 
         output.editState.sink { [weak self] isEditing in
             guard let self else { return }
-            self.playlistView.titleLabel.text = isEditing ? "재생목록 편집" : "재생목록"
+            let count = self.playState.playList.count
+            self.playlistView.titleLabel.text = isEditing ? "재생목록 편집" : "재생목록 " + String(count)
             self.playlistView.editButton.setTitle(isEditing ? "완료" : "편집", for: .normal)
             self.playlistView.editButton.setColor(isHighlight: isEditing)
             self.playlistView.playlistTableView.setEditing(isEditing, animated: true)

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -129,7 +129,6 @@ private extension PlaylistViewController {
     
     private func bindViewModel() {
         let input = PlaylistViewModel.Input(
-            viewWillAppearEvent: self.rx.methodInvoked(#selector(UIViewController.viewWillAppear)).map {_ in },
             closeButtonDidTapEvent: playlistView.closeButton.tapPublisher,
             editButtonDidTapEvent: playlistView.editButton.tapPublisher,
             repeatButtonDidTapEvent: playlistView.repeatButton.tapPublisher,
@@ -161,6 +160,7 @@ private extension PlaylistViewController {
     private func bindCountOfSongs(output: PlaylistViewModel.Output) {
         output.countOfSongs.sink { [weak self] count in
             guard let self else { return }
+            print("🚀 카운트:", count)
             self.playlistView.titleLabel.text = count == 0 ? "재생목록" : "재생목록 " + String(count)
         }.store(in: &subscription)
     }

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -129,6 +129,7 @@ private extension PlaylistViewController {
     
     private func bindViewModel() {
         let input = PlaylistViewModel.Input(
+            viewWillAppearEvent: self.rx.methodInvoked(#selector(UIViewController.viewWillAppear)).map {_ in },
             closeButtonDidTapEvent: playlistView.closeButton.tapPublisher,
             editButtonDidTapEvent: playlistView.editButton.tapPublisher,
             repeatButtonDidTapEvent: playlistView.repeatButton.tapPublisher,
@@ -145,6 +146,7 @@ private extension PlaylistViewController {
         )
         let output = self.viewModel.transform(from: input)
         
+        bindCountOfSongs(output: output)
         bindPlaylistTableView(output: output)
         bindSongCart(output: output)
         bindCloseButton(output: output)
@@ -154,6 +156,13 @@ private extension PlaylistViewController {
         bindShuffleMode(output: output)
         bindPlayButtonImages(output: output)
         bindwaveStreamAnimationView(output: output)
+    }
+    
+    private func bindCountOfSongs(output: PlaylistViewModel.Output) {
+        output.countOfSongs.sink { [weak self] count in
+            guard let self else { return }
+            self.playlistView.titleLabel.text = count == 0 ? "재생목록" : "재생목록 " + String(count)
+        }.store(in: &subscription)
     }
     
     private func bindPlaylistTableView(output: PlaylistViewModel.Output) {

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlayerViewModel.swift
@@ -30,8 +30,6 @@ final class PlayerViewModel: ViewModelType {
         let addPlaylistButtonDidTapEvent: AnyPublisher<Void, Never>
         let playlistButtonDidTapEvent: AnyPublisher<Void, Never>
         let miniExtendButtonDidTapEvent: AnyPublisher<Void, Never>
-        let miniPlayButtonDidTapEvent: AnyPublisher<Void, Never>
-        let miniCloseButtonDidTapEvent: AnyPublisher<Void, Never>
     }
     struct Output {
         var playerState = CurrentValueSubject<YouTubePlayer.PlaybackState, Never>(.unstarted)
@@ -112,7 +110,7 @@ final class PlayerViewModel: ViewModelType {
     }
     
     private func bindInput(input: Input, output: Output) {
-        input.playButtonDidTapEvent.merge(with: input.miniPlayButtonDidTapEvent).sink { [weak self] _ in
+        input.playButtonDidTapEvent.sink { [weak self] _ in
             guard let self else { return }
             let state = self.playState.state
             if state == .playing {
@@ -130,10 +128,6 @@ final class PlayerViewModel: ViewModelType {
             self?.playState.switchPlayerMode(to: .full)
         }.store(in: &subscription)
         
-        input.miniCloseButtonDidTapEvent.sink { [weak self] _ in
-            self?.playState.switchPlayerMode(to: .close)
-            self?.playState.stop()
-        }.store(in: &subscription)
         
         input.repeatButtonDidTapEvent.sink { [weak self] _ in
             guard let self else { return }

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
@@ -21,6 +21,7 @@ internal typealias PlayListSectionModel = SectionModel<Int, PlayListItem>
 
 final class PlaylistViewModel: ViewModelType {
     struct Input {
+        let viewWillAppearEvent: Observable<Void>
         let closeButtonDidTapEvent: AnyPublisher<Void, Never>
         let editButtonDidTapEvent: AnyPublisher<Void, Never>
         let repeatButtonDidTapEvent: AnyPublisher<Void, Never>
@@ -48,6 +49,7 @@ final class PlaylistViewModel: ViewModelType {
         var shuffleMode = CurrentValueSubject<ShuffleMode, Never>(.off)
         let dataSource: BehaviorRelay<[PlayListSectionModel]> = BehaviorRelay(value: [])
         let indexOfSelectedSongs: BehaviorRelay<[Int]> = BehaviorRelay(value: [])
+        let countOfSongs = CurrentValueSubject<Int, Never>(0)
     }
     
     private let playState = PlayState.shared
@@ -85,6 +87,12 @@ final class PlaylistViewModel: ViewModelType {
     }
     
     private func bindInput(input: Input, output: Output) {
+        input.viewWillAppearEvent.subscribe { [weak self] _ in
+            guard let self else { return }
+            let playlistCount = self.playState.playList.count
+            output.countOfSongs.send(playlistCount)
+        }.disposed(by: disposeBag)
+        
         input.closeButtonDidTapEvent.sink { _ in
             output.willClosePlaylist.send()
         }.store(in: &subscription)

--- a/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewModels/PlaylistViewModel.swift
@@ -21,7 +21,6 @@ internal typealias PlayListSectionModel = SectionModel<Int, PlayListItem>
 
 final class PlaylistViewModel: ViewModelType {
     struct Input {
-        let viewWillAppearEvent: Observable<Void>
         let closeButtonDidTapEvent: AnyPublisher<Void, Never>
         let editButtonDidTapEvent: AnyPublisher<Void, Never>
         let repeatButtonDidTapEvent: AnyPublisher<Void, Never>
@@ -76,6 +75,7 @@ final class PlaylistViewModel: ViewModelType {
         bindProgress(output: output)
         bindRepeatMode(output: output)
         bindShuffleMode(output: output)
+        bindCountOfSongs(output: output)
         
         output.indexOfSelectedSongs
             .map { $0.count }
@@ -87,12 +87,6 @@ final class PlaylistViewModel: ViewModelType {
     }
     
     private func bindInput(input: Input, output: Output) {
-        input.viewWillAppearEvent.subscribe { [weak self] _ in
-            guard let self else { return }
-            let playlistCount = self.playState.playList.count
-            output.countOfSongs.send(playlistCount)
-        }.disposed(by: disposeBag)
-        
         input.closeButtonDidTapEvent.sink { _ in
             output.willClosePlaylist.send()
         }.store(in: &subscription)
@@ -306,6 +300,14 @@ final class PlaylistViewModel: ViewModelType {
     private func bindShuffleMode(output: Output) {
         playState.$shuffleMode.sink { shuffleMode in
             output.shuffleMode.send(shuffleMode)
+        }.store(in: &subscription)
+    }
+    
+    private func bindCountOfSongs(output: Output) {
+        playState.playList.listChanged.sink { [weak self] _ in
+            guard let self else { return }
+            let count = self.playState.playList.count
+            output.countOfSongs.send(count)
         }.store(in: &subscription)
     }
     

--- a/Projects/Features/PlayerFeature/Sources/Views/MiniPlayerView.swift
+++ b/Projects/Features/PlayerFeature/Sources/Views/MiniPlayerView.swift
@@ -34,13 +34,6 @@ final class MiniPlayerView: UIView {
         $0.backgroundColor = DesignSystemAsset.PrimaryColor.point.color
     }
     
-    internal lazy var thumbnailImageView = UIImageView().then {
-        $0.image = DesignSystemAsset.Player.dummyThumbnailSmall.image
-        $0.contentMode = .scaleAspectFill
-        $0.layer.cornerRadius = 4
-        $0.clipsToBounds = true
-    }
-    
     internal lazy var titleArtistLabelView: UIView = UIView()
     
     internal lazy var titleLabel = MarqueeLabel().then {
@@ -76,9 +69,18 @@ final class MiniPlayerView: UIView {
         $0.tintColor = .systemGray
     }
     
+    internal lazy var nextButton = UIButton().then {
+        $0.setImage(DesignSystemAsset.Player.nextOn.image, for: .normal)
+        $0.tintColor = .systemGray
+    }
+    
     internal lazy var closeButton = UIButton().then {
         $0.setImage(DesignSystemAsset.Player.miniClose.image, for: .normal)
         $0.tintColor = .systemGray
+    }
+    
+    internal lazy var playlistButton = UIButton().then {
+        $0.setImage(DesignSystemAsset.Player.playList.image, for: .normal)
     }
     
     override init(frame: CGRect) {
@@ -99,12 +101,12 @@ private extension MiniPlayerView {
         self.configureBlur()
         self.configureContent()
         self.configurePlayTime()
-        self.configureThumbnail()
         self.configureTitleArtist()
         self.configureTitleLabel()
         self.configureArtistLabel()
         self.configurePlayButton()
-        self.configureCloseButton()
+        self.configureNextButton()
+        self.configurePlaylistButton()
     }
     
     private func configureSubViews() {
@@ -112,13 +114,13 @@ private extension MiniPlayerView {
         self.addSubview(contentView)
         self.contentView.addSubview(totalPlayTimeView)
         self.totalPlayTimeView.addSubview(currentPlayTimeView)
-        self.contentView.addSubview(thumbnailImageView)
         self.contentView.addSubview(titleArtistLabelView)
         self.titleArtistLabelView.addSubview(titleLabel)
         self.titleArtistLabelView.addSubview(artistLabel)
         self.contentView.addSubview(extendButton)
         self.contentView.addSubview(playButton)
-        self.contentView.addSubview(closeButton)
+        self.contentView.addSubview(nextButton)
+        self.contentView.addSubview(playlistButton)
     }
     
     private func configureBlur() {
@@ -149,22 +151,11 @@ private extension MiniPlayerView {
         }
     }
     
-    private func configureThumbnail() {
-        let height = 40
-        let width = height * 16 / 9
-        thumbnailImageView.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.left.equalToSuperview().offset(20)
-            $0.width.equalTo(width)
-            $0.height.equalTo(height)
-        }
-    }
-    
     private func configureTitleArtist() {
         titleArtistLabelView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(7)
             $0.bottom.equalToSuperview().offset(-7)
-            $0.left.equalTo(thumbnailImageView.snp.right).offset(8)
+            $0.left.equalToSuperview().offset(20)
             $0.right.equalTo(playButton.snp.left).offset(-12)
         }
     }
@@ -183,13 +174,21 @@ private extension MiniPlayerView {
     private func configurePlayButton() {
         playButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.right.equalTo(closeButton.snp.left).offset(-20)
+            $0.right.equalTo(nextButton.snp.left).offset(-20)
             $0.width.height.equalTo(32)
         }
     }
     
-    private func configureCloseButton() {
-        closeButton.snp.makeConstraints {
+    private func configureNextButton() {
+        nextButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.right.equalTo(playlistButton.snp.left).offset(-20)
+            $0.width.height.equalTo(32)
+        }
+    }
+    
+    private func configurePlaylistButton() {
+        playlistButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.right.equalToSuperview().offset(-16)
             $0.width.height.equalTo(32)


### PR DESCRIPTION
## 개요

## 작업사항
- **미니플레이어 UI 변경**
  - 썸네일 삭제 ❌
  - 닫기버튼 삭제 ❌
  - 다음버튼 추가 ✅
  - 재생목록 바로가기 버튼 추가 ✅
- **재생목록에 곡 수 표기**

<img width="885" alt="image" src="https://github.com/wakmusic/wakmusic-iOS/assets/60254939/c2ab021a-0303-470a-be3d-357456de9eda">
