### PR TITLE
🔀 :: (#477) Logout UseCase 추가

### DIFF
--- a/Projects/App/Sources/Application/AppComponent+Auth.swift
+++ b/Projects/App/Sources/Application/AppComponent+Auth.swift
@@ -32,6 +32,12 @@ public extension AppComponent {
         RequestComponent(parent: self)
     }
 
+    var localAuthDataSource: any LocalAuthDataSource {
+        shared {
+            LocalAuthDataSourceImpl(keychain: keychain)
+        }
+    }
+
     var remoteAuthDataSource: any RemoteAuthDataSource {
         shared {
             RemoteAuthDataSourceImpl(keychain: keychain)
@@ -40,7 +46,10 @@ public extension AppComponent {
 
     var authRepository: any AuthRepository {
         shared {
-            AuthRepositoryImpl(remoteAuthDataSource: remoteAuthDataSource)
+            AuthRepositoryImpl(
+                localAuthDataSource: localAuthDataSource,
+                remoteAuthDataSource: remoteAuthDataSource
+            )
         }
     }
 
@@ -53,6 +62,12 @@ public extension AppComponent {
     var fetchNaverUserInfoUseCase: any FetchNaverUserInfoUseCase {
         shared {
             FetchNaverUserInfoUseCaseImpl(authRepository: authRepository)
+        }
+    }
+
+    var logoutUseCase: any LogoutUseCase {
+        shared {
+            LogoutUseCaseImpl(authRepository: authRepository)
         }
     }
 }

--- a/Projects/Domains/AuthDomain/Interface/DataSource/LocalAuthDataSource.swift
+++ b/Projects/Domains/AuthDomain/Interface/DataSource/LocalAuthDataSource.swift
@@ -1,0 +1,5 @@
+import RxSwift
+
+public protocol LocalAuthDataSource {
+    func logout()
+}

--- a/Projects/Domains/AuthDomain/Interface/Repository/AuthRepository.swift
+++ b/Projects/Domains/AuthDomain/Interface/Repository/AuthRepository.swift
@@ -4,4 +4,5 @@ import RxSwift
 public protocol AuthRepository {
     func fetchToken(token: String, type: ProviderType) -> Single<AuthLoginEntity>
     func fetchNaverUserInfo(tokenType: String, accessToken: String) -> Single<NaverUserInfoEntity>
+    func logout() -> Completable
 }

--- a/Projects/Domains/AuthDomain/Interface/UseCase/LogoutUseCase.swift
+++ b/Projects/Domains/AuthDomain/Interface/UseCase/LogoutUseCase.swift
@@ -1,0 +1,5 @@
+import RxSwift
+
+public protocol LogoutUseCase {
+    func execute() -> Completable
+}

--- a/Projects/Domains/AuthDomain/Sources/DataSource/LocalAuthDataSourceImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/DataSource/LocalAuthDataSourceImpl.swift
@@ -1,0 +1,19 @@
+import AuthDomainInterface
+import KeychainModule
+import RxSwift
+import Utility
+
+public final class LocalAuthDataSourceImpl: LocalAuthDataSource {
+    private let keychain: any Keychain
+
+    public init(keychain: any Keychain) {
+        self.keychain = keychain
+    }
+
+    public func logout() {
+        keychain.delete(type: .accessToken)
+        keychain.delete(type: .refreshToken)
+        keychain.delete(type: .accessExpiresIn)
+        PreferenceManager.userInfo = nil
+    }
+}

--- a/Projects/Domains/AuthDomain/Sources/Repository/AuthRepositoryImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/Repository/AuthRepositoryImpl.swift
@@ -10,9 +10,14 @@ import AuthDomainInterface
 import RxSwift
 
 public final class AuthRepositoryImpl: AuthRepository {
+    private let localAuthDataSource: any LocalAuthDataSource
     private let remoteAuthDataSource: any RemoteAuthDataSource
 
-    public init(remoteAuthDataSource: RemoteAuthDataSource) {
+    public init(
+        localAuthDataSource: any LocalAuthDataSource,
+        remoteAuthDataSource: any RemoteAuthDataSource
+    ) {
+        self.localAuthDataSource = localAuthDataSource
         self.remoteAuthDataSource = remoteAuthDataSource
     }
 
@@ -22,5 +27,13 @@ public final class AuthRepositoryImpl: AuthRepository {
 
     public func fetchNaverUserInfo(tokenType: String, accessToken: String) -> Single<NaverUserInfoEntity> {
         remoteAuthDataSource.fetchNaverUserInfo(tokenType: tokenType, accessToken: accessToken)
+    }
+
+    public func logout() -> Completable {
+        Completable.create { [localAuthDataSource] observer in
+            localAuthDataSource.logout()
+            observer(.completed)
+            return Disposables.create()
+        }
     }
 }

--- a/Projects/Domains/AuthDomain/Sources/UseCase/LogoutUseCaseImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/UseCase/LogoutUseCaseImpl.swift
@@ -1,0 +1,14 @@
+import AuthDomainInterface
+import RxSwift
+
+public struct LogoutUseCaseImpl: LogoutUseCase {
+    private let authRepository: any AuthRepository
+
+    public init(authRepository: any AuthRepository) {
+        self.authRepository = authRepository
+    }
+
+    public func execute() -> Completable {
+        authRepository.logout()
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요

- 로그아웃을 하는 로직을 처리하기 위한 UseCase를 추가해요

Resolves: #477 

## 📃 작업내용

- Logout용 UseCase을 추가했어요
- Repository, DataSource에 Logout을 하는 어플리케이션 로직을 추가했어요

## 🙋‍♂️ 리뷰노트

- UseCase라는 개념의 약간 미약해질 수 있지만.. Logout로직을 처리하는 UseCase를 따로 하나 만들었어요
- LogoutUseCase가 동기적으로 처리됨에도 Completable인 이유는 이후 로그아웃 행동에 비동기적 처리가 추가될 수 있어서예요 (e.g. Logout API 추가)

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
