### PR TITLE
🔀 :: (#474) SwiftFormat 대상에 NeedleGenerated 파일 제외

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,5 +1,5 @@
 
---exclude fastlane,Tuist,Dependencies,Carthage
+--exclude fastlane,Tuist,Dependencies,Carthage,**/NeedleGenerated.swift
 
 # options
 --maxwidth 120


### PR DESCRIPTION
## 💡 배경 및 개요

format 자동화 기능이 있는데 이 친구가 돌아갈때마다 NeedleGenerated.swift (자동생성 파일) 도 포매팅이 되다보니 불필요하게 변경되는 코드가 많아져요!

Resolves: #474 

## 📃 작업내용

.swiftformat 파일 exclude 대상에 '**/NeedleGenerated.swift' 추가

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
