### PR TITLE
🔀 :: (#550) 설정 네비게이션 버튼 하이라이팅 효과 추가

### DIFF
--- a/Projects/Features/MyInfoFeature/Sources/Views/SettingItemButton.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/SettingItemButton.swift
@@ -13,7 +13,7 @@ private protocol SettingItemActionProtocol {
     var didTap: Observable<Void> { get }
 }
 
-final class SettingItemView: UIButton {
+final class SettingItemButton: UIButton {
     private let leftLabel = UILabel().then {
         $0.font = .setFont(.t5(weight: .medium))
         $0.textColor = DesignSystemAsset.BlueGrayColor.blueGray900.color
@@ -53,7 +53,7 @@ final class SettingItemView: UIButton {
     }
 }
 
-extension SettingItemView {
+extension SettingItemButton {
     func addView() {
         self.addSubviews(
             leftLabel,
@@ -76,13 +76,13 @@ extension SettingItemView {
     }
 }
 
-extension Reactive: SettingItemActionProtocol where Base: SettingItemView {
+extension Reactive: SettingItemActionProtocol where Base: SettingItemButton {
     var didTap: Observable<Void> {
         return base.rx.tap.asObservable()
     }
 }
 
-extension SettingItemView: SettingItemStateProtocol {
+extension SettingItemButton: SettingItemStateProtocol {
     func updateIsHighlighted(_ isHighlited: Bool) {
         self.backgroundColor = isHighlighted ? .black.withAlphaComponent(0.2) : .clear
     }

--- a/Projects/Features/MyInfoFeature/Sources/Views/SettingItemButton.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/SettingItemButton.swift
@@ -86,5 +86,4 @@ extension SettingItemButton: SettingItemStateProtocol {
     fileprivate func updateIsHighlighted(_ isHighlited: Bool) {
         self.backgroundColor = isHighlighted ? .black.withAlphaComponent(0.2) : .clear
     }
-    
 }

--- a/Projects/Features/MyInfoFeature/Sources/Views/SettingItemButton.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/SettingItemButton.swift
@@ -5,9 +5,7 @@ import SnapKit
 import Then
 import UIKit
 
-private protocol SettingItemStateProtocol {
-    func updateIsHighlighted(_ isHighlited: Bool)
-}
+private protocol SettingItemStateProtocol {}
 
 private protocol SettingItemActionProtocol {
     var didTap: Observable<Void> { get }
@@ -51,6 +49,10 @@ final class SettingItemButton: UIButton {
     public func setRightImage(_ image: UIImage?) {
         rightImageView.image = image
     }
+    
+    private func updateIsHighlighted(_ isHighlited: Bool) {
+        self.backgroundColor = isHighlighted ? .black.withAlphaComponent(0.2) : .clear
+    }
 }
 
 extension SettingItemButton {
@@ -79,11 +81,5 @@ extension SettingItemButton {
 extension Reactive: SettingItemActionProtocol where Base: SettingItemButton {
     var didTap: Observable<Void> {
         return base.rx.tap.asObservable()
-    }
-}
-
-extension SettingItemButton: SettingItemStateProtocol {
-    func updateIsHighlighted(_ isHighlited: Bool) {
-        self.backgroundColor = isHighlighted ? .black.withAlphaComponent(0.2) : .clear
     }
 }

--- a/Projects/Features/MyInfoFeature/Sources/Views/SettingItemButton.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/SettingItemButton.swift
@@ -5,7 +5,9 @@ import SnapKit
 import Then
 import UIKit
 
-private protocol SettingItemStateProtocol {}
+private protocol SettingItemStateProtocol {
+    func updateIsHighlighted(_ isHighlited: Bool)
+}
 
 private protocol SettingItemActionProtocol {
     var didTap: Observable<Void> { get }
@@ -49,10 +51,6 @@ final class SettingItemButton: UIButton {
     public func setRightImage(_ image: UIImage?) {
         rightImageView.image = image
     }
-
-    private func updateIsHighlighted(_ isHighlited: Bool) {
-        self.backgroundColor = isHighlighted ? .black.withAlphaComponent(0.2) : .clear
-    }
 }
 
 extension SettingItemButton {
@@ -82,4 +80,11 @@ extension Reactive: SettingItemActionProtocol where Base: SettingItemButton {
     var didTap: Observable<Void> {
         return base.rx.tap.asObservable()
     }
+}
+
+extension SettingItemButton: SettingItemStateProtocol {
+    fileprivate func updateIsHighlighted(_ isHighlited: Bool) {
+        self.backgroundColor = isHighlighted ? .black.withAlphaComponent(0.2) : .clear
+    }
+    
 }

--- a/Projects/Features/MyInfoFeature/Sources/Views/SettingItemButton.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/SettingItemButton.swift
@@ -25,13 +25,13 @@ final class SettingItemButton: UIButton {
     }
 
     private let horizontalInset: CGFloat
-    
+
     override var isHighlighted: Bool {
         didSet {
             updateIsHighlighted(isHighlighted)
         }
     }
-    
+
     public init(horizontalInset: CGFloat = 20) {
         self.horizontalInset = horizontalInset
         super.init(frame: .zero)

--- a/Projects/Features/MyInfoFeature/Sources/Views/SettingItemButton.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/SettingItemButton.swift
@@ -49,7 +49,7 @@ final class SettingItemButton: UIButton {
     public func setRightImage(_ image: UIImage?) {
         rightImageView.image = image
     }
-    
+
     private func updateIsHighlighted(_ isHighlited: Bool) {
         self.backgroundColor = isHighlighted ? .black.withAlphaComponent(0.2) : .clear
     }

--- a/Projects/Features/MyInfoFeature/Sources/Views/SettingItemView.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/SettingItemView.swift
@@ -5,11 +5,15 @@ import SnapKit
 import Then
 import UIKit
 
+private protocol SettingItemStateProtocol {
+    func updateIsHighlighted(_ isHighlited: Bool)
+}
+
 private protocol SettingItemActionProtocol {
     var didTap: Observable<Void> { get }
 }
 
-final class SettingItemView: UIView {
+final class SettingItemView: UIButton {
     private let leftLabel = UILabel().then {
         $0.font = .setFont(.t5(weight: .medium))
         $0.textColor = DesignSystemAsset.BlueGrayColor.blueGray900.color
@@ -21,7 +25,13 @@ final class SettingItemView: UIView {
     }
 
     private let horizontalInset: CGFloat
-
+    
+    override var isHighlighted: Bool {
+        didSet {
+            updateIsHighlighted(isHighlighted)
+        }
+    }
+    
     public init(horizontalInset: CGFloat = 20) {
         self.horizontalInset = horizontalInset
         super.init(frame: .zero)
@@ -68,9 +78,12 @@ extension SettingItemView {
 
 extension Reactive: SettingItemActionProtocol where Base: SettingItemView {
     var didTap: Observable<Void> {
-        let tapGestureRecognizer = UITapGestureRecognizer()
-        base.addGestureRecognizer(tapGestureRecognizer)
-        base.isUserInteractionEnabled = true
-        return tapGestureRecognizer.rx.event.map { _ in }.asObservable()
+        return base.rx.tap.asObservable()
+    }
+}
+
+extension SettingItemView: SettingItemStateProtocol {
+    func updateIsHighlighted(_ isHighlited: Bool) {
+        self.backgroundColor = isHighlighted ? .black.withAlphaComponent(0.2) : .clear
     }
 }

--- a/Projects/Features/MyInfoFeature/Sources/Views/SettingView.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/SettingView.swift
@@ -58,27 +58,27 @@ final class SettingView: UIView {
         $0.axis = .vertical
     }
 
-    fileprivate let notiNavgationButton = SettingItemView().then {
+    fileprivate let notiNavgationButton = SettingItemButton().then {
         $0.setLeftTitle("앱 알림 받기")
     }
 
-    fileprivate let termNavgationButton = SettingItemView().then {
+    fileprivate let termNavgationButton = SettingItemButton().then {
         $0.setLeftTitle("서비스 이용약관")
     }
 
-    fileprivate let privacyNavgationButton = SettingItemView().then {
+    fileprivate let privacyNavgationButton = SettingItemButton().then {
         $0.setLeftTitle("개인정보 처리 방침")
     }
 
-    fileprivate let openSourceNavgationButton = SettingItemView().then {
+    fileprivate let openSourceNavgationButton = SettingItemButton().then {
         $0.setLeftTitle("오픈소스 라이선스")
     }
 
-    fileprivate let removeCacheButton = SettingItemView().then {
+    fileprivate let removeCacheButton = SettingItemButton().then {
         $0.setLeftTitle("캐시 데이터 지우기")
     }
 
-    fileprivate let versionInfoButton = SettingItemView().then {
+    fileprivate let versionInfoButton = SettingItemButton().then {
         $0.setLeftTitle("버전 정보")
         $0.setRightImage(nil)
     }


### PR DESCRIPTION
## 💡 배경 및 개요
좀더 예쁘게 만들고 싶었어요

## 📃 작업내용

https://github.com/wakmusic/wakmusic-iOS/assets/60254939/e4a3d605-ad64-46ec-b3d9-f4278ee1a618

- 상속을 UIView -> UIButton 로 변경
- 하이라이팅 효과 추가

## 🙋‍♂️ 리뷰노트

https://github.com/wakmusic/wakmusic-iOS/assets/60254939/891ad877-3362-4617-85b6-3d11304f95c1

글자에도 opacity 줄 수 있는데 어떤게 더 예쁜가요?

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
