### PR TITLE
🔀 :: (#425) Domain 레이어 & BaseDomain 추가

### DIFF
--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/ModulePaths.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/ModulePaths.swift
@@ -12,6 +12,7 @@ public enum ModulePaths {
     case service(Service)
     case module(Module)
     case userInterface(UserInterface)
+    case domain(Domain)
 }
 
 extension ModulePaths: MicroTargetPathConvertable {
@@ -20,7 +21,8 @@ extension ModulePaths: MicroTargetPathConvertable {
         case let .feature(module as any MicroTargetPathConvertable),
             let .module(module as any MicroTargetPathConvertable),
             let .service(module as any MicroTargetPathConvertable),
-            let .userInterface(module as any MicroTargetPathConvertable):
+            let .userInterface(module as any MicroTargetPathConvertable),
+            let .domain(module as any MicroTargetPathConvertable):
             return module.targetName(type: type)
         }
     }
@@ -39,6 +41,13 @@ public extension ModulePaths {
         case SearchFeature
         case SignInFeature
         case StorageFeature
+    }
+}
+
+public extension ModulePaths {
+    enum Domain: String, MicroTargetPathConvertable {
+        case BaseDomain
+        case AppDomain
     }
 }
 

--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/PathExtension.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/PathExtension.swift
@@ -16,6 +16,9 @@ public extension ProjectDescription.Path {
     static func relativeToUserInterfaces(_ path: String) -> Self {
         return .relativeToRoot("Projects/UsertInterfaces/\(path)")
     }
+    static func relativeToDomain(_ path: String) -> Self {
+        return .relativeToRoot("Projects/Domains/\(path)")
+    }
     static var app: Self {
         return .relativeToRoot("Projects/App")
     }

--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/TargetDependency+MicroFeatureTarget.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/TargetDependency+MicroFeatureTarget.swift
@@ -10,42 +10,52 @@ import ProjectDescription
 
 public extension TargetDependency {
     static func feature(
-            target: ModulePaths.Feature,
-            type: MicroTargetType = .sources
-        ) -> TargetDependency {
-            .project(
-                target: target.targetName(type: type),
-                path: .relativeToFeature(target.rawValue)
-            )
-        }
+        target: ModulePaths.Feature,
+        type: MicroTargetType = .sources
+    ) -> TargetDependency {
+        .project(
+            target: target.targetName(type: type),
+            path: .relativeToFeature(target.rawValue)
+        )
+    }
 
-        static func service(
-            target: ModulePaths.Service,
-            type: MicroTargetType = .sources
-        ) -> TargetDependency {
-            .project(
-                target: target.targetName(type: type),
-                path: .relativeToService(target.rawValue)
-            )
-        }
+    static func service(
+        target: ModulePaths.Service,
+        type: MicroTargetType = .sources
+    ) -> TargetDependency {
+        .project(
+            target: target.targetName(type: type),
+            path: .relativeToService(target.rawValue)
+        )
+    }
 
-        static func module(
-            target: ModulePaths.Module,
-            type: MicroTargetType = .sources
-        ) -> TargetDependency {
-            .project(
-                target: target.targetName(type: type),
-                path: .relativeToModule(target.rawValue)
-            )
-        }
+    static func module(
+        target: ModulePaths.Module,
+        type: MicroTargetType = .sources
+    ) -> TargetDependency {
+        .project(
+            target: target.targetName(type: type),
+            path: .relativeToModule(target.rawValue)
+        )
+    }
 
-        static func userInterface(
-            target: ModulePaths.UserInterface,
-            type: MicroTargetType = .sources
-        ) -> TargetDependency {
-            .project(
-                target: target.targetName(type: type),
-                path: .relativeToUserInterfaces(target.rawValue)
-            )
-        }
+    static func userInterface(
+        target: ModulePaths.UserInterface,
+        type: MicroTargetType = .sources
+    ) -> TargetDependency {
+        .project(
+            target: target.targetName(type: type),
+            path: .relativeToUserInterfaces(target.rawValue)
+        )
+    }
+    
+    static func domain(
+        target: ModulePaths.Domain,
+        type: MicroTargetType = .sources
+    ) -> TargetDependency {
+        .project(
+            target: target.targetName(type: type),
+            path: .relativeToDomain(target.rawValue)
+        )
+    }
 }

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -35,12 +35,15 @@ let targets: [Target] = [
             .Project.Features.RootFeature,
             .Project.Module.ThirdPartyLib,
             .Project.Service.Data,
+            TargetDependency.domain(target: .BaseDomain)
         ],
