### PR TITLE
🔀 :: (#433) PR Assign, Labels 지정 자동화 workflow 추가

### DIFF
--- a/.github/workflows/AutoAssign.yml
+++ b/.github/workflows/AutoAssign.yml
@@ -1,0 +1,40 @@
+name: Auto assign PR author
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  assign-pr-author:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Get PR author
+        id: get-pr-author
+        run: echo "author=${{ github.event.pull_request.user.login }}" >> $GITHUB_OUTPUT
+
+      - name: Assign PR author
+        run: gh pr edit ${{ github.event.number }} --add-assignee ${{ steps.get-pr-author.outputs.author }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Comment success result to PR
+        uses: mshick/add-pr-comment@v2
+        if: ${{ success() }}
+        with:
+          message: |
+            ## ✅ Assign 자동 지정을 성공했어요!
+            @${{ steps.get-pr-author.outputs.author }}
+          allow-repeats: true
+
+      - name: Comment failure result to PR
+        uses: mshick/add-pr-comment@v2
+        if: ${{ failure() }}
+        with:
+          message: "## ❌ PR의 Assign 자동 지정을 실패했어요."
+          allow-repeats: true

--- a/.github/workflows/IssueToPRLabelSync.yml
+++ b/.github/workflows/IssueToPRLabelSync.yml
@@ -1,0 +1,55 @@
+name: Issue to PR label sync
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Extract issue number from PR title
+        id: extract-issue-number
+        run: |
+          sh .github/workflows/IssueToPRLabelSync/ExtractIssueNumber.sh >> $GITHUB_OUTPUT
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+
+      - name: Check if issue number is found
+        id: check-issue-number
+        run: echo "valid_format=$(if [[ -n "${{ steps.extract-issue-number.outputs.issue_number }}" ]]; then echo "true"; else echo "false"; fi)" >> $GITHUB_OUTPUT
+
+      - name: Add label if valid issue format
+        if: steps.check-issue-number.outputs.valid_format == 'true'
+        run: |
+          ISSUE_NUMBER="${{ steps.extract-issue-number.outputs.issue_number }}"
+          echo "Found Issue Number: $ISSUE_NUMBER"
+          gh issue view $ISSUE_NUMBER --json labels --template "{{range .labels}}'{{.name}}',{{end}}" \
+           | sed 's/.$//g' \
+           | xargs -I LABELS gh pr edit ${{ github.event.number }} --add-label "LABELS"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Skip if invalid issue format
+        if: steps.check-issue-number.outputs.valid_format == 'false'
+        run: echo "Invalid issue format. Skipping label addition."
+
+      - name: Comment success result to PR
+        uses: mshick/add-pr-comment@v2
+        if: steps.check-issue-number.outputs.valid_format == 'true'
+        with:
+          message: "## ✅ 이슈와 PR의 Labels 동기화를 성공했어요!"
+          allow-repeats: true
+
+      - name: Comment skip result to PR
+        uses: mshick/add-pr-comment@v2
+        if: steps.check-issue-number.outputs.valid_format == 'false'
+        with:
+          message: "## 🛠️ 이슈와 PR의 Labels 동기화를 스킵했어요."
+          allow-repeats: true

--- a/.github/workflows/IssueToPRLabelSync/ExtractIssueNumber.sh
+++ b/.github/workflows/IssueToPRLabelSync/ExtractIssueNumber.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "issue_number=$(echo $PR_TITLE | grep -oP '\(#[0-9]+\)' | grep -oP '[0-9]+')"


### PR DESCRIPTION
## 💡 배경 및 개요

PR 올릴떄마다 Assign이랑 Labels 지정하기가 너무 귀찮아서 이를 자동화하는 workflow를 추가해요

Resolves: #433 

## 📃 작업내용

- PR이 Open, Reopen될 때 Assign을 자신으로 두는 github action workflows 추가
- PR이 Open, Reopen될 때 제목에 있는 (#{숫자}) 로부터 이슈넘버를 가져와서 이슈로부터 Labels를 가져와 PR에 지정하는 github action workflows 추가

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
