### PR TITLE
🔀 :: (#424) 모듈 생성 스크립트 최신 코드 동기화

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ reset:
 	rm -rf *.xcworkspace
 
 feature:
+	echo "\033[0;31m이 명령어는 deprecated 되었습니다. 'make module'을 사용해주세요! \033[0m"
 	python3 Scripts/generate_new_feature.py
 
 pg:

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,6 @@ feature:
 
 pg:
 	swift Scripts/GeneratePlugin.swift
+
+module:
+	swift Scripts/GenerateModule.swift

--- a/Scripts/GenerateModule.swift
+++ b/Scripts/GenerateModule.swift
@@ -1,0 +1,250 @@
+#!/usr/bin/swift
+import Foundation
+
+func handleSIGINT(_ signal: Int32) {
+    exit(0)
+}
+
+signal(SIGINT, handleSIGINT)
+
+enum LayerType: String {
+    case feature = "Feature"
+    case service = "Service"
+    case module = "Module"
+    case userInterface = "UserInterface"
+}
+
+enum MicroTargetType: String {
+    case interface = "Interface"
+    case sources = ""
+    case testing = "Testing"
+    case unitTest = "Tests"
+    case uiTest = "UITests"
+    case demo = "Demo"
+}
+
+let fileManager = FileManager.default
+let currentPath = "./"
+let bash = Bash()
+
+func registerModuleDependency() {
+    registerModulePaths()
+    makeProjectDirectory()
+
+    let layerPrefix = layer.rawValue.lowercased()
+    let moduleEnum = ".\(layerPrefix)(.\(moduleName))"
+    var targetString = "[\n"
+    if hasInterface {
+        makeScaffold(target: .interface)
+        targetString += "\(tab(2)).interface(module: \(moduleEnum)),\n"
+    }
+    targetString += "\(tab(2)).implements(module: \(moduleEnum)"
+    if hasInterface {
+        targetString += ", dependencies: [\n\(tab(3)).\(layerPrefix)(target: .\(moduleName), type: .interface)\n\(tab(2))])"
+    } else {
+        targetString += ")"
+    }
+    if hasTesting {
+        makeScaffold(target: .testing)
+        let interfaceDependency = ".\(layerPrefix)(target: .\(moduleName), type: .interface)"
+        targetString += ",\n\(tab(2)).testing(module: \(moduleEnum), dependencies: [\n\(tab(3))\(interfaceDependency)\n\(tab(2))])"
+    }
+    if hasUnitTests {
+        makeScaffold(target: .unitTest)
+        targetString += ",\n\(tab(2)).tests(module: \(moduleEnum), dependencies: [\n\(tab(3)).\(layerPrefix)(target: .\(moduleName))\n\(tab(2))])"
+    }
+    if hasUITests {
+        makeScaffold(target: .uiTest)
+        // TODO: - ui test 타겟 설정 로직 추가
+    }
+    if hasDemo {
+        makeScaffold(target: .demo)
+        targetString += ",\n\(tab(2)).demo(module: \(moduleEnum), dependencies: [\n\(tab(3)).\(layerPrefix)(target: .\(moduleName))\n\(tab(2))])"
+    }
+    targetString += "\n\(tab(1))]"
+    makeProjectSwift(targetString: targetString)
+    makeSourceScaffold()
+}
+
+func tab(_ count: Int) -> String {
+    var tabString = ""
+    for _ in 0..<count {
+        tabString += "    "
+    }
+    return tabString
+}
+
+func registerModulePaths() {
+    updateFileContent(
+        filePath: currentPath + "Plugin/DependencyPlugin/ProjectDescriptionHelpers/ModulePaths.swift",
+        finding: "enum \(layer.rawValue): String, MicroTargetPathConvertable {\n",
+        inserting: "        case \(moduleName)\n"
+    )
+    print("Register \(moduleName) to ModulePaths.swift")
+}
+
+func makeDirectory(path: String) {
+    do {
+        try fileManager.createDirectory(atPath: path, withIntermediateDirectories: false, attributes: nil)
+    } catch {
+        fatalError("❌ failed to create directory: \(path)")
+    }
+}
+
+func makeDirectories(_ paths: [String]) {
+    paths.forEach(makeDirectory(path:))
+}
+
+func makeProjectSwift(targetString: String) {
+    let projectSwift = """
+import DependencyPlugin
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.module(
+    name: ModulePaths.\(layer.rawValue).\(moduleName).rawValue,
+    targets: \(targetString)
+)
+
+"""
+    writeContentInFile(
+        path: currentPath + "Projects/\(layer.rawValue)s/\(moduleName)/Project.swift",
+        content: projectSwift
+    )
+    #warning("TODO: Layer 이름(디렉토리 이름)과 ModulePaths 이름이 다르기에 경로에 Layer를 사용하는 부분들은 Projects/{이름}s 로 뒤에 s를 붙임")
+}
+
+func makeProjectDirectory() {
+    makeDirectory(path: currentPath + "Projects/\(layer.rawValue)s/\(moduleName)")
+}
+
+func makeSourceScaffold() {
+    _ = try? bash.run(
+        commandName: "tuist",
+        arguments: ["scaffold", "Sources", "--name", "\(moduleName)", "--layer", "\(layer.rawValue)s"]
+    )
+}
+
+func makeScaffold(target: MicroTargetType) {
+    _ = try? bash.run(
+        commandName: "tuist",
+        arguments: ["scaffold", "\(target.rawValue)", "--name", "\(moduleName)", "--layer", "\(layer.rawValue)s"]
+    )
+}
+
+func writeContentInFile(path: String, content: String) {
+    let fileURL = URL(fileURLWithPath: path)
+    let data = Data(content.utf8)
+    try? data.write(to: fileURL)
+}
+
+func updateFileContent(
+    filePath: String,
+    finding findingString: String,
+    inserting insertString: String
+) {
+    let fileURL = URL(fileURLWithPath: filePath)
+    guard let readHandle = try? FileHandle(forReadingFrom: fileURL) else {
+        fatalError("❌ Failed to find \(filePath)")
+    }
+    guard let readData = try? readHandle.readToEnd() else {
+        fatalError("❌ Failed to find \(filePath)")
+    }
+    try? readHandle.close()
+
+    guard var fileString = String(data: readData, encoding: .utf8) else { fatalError() }
+    fileString.insert(contentsOf: insertString, at: fileString.range(of: findingString)?.upperBound ?? fileString.endIndex)
+
+    guard let writeHandle = try? FileHandle(forWritingTo: fileURL) else {
+        fatalError("❌ Failed to find \(filePath)")
+    }
+    writeHandle.seek(toFileOffset: 0)
+    try? writeHandle.write(contentsOf: Data(fileString.utf8))
+    try? writeHandle.close()
+}
+
+// MARK: - Starting point
+
+print("Enter layer name\n(Feature | Service | Module | UserInterface)", terminator: " : ")
+let layerInput = readLine()
+guard
+    let layerInput,
+    !layerInput.isEmpty,
+    let layerUnwrapping = LayerType(rawValue: layerInput)
+else {
+    print("Layer is empty or invalid")
+    exit(1)
+}
+let layer = layerUnwrapping
+print("Layer: \(layer.rawValue)\n")
+
+print("Enter module name", terminator: " : ")
+let moduleInput = readLine()
+guard let moduleNameUnwrapping = moduleInput, !moduleNameUnwrapping.isEmpty else {
+    print("Module name is empty")
+    exit(1)
+}
+var moduleName = moduleNameUnwrapping
+print("Module name: \(moduleName)\n")
+
+print("This module has a 'Interface' Target? (y\\n, default = n)", terminator: " : ")
+let hasInterface = readLine()?.lowercased() == "y"
+
+print("This module has a 'Testing' Target? (y\\n, default = n)", terminator: " : ")
+let hasTesting = readLine()?.lowercased() == "y"
+
+print("This module has a 'UnitTests' Target? (y\\n, default = n)", terminator: " : ")
+let hasUnitTests = readLine()?.lowercased() == "y"
+
+print("This module has a 'UITests' Target? (y\\n, default = n)", terminator: " : ")
+let hasUITests = readLine()?.lowercased() == "y"
+
+print("This module has a 'Demo' Target? (y\\n, default = n)", terminator: " : ")
+let hasDemo = readLine()?.lowercased() == "y"
+
+print("")
+
+registerModuleDependency()
+
+print("")
+print("------------------------------------------------------------------------------------------------------------------------")
+print("Layer: \(layer.rawValue)")
+print("Module name: \(moduleName)")
+print("interface: \(hasInterface), testing: \(hasTesting), unitTests: \(hasUnitTests), uiTests: \(hasUITests), demo: \(hasDemo)")
+print("------------------------------------------------------------------------------------------------------------------------")
+print("✅ Module is created successfully!")
+
+// MARK: - Bash
+protocol CommandExecuting {
+    func run(commandName: String, arguments: [String]) throws -> String
+}
+
+enum BashError: Error {
+    case commandNotFound(name: String)
+}
+
+struct Bash: CommandExecuting {
+    func run(commandName: String, arguments: [String] = []) throws -> String {
+        return try run(resolve(commandName), with: arguments)
+    }
+
+    private func resolve(_ command: String) throws -> String {
+        guard var bashCommand = try? run("/bin/bash", with: ["-l", "-c", "which \(command)"]) else {
+            throw BashError.commandNotFound(name: command)
+        }
+        bashCommand = bashCommand.trimmingCharacters(in: NSCharacterSet.whitespacesAndNewlines)
+        return bashCommand
+    }
+
+    private func run(_ command: String, with arguments: [String] = []) throws -> String {
+        let process = Process()
+        process.launchPath = command
+        process.arguments = arguments
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.launch()
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: outputData, as: UTF8.self)
+        return output
+    }
+}

