### PR TITLE
🔀 :: (#443) 모듈 생성 스크립트 예외처리

### DIFF
--- a/Scripts/GenerateModule.swift
+++ b/Scripts/GenerateModule.swift
@@ -87,7 +87,16 @@ func registerModulePaths() {
 
 func makeDirectory(path: String) {
     do {
-        try fileManager.createDirectory(atPath: path, withIntermediateDirectories: false, attributes: nil)
+        if fileManager.fileExists(atPath: path) {
+            print("디렉토리를 생성하려는 곳에 이미 디렉토리가 존재해요, 덮어쓰기할까요?\n경로 : \(path)\n(y / n)")
+            let isOverwrite = readLine()?.lowercased() == "y"
+            if isOverwrite {
+                try fileManager.removeItem(atPath: path)
+                try fileManager.createDirectory(atPath: path, withIntermediateDirectories: false, attributes: nil)
+            }
+        } else {
+            try fileManager.createDirectory(atPath: path, withIntermediateDirectories: false, attributes: nil)
+        }
     } catch {
         fatalError("❌ failed to create directory: \(path)")
     }


### PR DESCRIPTION
## 💡 배경 및 개요
모듈 생성을 할 때, 생성할 모듈 경로에 디렉토리나 파일이 있으면 아래와 같은 에러가 떠요.
```bash
...
Register ArtistDomain to ModulePaths.swift
GenerateModule/GenerateModule.swift:92: Fatal error: ❌ failed to create directory: ./Projects/Domains/ArtistDomain
```

Resolves: #443 

## 📃 작업내용

모듈 생성 스크립트를 실행하고 디렉토리를 생성할 때, 해당 경로에 디렉토리나 파일이 있으면 사용자에게 덮어쓰기를 진행할것인지 질의를 해요.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
