### PR TITLE
🔀 :: (#453) 의존성 캐시의 flag인 hashFile의 입력 파일 변경

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Compute dependency cache key
         id: compute_hash
-        run: echo "hash=${{ hashFiles('Tuist/Dependencies.swift') }}" >> $GITHUB_OUTPUT
+        run: echo "hash=${{ hashFiles('Tuist/Package.swift') }}" >> $GITHUB_OUTPUT
 
       - name: Check dependency cache
         uses: actions/cache@v3


### PR DESCRIPTION
## 💡 배경 및 개요
현재 구축되어있는 CI에는 의존성 캐싱이 구현되어있어요. 이때 의존성이 바뀌었는지 확인하는 값의 기준이 `Tuist/Dependencies.swift` 의 파일이 변경되었는지를 기준으로 판단하는데, 이전에 Tuist의 버전을 업그레이드하면서 ( #402 ) 의존성 정의를 `Tuist/Package.swift`에 하도록 변경하였어요.
그렇기에 추후 새로운 의존성을 추가할 때 Dependencies.swift의 내용은 안바뀌기에 이전 의존성을 써서 에러가 날 수 있기에 hashFile의 입력 파일을 `Tuist/Package.swift`로 바꿨어요.

Resolves: #435 

## 📃 작업내용

- hashFile의 argument에 `Tuist/Package.swift`를 넘김

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

