### PR TITLE
🔀 :: (#569) 설정 화면 컴포넌트를 Stub 하기 위한 내부 모듈 Stub

### DIFF
--- a/Projects/Features/MyInfoFeature/Interface/Interface.swift
+++ b/Projects/Features/MyInfoFeature/Interface/Interface.swift
@@ -7,3 +7,11 @@ public protocol MyInfoFactory {
 public protocol SettingFactory {
     func makeView() -> UIViewController
 }
+
+public protocol AppPushSettingFactory {
+    func makeView() -> UIViewController
+}
+
+public protocol OpenSourceLicenseFactory {
+    func makeView() -> UIViewController
+}

--- a/Projects/Features/MyInfoFeature/Project.swift
+++ b/Projects/Features/MyInfoFeature/Project.swift
@@ -23,6 +23,7 @@ let project = Project.module(
             )
         ),
         .testing(module: .feature(.MyInfoFeature), dependencies: [
+            .feature(target: .MyInfoFeature),
             .feature(target: .MyInfoFeature, type: .interface),
             .feature(target: .BaseFeature, type: .testing),
             .feature(target: .SignInFeature, type: .testing)

--- a/Projects/Features/MyInfoFeature/Sources/Components/AppPushSettingComponent.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Components/AppPushSettingComponent.swift
@@ -1,4 +1,4 @@
-//import BaseFeatureInterface
+// import BaseFeatureInterface
 import MyInfoFeatureInterface
 import NeedleFoundation
 import UIKit

--- a/Projects/Features/MyInfoFeature/Sources/Components/OpenSourceLicenseComponent.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Components/OpenSourceLicenseComponent.swift
@@ -1,7 +1,7 @@
 import Foundation
-import UIKit
-import NeedleFoundation
 import MyInfoFeatureInterface
+import NeedleFoundation
+import UIKit
 
 public protocol OpenSourceLicenseDependency: Dependency {}
 

--- a/Projects/Features/MyInfoFeature/Sources/Components/SettingComponent.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Components/SettingComponent.swift
@@ -27,10 +27,10 @@ public final class SettingComponent: Component<SettingDependency>, SettingFactor
             ),
             textPopUpFactory: dependency.textPopUpFactory,
             signInFactory: dependency.signInFactory,
-            appPushSettingComponent: dependency.appPushSettingComponent,
-            serviceTermsComponent: dependency.serviceTermsComponent,
-            privacyComponent: dependency.privacyComponent,
-            openSourceLicenseComponent: dependency.openSourceLicenseComponent
+            appPushSettingFactory: dependency.appPushSettingComponent,
+            serviceTermsFactory: dependency.serviceTermsComponent,
+            privacyFactory: dependency.privacyComponent,
+            openSourceLicenseFactory: dependency.openSourceLicenseComponent
         )
     }
 }

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/Setting/SettingViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/Setting/SettingViewController.swift
@@ -14,10 +14,10 @@ import Utility
 final class SettingViewController: BaseReactorViewController<SettingReactor> {
     private var textPopUpFactory: TextPopUpFactory!
     private var signInFactory: SignInFactory!
-    private var appPushSettingComponent: AppPushSettingComponent!
-    private var serviceTermsComponent: ServiceTermsComponent!
-    private var privacyComponent: PrivacyComponent!
-    private var openSourceLicenseComponent: OpenSourceLicenseComponent!
+    private var appPushSettingFactory: AppPushSettingFactory!
+    private var serviceTermsFactory: ServiceTermFactory!
+    private var privacyFactory: PrivacyFactory!
+    private var openSourceLicenseFactory: OpenSourceLicenseFactory!
 
     let settingView = SettingView()
 
@@ -29,18 +29,18 @@ final class SettingViewController: BaseReactorViewController<SettingReactor> {
         reactor: SettingReactor,
         textPopUpFactory: TextPopUpFactory,
         signInFactory: SignInFactory,
-        appPushSettingComponent: AppPushSettingComponent,
-        serviceTermsComponent: ServiceTermsComponent,
-        privacyComponent: PrivacyComponent,
-        openSourceLicenseComponent: OpenSourceLicenseComponent
+        appPushSettingFactory: AppPushSettingFactory,
+        serviceTermsFactory: ServiceTermFactory,
+        privacyFactory: PrivacyFactory,
+        openSourceLicenseFactory: OpenSourceLicenseFactory
     ) -> SettingViewController {
         let viewController = SettingViewController(reactor: reactor)
         viewController.textPopUpFactory = textPopUpFactory
         viewController.signInFactory = signInFactory
-        viewController.appPushSettingComponent = appPushSettingComponent
-        viewController.serviceTermsComponent = serviceTermsComponent
-        viewController.privacyComponent = privacyComponent
-        viewController.openSourceLicenseComponent = openSourceLicenseComponent
+        viewController.appPushSettingFactory = appPushSettingFactory
+        viewController.serviceTermsFactory = serviceTermsFactory
+        viewController.privacyFactory = privacyFactory
+        viewController.openSourceLicenseFactory = openSourceLicenseFactory
         return viewController
     }
 
@@ -52,18 +52,18 @@ final class SettingViewController: BaseReactorViewController<SettingReactor> {
                 case .dismiss:
                     owner.navigationController?.popViewController(animated: true)
                 case .appPushSetting:
-                    let vc = owner.appPushSettingComponent.makeView()
+                    let vc = owner.appPushSettingFactory.makeView()
                     owner.navigationController?.pushViewController(vc, animated: true)
                 case .serviceTerms:
-                    let vc = owner.serviceTermsComponent.makeView()
+                    let vc = owner.serviceTermsFactory.makeView()
                     vc.modalPresentationStyle = .overFullScreen
                     owner.present(vc, animated: true)
                 case .privacy:
-                    let vc = owner.privacyComponent.makeView()
+                    let vc = owner.privacyFactory.makeView()
                     vc.modalPresentationStyle = .overFullScreen
                     owner.present(vc, animated: true)
                 case .openSource:
-                    let vc = owner.openSourceLicenseComponent.makeView()
+                    let vc = owner.openSourceLicenseFactory.makeView()
                     owner.navigationController?.pushViewController(vc, animated: true)
                 }
             }