--- a/Scripts/GenerateModule.swift
+++ b/Scripts/GenerateModule.swift
@@ -167,41 +167,41 @@ func updateFileContent(
 
 // MARK: - Starting point
 
-print("Enter layer name\n(Feature | Domain | Service | Module | UserInterface)", terminator: " : ")
+print("레이어 이름을 입력해주세요!\n(Feature | Domain | Service | Module | UserInterface)", terminator: " : ")
 let layerInput = readLine()
 guard
     let layerInput,
     !layerInput.isEmpty,
     let layerUnwrapping = LayerType(rawValue: layerInput)
 else {
-    print("Layer is empty or invalid")
+    print("입력이 비었거나 잘못되었어요!")
     exit(1)
 }
 let layer = layerUnwrapping
 print("Layer: \(layer.rawValue)\n")
 
-print("Enter module name", terminator: " : ")
+print("모듈 이름을 입력해주세요!", terminator: " : ")
 let moduleInput = readLine()
 guard let moduleNameUnwrapping = moduleInput, !moduleNameUnwrapping.isEmpty else {
-    print("Module name is empty")
+    print("모듈 이름이 비었어요!")
     exit(1)
 }
 var moduleName = moduleNameUnwrapping
-print("Module name: \(moduleName)\n")
+print("모듈 이름: \(moduleName)\n")
 
-print("This module has a 'Interface' Target? (y\\n, default = n)", terminator: " : ")
+print("'Interface' Target을 포함하나요? (y\\n, default = n)", terminator: " : ")
 let hasInterface = readLine()?.lowercased() == "y"
 
-print("This module has a 'Testing' Target? (y\\n, default = n)", terminator: " : ")
+print("'Testing' Target을 포함하나요? (y\\n, default = n)", terminator: " : ")
 let hasTesting = readLine()?.lowercased() == "y"
 
-print("This module has a 'UnitTests' Target? (y\\n, default = n)", terminator: " : ")
+print("'UnitTests' Target을 포함하나요? (y\\n, default = n)", terminator: " : ")
 let hasUnitTests = readLine()?.lowercased() == "y"
 
-print("This module has a 'UITests' Target? (y\\n, default = n)", terminator: " : ")
+print("'UITests' Target을 포함하나요? (y\\n, default = n)", terminator: " : ")
 let hasUITests = readLine()?.lowercased() == "y"
 
-print("This module has a 'Demo' Target? (y\\n, default = n)", terminator: " : ")
+print("'Demo' Target을 포함하나요? (y\\n, default = n)", terminator: " : ")
 let hasDemo = readLine()?.lowercased() == "y"
 
 print("")
@@ -210,11 +210,11 @@ registerModuleDependency()
 
 print("")
 print("------------------------------------------------------------------------------------------------------------------------")
-print("Layer: \(layer.rawValue)")
-print("Module name: \(moduleName)")
+print("레이어: \(layer.rawValue)")
+print("모듈 이름: \(moduleName)")
 print("interface: \(hasInterface), testing: \(hasTesting), unitTests: \(hasUnitTests), uiTests: \(hasUITests), demo: \(hasDemo)")
 print("------------------------------------------------------------------------------------------------------------------------")
-print("✅ Module is created successfully!")
+print("✅ 모듈을 성공적으로 생성했어요!")
 
 // MARK: - Bash
 protocol CommandExecuting {

--- a/Scripts/GenerateModule.swift
+++ b/Scripts/GenerateModule.swift
@@ -9,6 +9,8 @@ signal(SIGINT, handleSIGINT)
 
 enum LayerType: String {
     case feature = "Feature"
+    case domain = "Domain"
+    @available(*, deprecated, message: "Service 레이어는 미래에 지워집니다. Service 레이어의 내용은 Domain 레이어로 이전될 예정입니다.")
     case service = "Service"
     case module = "Module"
     case userInterface = "UserInterface"
@@ -165,7 +167,7 @@ func updateFileContent(
 
 // MARK: - Starting point
 
-print("Enter layer name\n(Feature | Service | Module | UserInterface)", terminator: " : ")
+print("Enter layer name\n(Feature | Domain | Service | Module | UserInterface)", terminator: " : ")
 let layerInput = readLine()
 guard
     let layerInput,


### PR DESCRIPTION
## 💡 배경 및 개요

https://github.com/wakmusic/wakmusic-iOS/issues/419
해당 작업을 진행하며 Project를 정의하는 슈가 메서드가 기존의 메서드는 deprecated되고 새로운 메서드를 사용하도록 변경되었어요.
새롭게 사용하는 메서드를 기준으로 Project.swift를 정의하여 모듈을 만들 수 있는 스크립트를 만들어요.
더해서 기존의 feature 생성 스크립트는 feature 레이어에만 한정하여 사용할 수 있지만, 다른 레이어에서도 추가로 만들 수 있도록 기능을 확장했어요.

Resolves: #424

## 📃 작업내용

- 모듈 생성 스크립트 작성 (Swift)
  - 모듈 레이어 입력
  - 모듈 이름 입력
  - 모듈이 가진 Target 입력 (Interface, Source{Implementation}, Testing, UnitTests, UITests, Demo)
  - 위 입력을 한 후 새로운 모듈을 만들어요
    - ModulePaths에 새 모듈 case 추가
    - 실제 경로에 해당하는 곳에 모듈 기본 파일 및 Project.swift 정의
- `make feature` 명령어 deprecate
- `make module` 명령어 지원

## 🙋‍♂️ 리뷰노트

새 모듈을 추가할 때, 입력을 하라는 문구를 한국어로 할까요? 굳이 영어로 할 필요성을 못느껴서 어떻게 생각하시는지 궁금해요 :)

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
- [x] 모듈 생성 스크립트 가이드 문서 작성 - [문서](https://www.notion.so/waktaverse/311a3e082f034962b8840677b9e4c417?pvs=4)