-        settings: .settings(base: env.baseSetting,
-                            configurations: [
-                              .debug(name: .debug, xcconfig: "XCConfig/Secrets.xcconfig"),
-                              .release(name: .release, xcconfig: "XCConfig/Secrets.xcconfig")
-                            ])
+        settings: .settings(
+            base: env.baseSetting,
+            configurations: [
+                .debug(name: .debug, xcconfig: "XCConfig/Secrets.xcconfig"),
+                .release(name: .release, xcconfig: "XCConfig/Secrets.xcconfig")
+            ]
+        )
     ),
     
     .init(

--- a/Projects/Domains/BaseDomain/Interface/t.swift
+++ b/Projects/Domains/BaseDomain/Interface/t.swift
@@ -1,0 +1,9 @@
+//
+//  t.swift
+//  BaseDomain
+//
+//  Created by KTH on 2024/03/04.
+//  Copyright © 2024 yongbeomkwak. All rights reserved.
+//
+
+import Foundation

--- a/Projects/Domains/BaseDomain/Project.swift
+++ b/Projects/Domains/BaseDomain/Project.swift
@@ -1,0 +1,18 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.module(
+    name: ModulePaths.Domain.BaseDomain.rawValue,
+    targets: [
+        .implements(
+            module: .domain(.BaseDomain),
+            product: .staticFramework
+        ),
+        .interface(module: .domain(.BaseDomain)),
+        .tests(
+            module: .domain(.BaseDomain),
+            dependencies: [.domain(target: .BaseDomain, type: .interface)]
+        )
+    ]
+)

--- a/Projects/Domains/BaseDomain/Sources/t.swift
+++ b/Projects/Domains/BaseDomain/Sources/t.swift
@@ -1,0 +1,9 @@
+//
+//  t.swift
+//  BaseDomain
+//
+//  Created by KTH on 2024/03/04.
+//  Copyright © 2024 yongbeomkwak. All rights reserved.
+//
+
+import Foundation

--- a/Projects/Domains/BaseDomain/Tests/t.swift
+++ b/Projects/Domains/BaseDomain/Tests/t.swift
@@ -1,0 +1,9 @@
+//
+//  t.swift
+//  BaseDomain
+//
+//  Created by KTH on 2024/03/04.
+//  Copyright © 2024 yongbeomkwak. All rights reserved.
+//
+
+import Foundation

--- a/Tuist/ProjectDescriptionHelpers/Project/Project+Template.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project/Project+Template.swift
@@ -4,7 +4,6 @@ import Foundation
 import EnvironmentPlugin
 
 public extension Project {
-    
     static func module(
         name: String,
         options: Options = .options(),
@@ -14,15 +13,15 @@ public extension Project {
             configurations: [
                 .debug(name: .debug),
                 .release(name: .release)
-            ], defaultSettings: .recommended),
+            ], 
+            defaultSettings: .recommended
+        ),
         targets: [Target],
         fileHeaderTemplate: FileHeaderTemplate? = nil,
         additionalFiles: [FileElement] = [],
         resourceSynthesizers: [ResourceSynthesizer] = .default
     ) -> Project {
-        
         #warning("백튼님 여기 데모(Example) 앱 도입할 때 , schemes 쪽 건드려야할 듯??")
-        
         return Project(
             name: name,
             organizationName: env.organizationName,
@@ -34,8 +33,6 @@ public extension Project {
             fileHeaderTemplate: fileHeaderTemplate,
             additionalFiles: additionalFiles,
             resourceSynthesizers: resourceSynthesizers
-            
-            
         )
     }
     


### PR DESCRIPTION
## 💡 배경 및 개요

#425 
현재 왁뮤 iOS 모듈 구조에 도메인 레이어를 추가적으로 도입합니다.

1. 시간이 지날수록 비대해지는 Data, Domain, Network, Database, APIKit, DataMapping 모듈
2. UseCase 추가 시 작업 영역이 비효율적
3. 도메인 로직을 위해서는 모두가 Domain 모듈에 의존

위와 같은 이유로 EndPoint에 기준하여 도메인 모듈을 분리합니다.

Resolves: #425 

## 📃 작업내용

- ModulePaths(enum)에 domain 케이스 추가
- ModulePaths의 extension으로 Domain(enum)추가 
- Domain(enum)에 BaseDomain, AppDomain 케이스 추가
- Domain 레이어 추가 및 BaseDomain 프로젝트 모듈 생성

## 🙋‍♂️ 리뷰노트

작업 내용 외에 불필요한 개행, 들여쓰기 정리하였습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