--- a/Projects/Features/MyInfoFeature/Testing/AppPushSettingComponentStub.swift
+++ b/Projects/Features/MyInfoFeature/Testing/AppPushSettingComponentStub.swift
@@ -1,5 +1,4 @@
-// import BaseFeatureInterface
-import MyInfoFeature
+@testable import MyInfoFeature
 import MyInfoFeatureInterface
 import UIKit
 

--- a/Projects/Features/MyInfoFeature/Testing/AppPushSettingComponentStub.swift
+++ b/Projects/Features/MyInfoFeature/Testing/AppPushSettingComponentStub.swift
@@ -1,4 +1,4 @@
-//import BaseFeatureInterface
+// import BaseFeatureInterface
 import MyInfoFeature
 import MyInfoFeatureInterface
 import UIKit

--- a/Projects/Features/MyInfoFeature/Testing/AppPushSettingComponentStub.swift
+++ b/Projects/Features/MyInfoFeature/Testing/AppPushSettingComponentStub.swift
@@ -1,11 +1,9 @@
 //import BaseFeatureInterface
+import MyInfoFeature
 import MyInfoFeatureInterface
-import NeedleFoundation
 import UIKit
 
-public protocol AppPushSettingDependency: Dependency {}
-
-public final class AppPushSettingComponent: Component<AppPushSettingDependency>, AppPushSettingFactory {
+public final class AppPushSettingComponentStub: AppPushSettingFactory {
     public func makeView() -> UIViewController {
         return AppPushSettingViewController.viewController(
             reactor: AppPushSettingReactor()

--- a/Projects/Features/MyInfoFeature/Testing/OpenSourceLicenseComponentStub.swift
+++ b/Projects/Features/MyInfoFeature/Testing/OpenSourceLicenseComponentStub.swift
@@ -1,5 +1,5 @@
 import Foundation
-import MyInfoFeature
+@testable import MyInfoFeature
 import MyInfoFeatureInterface
 import UIKit
 

--- a/Projects/Features/MyInfoFeature/Testing/OpenSourceLicenseComponentStub.swift
+++ b/Projects/Features/MyInfoFeature/Testing/OpenSourceLicenseComponentStub.swift
@@ -1,7 +1,7 @@
 import Foundation
-import UIKit
 import MyInfoFeature
 import MyInfoFeatureInterface
+import UIKit
 
 public final class OpenSourceLicenseComponentStub: OpenSourceLicenseFactory {
     public func makeView() -> UIViewController {

--- a/Projects/Features/MyInfoFeature/Testing/OpenSourceLicenseComponentStub.swift
+++ b/Projects/Features/MyInfoFeature/Testing/OpenSourceLicenseComponentStub.swift
@@ -1,11 +1,9 @@
 import Foundation
 import UIKit
-import NeedleFoundation
+import MyInfoFeature
 import MyInfoFeatureInterface
 
-public protocol OpenSourceLicenseDependency: Dependency {}
-
-public final class OpenSourceLicenseComponent: Component<OpenSourceLicenseDependency>, OpenSourceLicenseFactory {
+public final class OpenSourceLicenseComponentStub: OpenSourceLicenseFactory {
     public func makeView() -> UIViewController {
         return OpenSourceLicenseViewController.viewController(
             viewModel: OpenSourceLicenseViewModel()

--- a/Projects/Features/MyInfoFeature/Testing/SettingComponentStub.swift
+++ b/Projects/Features/MyInfoFeature/Testing/SettingComponentStub.swift
@@ -1,14 +1,14 @@
 import AuthDomainInterface
 import AuthDomainTesting
 import BaseFeatureInterface
+@testable import BaseFeatureTesting
+@testable import MyInfoFeature
 import MyInfoFeatureInterface
 import SignInFeatureInterface
+@testable import SignInFeatureTesting
 import UIKit
 import UserDomainInterface
 import UserDomainTesting
-@testable import MyInfoFeature
-@testable import BaseFeatureTesting
-@testable import SignInFeatureTesting
 
 public final class SettingComponentStub: SettingFactory {
     public func makeView() -> UIViewController {

--- a/Projects/Features/MyInfoFeature/Testing/SettingComponentStub.swift
+++ b/Projects/Features/MyInfoFeature/Testing/SettingComponentStub.swift
@@ -1,10 +1,11 @@
 import AuthDomainInterface
 import AuthDomainTesting
-//import BaseFeature
-import BaseFeatureTesting
 import BaseFeatureInterface
-import MyInfoFeatureInterface
+
+// import BaseFeature
+import BaseFeatureTesting
 import MyInfoFeature
+import MyInfoFeatureInterface
 import SignInFeatureInterface
 import SignInFeatureTesting
 import UIKit

--- a/Projects/Features/MyInfoFeature/Testing/SettingComponentStub.swift
+++ b/Projects/Features/MyInfoFeature/Testing/SettingComponentStub.swift
@@ -1,16 +1,14 @@
 import AuthDomainInterface
 import AuthDomainTesting
 import BaseFeatureInterface
-
-// import BaseFeature
-import BaseFeatureTesting
-import MyInfoFeature
 import MyInfoFeatureInterface
 import SignInFeatureInterface
-import SignInFeatureTesting
 import UIKit
 import UserDomainInterface
 import UserDomainTesting
+@testable import MyInfoFeature
+@testable import BaseFeatureTesting
+@testable import SignInFeatureTesting
 
 public final class SettingComponentStub: SettingFactory {
     public func makeView() -> UIViewController {
@@ -22,9 +20,9 @@ public final class SettingComponentStub: SettingFactory {
             textPopUpFactory: TextPopUpComponentStub(),
             signInFactory: SignInComponentStub(),
             appPushSettingFactory: AppPushSettingComponentStub(),
-            serviceTermsFactory: ServiceTermsComponentStub(),
+            serviceTermsFactory: ServiceTermComponentStub(),
             privacyFactory: PrivacyComponentStub(),
-            ppenSourceLicenseFactory: OpenSourceLicenseComponentStub()
+            openSourceLicenseFactory: OpenSourceLicenseComponentStub()
         )
     }
 }

--- a/Projects/Features/MyInfoFeature/Testing/SettingComponentStub.swift
+++ b/Projects/Features/MyInfoFeature/Testing/SettingComponentStub.swift
@@ -1,0 +1,29 @@
+import AuthDomainInterface
+import AuthDomainTesting
+//import BaseFeature
+import BaseFeatureTesting
+import BaseFeatureInterface
+import MyInfoFeatureInterface
+import MyInfoFeature
+import SignInFeatureInterface
+import SignInFeatureTesting
+import UIKit
+import UserDomainInterface
+import UserDomainTesting
+
+public final class SettingComponentStub: SettingFactory {
+    public func makeView() -> UIViewController {
+        return SettingViewController.viewController(
+            reactor: SettingReactor(
+                withDrawUserInfoUseCase: WithdrawUserInfoUseCaseSpy(),
+                logoutUseCase: LogoutUseCaseSpy()
+            ),
+            textPopUpFactory: TextPopUpComponentStub(),
+            signInFactory: SignInComponentStub(),
+            appPushSettingFactory: AppPushSettingComponentStub(),
+            serviceTermsFactory: ServiceTermsComponentStub(),
+            privacyFactory: PrivacyComponentStub(),
+            ppenSourceLicenseFactory: OpenSourceLicenseComponentStub()
+        )
+    }
+}

--- a/Projects/Features/MyInfoFeature/Testing/SettingComponentStub.swift
+++ b/Projects/Features/MyInfoFeature/Testing/SettingComponentStub.swift
@@ -1,5 +1,5 @@
 import AuthDomainInterface
-import AuthDomainTesting
+@testable import AuthDomainTesting
 import BaseFeatureInterface
 @testable import BaseFeatureTesting
 @testable import MyInfoFeature
@@ -8,7 +8,7 @@ import SignInFeatureInterface
 @testable import SignInFeatureTesting
 import UIKit
 import UserDomainInterface
-import UserDomainTesting
+@testable import UserDomainTesting
 
 public final class SettingComponentStub: SettingFactory {
     public func makeView() -> UIViewController {

--- a/Projects/Features/MyInfoFeature/Testing/testing.swift
+++ b/Projects/Features/MyInfoFeature/Testing/testing.swift
@@ -1,0 +1,1 @@
+// for tuist


### PR DESCRIPTION
## 💡 배경 및 개요
설정화면의 Stub을 만들기 위한 내부 모듈들의 Stub 객체를 생성해야 했습니다.

Resolves: #569

## 📃 작업내용
- MyInfoFeature 내부 컴포넌트들에 대한 Stub 객체를 생성했습니다.
- 설정화면 컴포넌트에 대한 Stub 객체를 생성했습니다.

## 🙋‍♂️ 리뷰노트
SettingComponentStub 은 Testing 모듈에 있고,
Testing모듈은 Feature를 모르기 때문에 SettingViewController 에 Cannot find 'SettingViewController' in scope 에러가 발생했습니다. 이에 대한 해결법으로 
1. Testing 모듈에 Feature 의존성을 추가한다.
2. 모든 ViewController, Reactor 를 각 ~ViewControllerType, ~ReactorType 프로토콜을 인터페이스 모듈에 만들어 채택하도록 한다.

둘 중 코스트가 더 적은 1번 방법을 사용했습니다.

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
![img](https://github.com/wakmusic/wakmusic-iOS/assets/60254939/3e460c4e-e3bb-48d0-aaa1-33820cf4271e)
위는 정석적인 TMA 모듈 의존 구조