### PR TITLE
🔀  :: (#554) pre-push 시점에 SwiftFormat 적용

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -13,6 +13,8 @@ fi
 RESULT=$($FORMAT ./Projects --config .swiftformat)
 
 if [ "$RESULT" == '' ]; then
+    git add .
+    git commit -m "🎨 :: 코드 Formatting 적용"
     printf "\n 🎉 SwiftFormat 적용을 완료했습니다 !! \n"
 else
     echo ""

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "realm/realm-swift" ~> 10.50.0
+github "realm/realm-swift" == 10.50.0


### PR DESCRIPTION
## 💡 배경 및 개요
기존에 pre-commit (커밋 전) 시점에 SwiftFormat을 돌리고 개발자가 직접 commit을 하게 했습니다.
단, 이러면서 대두된 문제점이 개발자가 꽤나 번거로움을 느끼게 되고 코드상에 Format을 진행한 커밋이 거의 절반을 먹게 될 수도 있다는 등의 문제점을 야기했습니다.
개발자가 직접 commit을 하게 된 이유는 수동으로 커밋한다면 개발자의 의지대로 커밋을 분리하기가 어려워지기 때문입니다 (pre-commit 시점에 git add . git commit -m "Formatt" 이런식으로 진행했다면 무조건 모든 작업이 하나의 커밋에 이루어져야함

이를 해결하기 위해 SwiftFormat을 자동으로 돌리는 시점을 pre-commit에서 pre-push로 시점 이동을 시킵니다

Resolves: #554 

## 📃 작업내용

- pre-commit 트리거 제거
- pre-push 파일 추가
- RealmSwift의 10.50.1버전에서 Xcode 버전과의 오류가 뜨기에 10.50.0으로 아예 exact합니다.

## 🙋‍♂️ 리뷰노트

1. 지금 pre-push 직전에 무조건 git add . git commit -m "" 를 하게 되는데 유저에게 SwiftFormat을 돌리겠습니까? 혹은 Formatting한 결과물을 commit까지 하겠습니까?를 물어볼까요?

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
