### PR TITLE
🔀 :: (#457) Reactor 의존성 추가

### DIFF
--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
@@ -27,6 +27,7 @@ public extension TargetDependency.SPM {
     static let FirebaseAnalytics = TargetDependency.external(name: "FirebaseAnalyticsWithoutAdIdSupport")
     static let FirebaseCrashlytics = TargetDependency.external(name: "FirebaseCrashlytics")
     static let NVActivityIndicatorView = TargetDependency.external(name: "NVActivityIndicatorView")
+    static let ReactorKit = TargetDependency.external(name: "ReactorKit")
 
 // MARK: Native SPM
     static let YouTubePlayerKit = TargetDependency.package(product: "YouTubePlayerKit")

--- a/Projects/Features/BaseFeature/Project.swift
+++ b/Projects/Features/BaseFeature/Project.swift
@@ -8,6 +8,7 @@ let project = Project.makeModule(
         .Project.Service.Domain,
         .Project.Module.FeatureThirdPartyLib,
         .Project.UserInterfaces.DesignSystem,
-        .Project.Module.Utility
+        .Project.Module.Utility,
+        .SPM.ReactorKit
     ]
 )

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -226,6 +226,15 @@
       }
     },
     {
+      "identity" : "reactorkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactorKit/ReactorKit.git",
+      "state" : {
+        "revision" : "8fa33f09c6f6621a2aa536d739956d53b84dd139",
+        "version" : "3.2.0"
+      }
+    },
+    {
       "identity" : "rxdatasources",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RxSwiftCommunity/RxDataSources.git",
@@ -295,6 +304,15 @@
       "state" : {
         "revision" : "e421a7b3440a271834337694e6050133a3958bc7",
         "version" : "2.7.0"
+      }
+    },
+    {
+      "identity" : "weakmaptable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactorKit/WeakMapTable.git",
+      "state" : {
+        "revision" : "cb05d64cef2bbf51e85c53adee937df46540a74e",
+        "version" : "1.2.1"
       }
     }
   ],

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.8.0"),
         .package(url: "https://github.com/cbpowell/MarqueeLabel.git", from: "4.3.0"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.7.0"),
-        .package(url: "https://github.com/ninjaprox/NVActivityIndicatorView.git", from: "5.1.1")
+        .package(url: "https://github.com/ninjaprox/NVActivityIndicatorView.git", from: "5.1.1"),
+        .package(url: "https://github.com/ReactorKit/ReactorKit.git", from: "3.2.0")
     ]
 )


### PR DESCRIPTION
## 💡 배경 및 개요

ReactorKit 도입이 되기에 ReactorKit 의존성을 추가해요.

Resolves: #457 

## 📃 작업내용

- Package.swift에 ReactorKit 추가
- SPM Namespace에 ReactorKit 추가

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
