### PR TITLE
🔀 :: (#477) Feature 레이어의 로그아웃 로직 리팩토링

### DIFF
--- a/Projects/App/Sources/Application/NeedleGenerated.swift
+++ b/Projects/App/Sources/Application/NeedleGenerated.swift
@@ -582,6 +582,9 @@ private class ContainSongsDependencydbd9ae8a072db3a22630Provider: ContainSongsDe
     var addSongIntoPlayListUseCase: any AddSongIntoPlayListUseCase {
         return appComponent.addSongIntoPlayListUseCase
     }
+    var logoutUseCase: any LogoutUseCase {
+        return appComponent.logoutUseCase
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -616,6 +619,9 @@ private class MultiPurposePopDependency30141c7a9a9e67e148afProvider: MultiPurpos
     }
     var editPlayListNameUseCase: any EditPlayListNameUseCase {
         return appComponent.editPlayListNameUseCase
+    }
+    var logoutUseCase: any LogoutUseCase {
+        return appComponent.logoutUseCase
     }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
@@ -742,10 +748,12 @@ extension AppComponent: Registration {
         localTable["storageComponent-StorageComponent"] = { [unowned self] in self.storageComponent as Any }
         localTable["afterLoginComponent-AfterLoginComponent"] = { [unowned self] in self.afterLoginComponent as Any }
         localTable["requestComponent-RequestComponent"] = { [unowned self] in self.requestComponent as Any }
+        localTable["localAuthDataSource-any LocalAuthDataSource"] = { [unowned self] in self.localAuthDataSource as Any }
         localTable["remoteAuthDataSource-any RemoteAuthDataSource"] = { [unowned self] in self.remoteAuthDataSource as Any }
         localTable["authRepository-any AuthRepository"] = { [unowned self] in self.authRepository as Any }
         localTable["fetchTokenUseCase-any FetchTokenUseCase"] = { [unowned self] in self.fetchTokenUseCase as Any }
         localTable["fetchNaverUserInfoUseCase-any FetchNaverUserInfoUseCase"] = { [unowned self] in self.fetchNaverUserInfoUseCase as Any }
+        localTable["logoutUseCase-any LogoutUseCase"] = { [unowned self] in self.logoutUseCase as Any }
         localTable["remoteLikeDataSource-any RemoteLikeDataSource"] = { [unowned self] in self.remoteLikeDataSource as Any }
         localTable["likeRepository-any LikeRepository"] = { [unowned self] in self.likeRepository as Any }
         localTable["fetchLikeNumOfSongUseCase-any FetchLikeNumOfSongUseCase"] = { [unowned self] in self.fetchLikeNumOfSongUseCase as Any }
@@ -1026,6 +1034,7 @@ extension ContainSongsComponent: Registration {
         keyPathToName[\ContainSongsDependency.multiPurposePopComponent] = "multiPurposePopComponent-MultiPurposePopComponent"
         keyPathToName[\ContainSongsDependency.fetchPlayListUseCase] = "fetchPlayListUseCase-any FetchPlayListUseCase"
         keyPathToName[\ContainSongsDependency.addSongIntoPlayListUseCase] = "addSongIntoPlayListUseCase-any AddSongIntoPlayListUseCase"
+        keyPathToName[\ContainSongsDependency.logoutUseCase] = "logoutUseCase-any LogoutUseCase"
     }
 }
 extension ServiceInfoComponent: Registration {
@@ -1039,6 +1048,7 @@ extension MultiPurposePopComponent: Registration {
         keyPathToName[\MultiPurposePopDependency.loadPlayListUseCase] = "loadPlayListUseCase-any LoadPlayListUseCase"
         keyPathToName[\MultiPurposePopDependency.setUserNameUseCase] = "setUserNameUseCase-any SetUserNameUseCase"
         keyPathToName[\MultiPurposePopDependency.editPlayListNameUseCase] = "editPlayListNameUseCase-any EditPlayListNameUseCase"
+        keyPathToName[\MultiPurposePopDependency.logoutUseCase] = "logoutUseCase-any LogoutUseCase"
     }
 }
 extension NewSongsComponent: Registration {

--- a/Projects/App/Sources/Application/NeedleGenerated.swift
+++ b/Projects/App/Sources/Application/NeedleGenerated.swift
@@ -372,6 +372,9 @@ private class FavoriteDependency8f7fd37aeb6f0e5d0e30Provider: FavoriteDependency
     var deleteFavoriteListUseCase: any DeleteFavoriteListUseCase {
         return appComponent.deleteFavoriteListUseCase
     }
+    var logoutUseCase: any LogoutUseCase {
+        return appComponent.logoutUseCase
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -958,6 +961,7 @@ extension FavoriteComponent: Registration {
         keyPathToName[\FavoriteDependency.fetchFavoriteSongsUseCase] = "fetchFavoriteSongsUseCase-any FetchFavoriteSongsUseCase"
         keyPathToName[\FavoriteDependency.editFavoriteSongsOrderUseCase] = "editFavoriteSongsOrderUseCase-any EditFavoriteSongsOrderUseCase"
         keyPathToName[\FavoriteDependency.deleteFavoriteListUseCase] = "deleteFavoriteListUseCase-any DeleteFavoriteListUseCase"
+        keyPathToName[\FavoriteDependency.logoutUseCase] = "logoutUseCase-any LogoutUseCase"
     }
 }
 extension RequestComponent: Registration {

--- a/Projects/App/Sources/Application/NeedleGenerated.swift
+++ b/Projects/App/Sources/Application/NeedleGenerated.swift
@@ -655,6 +655,9 @@ private class PlayListDetailDependencyb06fb5392859952b82a2Provider: PlayListDeta
     var removeSongsUseCase: any RemoveSongsUseCase {
         return appComponent.removeSongsUseCase
     }
+    var logoutUseCase: any LogoutUseCase {
+        return appComponent.logoutUseCase
+    }
     var multiPurposePopComponent: MultiPurposePopComponent {
         return appComponent.multiPurposePopComponent
     }
@@ -1061,6 +1064,7 @@ extension PlayListDetailComponent: Registration {
         keyPathToName[\PlayListDetailDependency.fetchPlayListDetailUseCase] = "fetchPlayListDetailUseCase-any FetchPlayListDetailUseCase"
         keyPathToName[\PlayListDetailDependency.editPlayListUseCase] = "editPlayListUseCase-any EditPlayListUseCase"
         keyPathToName[\PlayListDetailDependency.removeSongsUseCase] = "removeSongsUseCase-any RemoveSongsUseCase"
+        keyPathToName[\PlayListDetailDependency.logoutUseCase] = "logoutUseCase-any LogoutUseCase"
         keyPathToName[\PlayListDetailDependency.multiPurposePopComponent] = "multiPurposePopComponent-MultiPurposePopComponent"
         keyPathToName[\PlayListDetailDependency.containSongsComponent] = "containSongsComponent-ContainSongsComponent"
     }

--- a/Projects/App/Sources/Application/NeedleGenerated.swift
+++ b/Projects/App/Sources/Application/NeedleGenerated.swift
@@ -322,6 +322,9 @@ private class MyPlayListDependency067bbf42b28f80e413acProvider: MyPlayListDepend
     var deletePlayListUseCase: any DeletePlayListUseCase {
         return appComponent.deletePlayListUseCase
     }
+    var logoutUseCase: any LogoutUseCase {
+        return appComponent.logoutUseCase
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -943,6 +946,7 @@ extension MyPlayListComponent: Registration {
         keyPathToName[\MyPlayListDependency.fetchPlayListUseCase] = "fetchPlayListUseCase-any FetchPlayListUseCase"
         keyPathToName[\MyPlayListDependency.editPlayListOrderUseCase] = "editPlayListOrderUseCase-any EditPlayListOrderUseCase"
         keyPathToName[\MyPlayListDependency.deletePlayListUseCase] = "deletePlayListUseCase-any DeletePlayListUseCase"
+        keyPathToName[\MyPlayListDependency.logoutUseCase] = "logoutUseCase-any LogoutUseCase"
     }
 }
 extension AfterLoginComponent: Registration {

--- a/Projects/App/Sources/Application/NeedleGenerated.swift
+++ b/Projects/App/Sources/Application/NeedleGenerated.swift
@@ -702,6 +702,9 @@ private class ProfilePopDependency081172e20caa75abdb54Provider: ProfilePopDepend
     var setProfileUseCase: any SetProfileUseCase {
         return appComponent.setProfileUseCase
     }
+    var logoutUseCase: any LogoutUseCase {
+        return appComponent.logoutUseCase
+    }
     private let appComponent: AppComponent
     init(appComponent: AppComponent) {
         self.appComponent = appComponent
@@ -1083,6 +1086,7 @@ extension ProfilePopComponent: Registration {
     public func registerItems() {
         keyPathToName[\ProfilePopDependency.fetchProfileListUseCase] = "fetchProfileListUseCase-any FetchProfileListUseCase"
         keyPathToName[\ProfilePopDependency.setProfileUseCase] = "setProfileUseCase-any SetProfileUseCase"
+        keyPathToName[\ProfilePopDependency.logoutUseCase] = "logoutUseCase-any LogoutUseCase"
     }
 }
 extension NewSongsContentComponent: Registration {

--- a/Projects/App/Sources/Application/NeedleGenerated.swift
+++ b/Projects/App/Sources/Application/NeedleGenerated.swift
@@ -143,6 +143,9 @@ private class PlayerDependencyf8a3d594cc3b9254f8adProvider: PlayerDependency {
     var fetchFavoriteSongsUseCase: any FetchFavoriteSongsUseCase {
         return appComponent.fetchFavoriteSongsUseCase
     }
+    var logoutUseCase: any LogoutUseCase {
+        return appComponent.logoutUseCase
+    }
     var playlistComponent: PlaylistComponent {
         return appComponent.playlistComponent
     }
@@ -870,6 +873,7 @@ extension PlayerComponent: Registration {
         keyPathToName[\PlayerDependency.cancelLikeSongUseCase] = "cancelLikeSongUseCase-any CancelLikeSongUseCase"
         keyPathToName[\PlayerDependency.fetchLikeNumOfSongUseCase] = "fetchLikeNumOfSongUseCase-any FetchLikeNumOfSongUseCase"
         keyPathToName[\PlayerDependency.fetchFavoriteSongsUseCase] = "fetchFavoriteSongsUseCase-any FetchFavoriteSongsUseCase"
+        keyPathToName[\PlayerDependency.logoutUseCase] = "logoutUseCase-any LogoutUseCase"
         keyPathToName[\PlayerDependency.playlistComponent] = "playlistComponent-PlaylistComponent"
         keyPathToName[\PlayerDependency.containSongsComponent] = "containSongsComponent-ContainSongsComponent"
     }

--- a/Projects/Features/CommonFeature/Sources/Components/ContainSongsComponent.swift
+++ b/Projects/Features/CommonFeature/Sources/Components/ContainSongsComponent.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 yongbeomkwak. All rights reserved.
 //
 
+import AuthDomainInterface
 import Foundation
 import NeedleFoundation
 import PlayListDomainInterface
@@ -15,6 +16,7 @@ public protocol ContainSongsDependency: Dependency {
     var multiPurposePopComponent: MultiPurposePopComponent { get }
     var fetchPlayListUseCase: any FetchPlayListUseCase { get }
     var addSongIntoPlayListUseCase: any AddSongIntoPlayListUseCase { get }
+    var logoutUseCase: any LogoutUseCase { get }
 }
 
 public final class ContainSongsComponent: Component<ContainSongsDependency> {
@@ -24,7 +26,8 @@ public final class ContainSongsComponent: Component<ContainSongsDependency> {
             viewModel: .init(
                 songs: songs,
                 fetchPlayListUseCase: dependency.fetchPlayListUseCase,
-                addSongIntoPlayListUseCase: dependency.addSongIntoPlayListUseCase
+                addSongIntoPlayListUseCase: dependency.addSongIntoPlayListUseCase,
+                logoutUseCase: dependency.logoutUseCase
             )
         )
     }

--- a/Projects/Features/CommonFeature/Sources/Components/MultiPurposePopComponent.swift
+++ b/Projects/Features/CommonFeature/Sources/Components/MultiPurposePopComponent.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 yongbeomkwak. All rights reserved.
 //
 
+import AuthDomainInterface
 import Foundation
 import NeedleFoundation
 import PlayListDomainInterface
@@ -16,6 +17,7 @@ public protocol MultiPurposePopDependency: Dependency {
     var loadPlayListUseCase: any LoadPlayListUseCase { get }
     var setUserNameUseCase: any SetUserNameUseCase { get }
     var editPlayListNameUseCase: any EditPlayListNameUseCase { get }
+    var logoutUseCase: any LogoutUseCase { get }
 }
 
 public final class MultiPurposePopComponent: Component<MultiPurposePopDependency> {
@@ -31,7 +33,8 @@ public final class MultiPurposePopComponent: Component<MultiPurposePopDependency
                 createPlayListUseCase: dependency.createPlayListUseCase,
                 loadPlayListUseCase: dependency.loadPlayListUseCase,
                 setUserNameUseCase: dependency.setUserNameUseCase,
-                editPlayListNameUseCase: dependency.editPlayListNameUseCase
+                editPlayListNameUseCase: dependency.editPlayListNameUseCase,
+                logoutUseCase: dependency.logoutUseCase
             ),
             completion: completion
         )

--- a/Projects/Features/CommonFeature/Sources/Components/PlayListDetailComponent.swift
+++ b/Projects/Features/CommonFeature/Sources/Components/PlayListDetailComponent.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 yongbeomkwak. All rights reserved.
 //
 
+import AuthDomainInterface
 import Foundation
 import NeedleFoundation
 import PlayListDomainInterface
@@ -15,6 +16,7 @@ public protocol PlayListDetailDependency: Dependency {
 
     var editPlayListUseCase: any EditPlayListUseCase { get }
     var removeSongsUseCase: any RemoveSongsUseCase { get }
+    var logoutUseCase: any LogoutUseCase { get }
 
     var multiPurposePopComponent: MultiPurposePopComponent { get }
     var containSongsComponent: ContainSongsComponent { get }
@@ -28,7 +30,8 @@ public final class PlayListDetailComponent: Component<PlayListDetailDependency> 
                 type: type,
                 fetchPlayListDetailUseCase: dependency.fetchPlayListDetailUseCase,
                 editPlayListUseCase: dependency.editPlayListUseCase,
-                removeSongsUseCase: dependency.removeSongsUseCase
+                removeSongsUseCase: dependency.removeSongsUseCase,
+                logoutUseCase: dependency.logoutUseCase
             ),
             multiPurposePopComponent: dependency.multiPurposePopComponent,
             containSongsComponent: dependency.containSongsComponent

--- a/Projects/Features/CommonFeature/Sources/Components/ProfilePopComponent.swift
+++ b/Projects/Features/CommonFeature/Sources/Components/ProfilePopComponent.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 yongbeomkwak. All rights reserved.
 //
 
+import AuthDomainInterface
 import Foundation
 import NeedleFoundation
 import UserDomainInterface
@@ -13,6 +14,7 @@ import UserDomainInterface
 public protocol ProfilePopDependency: Dependency {
     var fetchProfileListUseCase: any FetchProfileListUseCase { get }
     var setProfileUseCase: any SetProfileUseCase { get }
+    var logoutUseCase: any LogoutUseCase { get }
 }
 
 public final class ProfilePopComponent: Component<ProfilePopDependency> {
@@ -20,7 +22,8 @@ public final class ProfilePopComponent: Component<ProfilePopDependency> {
         return ProfilePopViewController.viewController(
             viewModel: .init(
                 fetchProfileListUseCase: dependency.fetchProfileListUseCase,
-                setProfileUseCase: dependency.setProfileUseCase
+                setProfileUseCase: dependency.setProfileUseCase,
+                logoutUseCas: dependency.logoutUseCase
             )
         )
     }

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -112,18 +112,22 @@ extension ContainSongsViewController {
                 guard let self = self else { return }
                 self.showToast(text: result.description, font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
 
-                if result.status == 401 {
-                    LOGOUT()
-                    PlayState.shared.switchPlayerMode(to: .mini)
-                    self.dismiss(animated: true) { [weak self] in
-                        guard let self else { return }
-                        self.delegate?.tokenExpired()
-                    }
-                } else {
-                    NotificationCenter.default.post(name: .playListRefresh, object: nil) // 플리목록창 이름 변경하기 위함
-                    self.dismiss(animated: true)
-                }
+                NotificationCenter.default.post(name: .playListRefresh, object: nil) // 플리목록창 이름 변경하기 위함
+                self.dismiss(animated: true)
             })
+            .disposed(by: disposeBag)
+
+        output.onLogout
+            .bind(with: self) { owner, error in
+                let toastFont = DesignSystemFontFamily.Pretendard.light.font(size: 14)
+                owner.showToast(text: error.localizedDescription, font: toastFont)
+                NotificationCenter.default.post(name: .movedTab, object: 4)
+
+                PlayState.shared.switchPlayerMode(to: .mini)
+                owner.dismiss(animated: true) {
+                    owner.delegate?.tokenExpired()
+                }
+            }
             .disposed(by: disposeBag)
 
         NotificationCenter.default.rx.notification(.playListRefresh)

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
@@ -354,18 +354,21 @@ extension MultiPurposePopupViewController {
                     text: description,
                     font: DesignSystemFontFamily.Pretendard.light.font(size: 14)
                 )
-
-            } else if res.status == 401 {
-                self.showToast(text: res.description, font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
-                LOGOUT()
-                if self.viewModel.type == .edit || self.viewModel.type == .creation {
-                    self.delegate?.didTokenExpired()
-                }
-
             } else {
                 self.showToast(text: res.description, font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
             }
         })
+        .disposed(by: disposeBag)
+
+        output.onLogout.bind(with: self) { owner, error in
+            let toastFont = DesignSystemFontFamily.Pretendard.light.font(size: 14)
+            owner.showToast(text: error.localizedDescription, font: toastFont)
+            NotificationCenter.default.post(name: .movedTab, object: 4)
+
+            if owner.viewModel.type == .edit || owner.viewModel.type == .creation {
+                owner.delegate?.didTokenExpired()
+            }
+        }
         .disposed(by: disposeBag)
 
         saveButton.rx.tap.subscribe(onNext: { [weak self] in

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/PlayListDetailViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/PlayListDetailViewController.swift
@@ -325,15 +325,18 @@ extension PlayListDetailViewController {
                 guard let self = self else { return }
                 self.showToast(text: $0.description, font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
 
-                if $0.status == 401 {
-                    LOGOUT()
-                    self.navigationController?.popViewController(animated: true)
-
-                } else {
-                    self.input.state.accept(EditState(isEditing: false, force: true))
-                }
+                self.input.state.accept(EditState(isEditing: false, force: true))
             })
             .disposed(by: disposeBag)
+
+        output.onLogout.bind(with: self) { owner, error in
+            let toastFont = DesignSystemFontFamily.Pretendard.light.font(size: 14)
+            owner.showToast(text: error.localizedDescription, font: toastFont)
+            NotificationCenter.default.post(name: .movedTab, object: 4)
+
+            owner.navigationController?.popViewController(animated: true)
+        }
+        .disposed(by: disposeBag)
 
         tableView.rx.itemSelected
             .withLatestFrom(output.dataSource) { ($0, $1) }

--- a/Projects/Features/CommonFeature/Sources/ViewControllers/ProfilePopViewController.swift
+++ b/Projects/Features/CommonFeature/Sources/ViewControllers/ProfilePopViewController.swift
@@ -152,18 +152,7 @@ extension ProfilePopViewController {
 
                 if result.status == 200 {
                     self.dismiss(animated: true)
-                }
-
-                else if result.status == 401 {
-                    LOGOUT()
-                    self.dismiss(animated: true)
-                    self.showToast(
-                        text: result.description,
-                        font: DesignSystemFontFamily.Pretendard.light.font(size: 14)
-                    )
-                }
-
-                else {
+                } else {
                     self.showToast(
                         text: result.description,
                         font: DesignSystemFontFamily.Pretendard.light.font(size: 14)
@@ -181,6 +170,16 @@ extension ProfilePopViewController {
                 self.panModalTransition(to: .longForm)
                 self.view.layoutIfNeeded()
             }).disposed(by: disposeBag)
+
+        viewModel.output.onLogout
+            .bind(with: self) { owner, error in
+                let toastFont = DesignSystemFontFamily.Pretendard.light.font(size: 14)
+                owner.showToast(text: error.localizedDescription, font: toastFont)
+                NotificationCenter.default.post(name: .movedTab, object: 4)
+
+                owner.dismiss(animated: true)
+            }
+            .disposed(by: disposeBag)
     }
 }
 

--- a/Projects/Features/PlayerFeature/Sources/Components/PlayerComponent.swift
+++ b/Projects/Features/PlayerFeature/Sources/Components/PlayerComponent.swift
@@ -1,3 +1,4 @@
+import AuthDomainInterface
 import CommonFeature
 import Foundation
 import LikeDomainInterface
@@ -11,6 +12,7 @@ public protocol PlayerDependency: Dependency {
     var cancelLikeSongUseCase: any CancelLikeSongUseCase { get }
     var fetchLikeNumOfSongUseCase: any FetchLikeNumOfSongUseCase { get }
     var fetchFavoriteSongsUseCase: any FetchFavoriteSongsUseCase { get }
+    var logoutUseCase: any LogoutUseCase { get }
     var playlistComponent: PlaylistComponent { get }
     var containSongsComponent: ContainSongsComponent { get }
 }
@@ -23,7 +25,8 @@ public final class PlayerComponent: Component<PlayerDependency> {
                 addLikeSongUseCase: dependency.addLikeSongUseCase,
                 cancelLikeSongUseCase: dependency.cancelLikeSongUseCase,
                 fetchLikeNumOfSongUseCase: dependency.fetchLikeNumOfSongUseCase,
-                fetchFavoriteSongsUseCase: dependency.fetchFavoriteSongsUseCase
+                fetchFavoriteSongsUseCase: dependency.fetchFavoriteSongsUseCase,
+                logoutUseCase: dependency.logoutUseCase
             ),
             playlistComponent: dependency.playlistComponent,
             containSongsComponent: dependency.containSongsComponent

--- a/Projects/Features/StorageFeature/Sources/Components/FavoriteComponent.swift
+++ b/Projects/Features/StorageFeature/Sources/Components/FavoriteComponent.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 yongbeomkwak. All rights reserved.
 //
 
+import AuthDomainInterface
 import CommonFeature
 import Foundation
 import NeedleFoundation
@@ -17,6 +18,7 @@ public protocol FavoriteDependency: Dependency {
     var fetchFavoriteSongsUseCase: any FetchFavoriteSongsUseCase { get }
     var editFavoriteSongsOrderUseCase: any EditFavoriteSongsOrderUseCase { get }
     var deleteFavoriteListUseCase: any DeleteFavoriteListUseCase { get }
+    var logoutUseCase: any LogoutUseCase { get }
 }
 
 public final class FavoriteComponent: Component<FavoriteDependency> {
@@ -25,7 +27,8 @@ public final class FavoriteComponent: Component<FavoriteDependency> {
             viewModel: .init(
                 fetchFavoriteSongsUseCase: dependency.fetchFavoriteSongsUseCase,
                 editFavoriteSongsOrderUseCase: dependency.editFavoriteSongsOrderUseCase,
-                deleteFavoriteListUseCase: dependency.deleteFavoriteListUseCase
+                deleteFavoriteListUseCase: dependency.deleteFavoriteListUseCase,
+                logoutUseCase: dependency.logoutUseCase
             ),
             containSongsComponent: dependency.containSongsComponent
         )

--- a/Projects/Features/StorageFeature/Sources/Components/MyPlayListComponent.swift
+++ b/Projects/Features/StorageFeature/Sources/Components/MyPlayListComponent.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 yongbeomkwak. All rights reserved.
 //
 
+import AuthDomainInterface
 import CommonFeature
 import Foundation
 import NeedleFoundation
@@ -17,6 +18,7 @@ public protocol MyPlayListDependency: Dependency {
     var fetchPlayListUseCase: any FetchPlayListUseCase { get }
     var editPlayListOrderUseCase: any EditPlayListOrderUseCase { get }
     var deletePlayListUseCase: any DeletePlayListUseCase { get }
+    var logoutUseCase: any LogoutUseCase { get }
 }
 
 public final class MyPlayListComponent: Component<MyPlayListDependency> {
@@ -25,7 +27,8 @@ public final class MyPlayListComponent: Component<MyPlayListDependency> {
             viewModel: .init(
                 fetchPlayListUseCase: dependency.fetchPlayListUseCase,
                 editPlayListOrderUseCase: dependency.editPlayListOrderUseCase,
-                deletePlayListUseCase: dependency.deletePlayListUseCase
+                deletePlayListUseCase: dependency.deletePlayListUseCase,
+                logoutUseCase: dependency.logoutUseCase
             ),
             multiPurposePopComponent: dependency.multiPurposePopComponent,
             playListDetailComponent: dependency.playListDetailComponent

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/FavoriteViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/FavoriteViewController.swift
@@ -173,16 +173,22 @@ extension FavoriteViewController {
             .subscribe(onNext: { [weak self] (result: BaseEntity) in
                 guard let self = self else { return }
 
-                if result.status == 401 {
-                    LOGOUT()
-                }
-
                 self.showToast(
                     text: result.description,
                     font: DesignSystemFontFamily.Pretendard.light.font(size: 14)
                 )
             })
             .disposed(by: disposeBag)
+
+        output.onLogout.bind(with: self) { owner, error in
+            NotificationCenter.default.post(name: .movedTab, object: 4)
+
+            owner.showToast(
+                text: error.localizedDescription,
+                font: DesignSystemFontFamily.Pretendard.light.font(size: 14)
+            )
+        }
+        .disposed(by: disposeBag)
     }
 
     private func createDatasources() -> RxTableViewSectionedReloadDataSource<FavoriteSectionModel> {

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/MyPlayListViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/MyPlayListViewController.swift
@@ -195,16 +195,21 @@ extension MyPlayListViewController {
                     return
                 }
 
-                if result.status == 401 {
-                    LOGOUT()
-                }
-
                 self.showToast(
                     text: result.description,
                     font: DesignSystemFontFamily.Pretendard.light.font(size: 14)
                 )
             })
             .disposed(by: disposeBag)
+
+        output.onLogout.bind(with: self) { owner, error in
+            NotificationCenter.default.post(name: .movedTab, object: 4)
+            owner.showToast(
+                text: error.localizedDescription,
+                font: DesignSystemFontFamily.Pretendard.light.font(size: 14)
+            )
+        }
+        .disposed(by: disposeBag)
     }
 
     private func createDatasources() -> RxTableViewSectionedReloadDataSource<MyPlayListSectionModel> {

--- a/Projects/Modules/Utility/Sources/Utils/Utils.swift
+++ b/Projects/Modules/Utility/Sources/Utils/Utils.swift
@@ -95,10 +95,3 @@ public func DEBUG_LOG(_ msg: Any, file: String = #file, function: String = #func
         print("[\(fileName)] \(funcName)(\(line)): \(msg)")
     #endif
 }
-
-public func LOGOUT() {
-    let keychain = KeychainImpl()
-    keychain.delete(type: .accessToken)
-    Utility.PreferenceManager.userInfo = nil
-    NotificationCenter.default.post(name: .movedTab, object: 4)
-}


### PR DESCRIPTION
## 💡 배경 및 개요
로그아웃을 처리하는 로직이 Presentation 영역에서 진행되었어요.

Resolves: #477 

## 📃 작업내용

- ContainSongs, MultiPurposePopup, PlayListDetail, ProfilePop, Player, Favorite, MyPlayList 페이지의 Logout 로직을 리팩토링했어요.
  - 도메인 로직에 해당하는 영역을 ViewModel이 하도록 옮겼어요.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
