### PR TITLE
🔀 :: (#550) 회원탈퇴 버튼 디자인 및 위치 변경

### DIFF
--- a/Projects/Features/MyInfoFeature/Sources/Views/SettingView.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/SettingView.swift
@@ -37,16 +37,6 @@ final class SettingView: UIView {
         $0.setTextWithAttributes(kernValue: -0.5)
     }
 
-    fileprivate let withDrawButton = UIButton().then {
-        $0.setTitle("회원탈퇴", for: .normal)
-        $0.titleLabel?.font = .setFont(.t7(weight: .bold))
-        $0.titleLabel?.setTextWithAttributes(kernValue: -0.5)
-        $0.setTitleColor(DesignSystemAsset.BlueGrayColor.blueGray400.color, for: .normal)
-        $0.layer.cornerRadius = 4
-        $0.layer.borderWidth = 1
-        $0.layer.borderColor = DesignSystemAsset.BlueGrayColor.blueGray300.color.cgColor
-    }
-
     private let versionLabel = UILabel().then {
         $0.text = "0.0.0"
         $0.font = DesignSystemFontFamily.SCoreDream._3Light.font(size: 12)
@@ -87,15 +77,7 @@ final class SettingView: UIView {
         $0.image = DesignSystemAsset.MyInfo.dot.image
     }
 
-    private let descriptionLabel = UILabel().then {
-        $0.numberOfLines = 0
-        $0.textColor = .black
-        $0.text = "왁타버스 뮤직 팀에 속한 모든 팀원들은 부아내비 (부려먹는 게 아니라 내가 비빈 거다)라는 모토를 가슴에 새기고 일하고 있습니다."
-        $0.font = .setFont(.t7(weight: .light))
-        $0.textColor = DesignSystemAsset.BlueGrayColor.blueGray500.color
-        $0.lineBreakMode = .byWordWrapping
-        $0.setTextWithAttributes(kernValue: -0.5)
-    }
+    fileprivate let withDrawLabel = WithDrawLabel()
 
     init() {
         super.init(frame: .zero)
@@ -118,7 +100,7 @@ private extension SettingView {
             vStackView,
             versionLabel,
             dotImageView,
-            descriptionLabel
+            withDrawLabel
         )
         vStackView.addArrangedSubviews(
             notiNavgationButton,
@@ -137,16 +119,11 @@ private extension SettingView {
             $0.height.equalTo(48)
         }
         wmNavigationbarView.setLeftViews([dismissButton])
-        wmNavigationbarView.setRightViews([withDrawButton])
 
         titleLabel.snp.makeConstraints {
             $0.center.equalTo(wmNavigationbarView.snp.center)
         }
 
-        withDrawButton.snp.makeConstraints {
-            $0.width.equalTo(64)
-            $0.height.equalTo(24)
-        }
         vStackView.snp.makeConstraints {
             $0.top.equalTo(wmNavigationbarView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
@@ -160,9 +137,10 @@ private extension SettingView {
         dotImageView.snp.makeConstraints {
             $0.top.equalTo(vStackView.snp.bottom).offset(12)
             $0.left.equalToSuperview().offset(20)
+            $0.width.height.equalTo(16)
         }
 
-        descriptionLabel.snp.makeConstraints {
+        withDrawLabel.snp.makeConstraints {
             $0.top.equalTo(vStackView.snp.bottom).offset(12)
             $0.left.equalTo(dotImageView.snp.right)
             $0.right.equalToSuperview().inset(20)
@@ -174,7 +152,7 @@ extension SettingView: SettingStateProtocol {}
 
 extension Reactive: SettingActionProtocol where Base: SettingView {
     var dismissButtonDidTap: Observable<Void> { base.dismissButton.rx.tap.asObservable() }
-    var withDrawButtonDidTap: Observable<Void> { base.withDrawButton.rx.tap.asObservable() }
+    var withDrawButtonDidTap: Observable<Void> { base.withDrawLabel.rx.didTap }
     var appPushSettingNavigationButtonDidTap: Observable<Void> { base.notiNavgationButton.rx.didTap }
     var termsNavigationButtonDidTap: Observable<Void> { base.termNavgationButton.rx.didTap }
     var privacyNavigationButtonDidTap: Observable<Void> { base.privacyNavgationButton.rx.didTap }

--- a/Projects/Features/MyInfoFeature/Sources/Views/WithDrawLabel.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/WithDrawLabel.swift
@@ -1,0 +1,46 @@
+import DesignSystem
+import RxCocoa
+import RxSwift
+import UIKit
+
+private protocol WithDrawLabelActionProtocol {
+    var didTap: Observable<Void> { get }
+}
+
+final class WithDrawLabel: UILabel {
+    let target = "여기"
+
+    init(_ text: String = "회원 탈퇴를 원하신다면 여기를 눌러주세요.") {
+        super.init(frame: .zero)
+        self.text = text
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    func configure() {
+        guard let text = self.text else { return }
+        let attrStr = NSMutableAttributedString(string: text)
+        let fullRange = NSRange(location: 0, length: attrStr.length)
+        let targetRange = (text as NSString).range(of: target)
+        let color = DesignSystemAsset.BlueGrayColor.blueGray500.color
+        let font = UIFont.setFont(.t7(weight: .light))
+        attrStr.addAttribute(.foregroundColor, value: color, range: fullRange)
+        attrStr.addAttribute(.font, value: font, range: fullRange)
+        attrStr.addAttribute(.kern, value: -0.5, range: fullRange)
+        attrStr.addAttribute(.underlineStyle, value: 1, range: targetRange)
+
+        self.attributedText = attrStr
+    }
+}
+
+extension Reactive: WithDrawLabelActionProtocol where Base: WithDrawLabel {
+    var didTap: Observable<Void> {
+        let tapGestureRecognizer = UITapGestureRecognizer()
+        base.addGestureRecognizer(tapGestureRecognizer)
+        base.isUserInteractionEnabled = true
+        return tapGestureRecognizer.rx.event.map { _ in }.asObservable()
+    }
+}

--- a/Projects/Features/MyInfoFeature/Sources/Views/WithDrawLabel.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/WithDrawLabel.swift
@@ -8,7 +8,7 @@ private protocol WithDrawLabelActionProtocol {
 }
 
 final class WithDrawLabel: UILabel {
-    let target = "여기"
+    private let target = "여기"
 
     init(_ text: String = "회원 탈퇴를 원하신다면 여기를 눌러주세요.") {
         super.init(frame: .zero)


### PR DESCRIPTION
## 💡 배경 및 개요
디자인이 변경되었어요

## 📃 작업내용
<img src = "https://github.com/wakmusic/wakmusic-iOS/assets/60254939/143a5db8-0aa5-457d-9b1d-84f6932f0790" width = "50%">

## 🙋‍♂️ 리뷰노트
-`여기` 이 부분에만 터치 이벤트를 적용하고싶긴 한데, 중요한 기능은 아니라 간단하게 label 전체에 대해 터치 이벤트를 받도록 두었습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
