### PR TITLE
🔀 :: (#455) make setup 후 tuist command를 못찾는 버그 해결

### DIFF
--- a/Scripts/Setup.sh
+++ b/Scripts/Setup.sh
@@ -29,7 +29,10 @@ if which tuist > /dev/null; then
   echo "✅ Tuist가 설치되어있어요."
 else
   echo "❌ Tuist가 설치되어있지 않아요. Tuist 설치를 시작해요."
-  brew install mise
+  curl https://mise.run | sh
+  echo 'eval "$(~/.local/bin/mise activate --shims zsh)"' >> ~/.zshrc
+  source ~/.zshrc
+
   mise install tuist
   tuist version
 fi

--- a/Scripts/Setup.sh
+++ b/Scripts/Setup.sh
@@ -37,7 +37,7 @@ else
   tuist version
 fi
 
-if whice carthage > /dev/null; then
+if which carthage > /dev/null; then
   echo "✅ Carthage가 설치되어있어요."
 else
   echo "❌ Carthage가 설치되어있지 않아요. Carthage 설치를 시작해요."


### PR DESCRIPTION
## 💡 배경 및 개요

`make setup`을 실행해서 mise를 통해 tuist를 설치하고나니 tuist command를 못찾았어요.

Resolves: #455 

## 📃 작업내용

- Setup.sh 스크립트에 zshrc에 mise를 activate하는 스크립트를 추가했어요
- 설치를 homebrew가 아닌 mise의 스크립트를 사용하여 로컬로 다운바도록 변경했어요. brew로 할경우 사람마다 경로가 달라지는 경우가 있다더라구요.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
