### PR TITLE
🔀 :: (#596) 공지 화면 리팩토링

### DIFF
--- a/Projects/Features/BaseFeature/Sources/Views/NoticeCollectionViewCell.swift
+++ b/Projects/Features/BaseFeature/Sources/Views/NoticeCollectionViewCell.swift
@@ -10,7 +10,7 @@ import NoticeDomainInterface
 import UIKit
 import Utility
 
-public class NoticeCollectionViewCell: UICollectionViewCell {
+public final class NoticeCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var contentImageView: UIImageView!
 
     override public func awakeFromNib() {

--- a/Projects/Features/MainTabFeature/Sources/Components/NoticePopupComponent.swift
+++ b/Projects/Features/MainTabFeature/Sources/Components/NoticePopupComponent.swift
@@ -15,9 +15,7 @@ public protocol NoticePopupDependency: Dependency {}
 public final class NoticePopupComponent: Component<NoticePopupDependency> {
     public func makeView(model: [FetchNoticeEntity]) -> NoticePopupViewController {
         return NoticePopupViewController.viewController(
-            viewModel: .init(
-                fetchNoticeEntities: model
-            )
+            viewModel: .init(noticeEntities: model)
         )
     }
 }

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
@@ -30,10 +30,13 @@ public final class MainTabBarViewController: BaseViewController, ViewControllerF
         ]
     }()
 
-    var viewModel: MainTabBarViewModel!
+    private var viewModel: MainTabBarViewModel!
+    private lazy var input = MainTabBarViewModel.Input()
+    private lazy var output = viewModel.transform(from: input)
+    private let disposeBag: DisposeBag = DisposeBag()
+
     private var previousIndex: Int?
     private var selectedIndex: Int = Utility.PreferenceManager.startPage ?? 0
-    private var disposeBag: DisposeBag = DisposeBag()
 
     private var homeComponent: HomeComponent!
     private var chartComponent: ChartComponent!
@@ -48,7 +51,8 @@ public final class MainTabBarViewController: BaseViewController, ViewControllerF
     override public func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
-        bind()
+        outputBind()
+        inputBind()
     }
 
     override public func viewDidAppear(_ animated: Bool) {
@@ -89,9 +93,12 @@ public final class MainTabBarViewController: BaseViewController, ViewControllerF
 }
 
 private extension MainTabBarViewController {
-    func bind() {
-        viewModel.output
-            .dataSource
+    func inputBind() {
+        input.fetchNoticePopup.onNext(())
+    }
+
+    func outputBind() {
+        output.dataSource
             .filter { !$0.isEmpty }
             .bind(with: self) { owner, model in
                 let viewController = owner.noticePopupComponent.makeView(model: model)
@@ -144,6 +151,7 @@ extension MainTabBarViewController: NoticePopupViewControllerDelegate {
             let viewController = noticeDetailComponent.makeView(model: model)
             viewController.modalPresentationStyle = .overFullScreen
             present(viewController, animated: true)
+
         } else {
             guard let URL = URL(string: model.thumbnail.link) else { return }
             present(SFSafariViewController(url: URL), animated: true)

--- a/Projects/Features/MainTabFeature/Sources/ViewModels/MainTabBarViewModel.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewModels/MainTabBarViewModel.swift
@@ -8,31 +8,34 @@
 
 import Foundation
 import NoticeDomainInterface
-import RxCocoa
+import RxRelay
 import RxSwift
 import Utility
 
 public final class MainTabBarViewModel {
-    let input = Input()
-    let output = Output()
+    private let fetchNoticeUseCase: FetchNoticeUseCase
     private let disposeBag = DisposeBag()
-    private var fetchNoticeUseCase: FetchNoticeUseCase
-
-    public struct Input {}
-
-    public struct Output {
-        let dataSource: BehaviorRelay<[FetchNoticeEntity]> = BehaviorRelay(value: [])
-    }
 
     public init(
         fetchNoticeUseCase: any FetchNoticeUseCase
     ) {
         self.fetchNoticeUseCase = fetchNoticeUseCase
+    }
 
+    public struct Input {
+        let fetchNoticePopup: PublishSubject<Void> = PublishSubject()
+    }
+
+    public struct Output {
+        let dataSource: BehaviorRelay<[FetchNoticeEntity]> = BehaviorRelay(value: [])
+    }
+
+    public func transform(from input: Input) -> Output {
+        let output = Output()
         let igoredNoticeIds: [Int] = Utility.PreferenceManager.ignoredNoticeIDs ?? []
         DEBUG_LOG("igoredNoticeIds: \(igoredNoticeIds)")
 
-        self.fetchNoticeUseCase.execute(type: .popup)
+        fetchNoticeUseCase.execute(type: .popup)
             .catchAndReturn([])
             .asObservable()
             .map { entities in
@@ -44,5 +47,7 @@ public final class MainTabBarViewModel {
             .debug("igoredNoticeIds")
             .bind(to: output.dataSource)
             .disposed(by: disposeBag)
+
+        return output
     }
 }

--- a/Projects/Features/MainTabFeature/Sources/ViewModels/MainTabBarViewModel.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewModels/MainTabBarViewModel.swift
@@ -35,9 +35,11 @@ public final class MainTabBarViewModel {
         let igoredNoticeIds: [Int] = Utility.PreferenceManager.ignoredNoticeIDs ?? []
         DEBUG_LOG("igoredNoticeIds: \(igoredNoticeIds)")
 
-        fetchNoticeUseCase.execute(type: .popup)
-            .catchAndReturn([])
-            .asObservable()
+        input.fetchNoticePopup
+            .flatMap { [fetchNoticeUseCase] _ -> Single<[FetchNoticeEntity]> in
+                return fetchNoticeUseCase.execute(type: .popup)
+                    .catchAndReturn([])
+            }
             .map { entities in
                 guard !igoredNoticeIds.isEmpty else { return entities }
                 return entities.filter { entity in

--- a/Projects/Features/StorageFeature/Resources/Storage.storyboard
+++ b/Projects/Features/StorageFeature/Resources/Storage.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -1291,7 +1291,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bau-r8-IYJ">
-                                        <rect key="frame" x="341" y="8" width="32" height="32"/>
+                                        <rect key="frame" x="20" y="8" width="32" height="32"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="32" id="EfH-Ea-DGB"/>
                                             <constraint firstAttribute="width" constant="32" id="pSQ-p0-GN8"/>
@@ -1303,7 +1303,7 @@
                                     </button>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="bau-r8-IYJ" secondAttribute="trailing" constant="20" id="7zI-kw-Dbm"/>
+                                    <constraint firstItem="bau-r8-IYJ" firstAttribute="leading" secondItem="dDG-n2-HUg" secondAttribute="leading" constant="20" id="AbW-Fp-9vs"/>
                                     <constraint firstItem="ZeI-bM-ifs" firstAttribute="centerX" secondItem="dDG-n2-HUg" secondAttribute="centerX" id="Bro-3U-9V5"/>
                                     <constraint firstItem="bau-r8-IYJ" firstAttribute="centerY" secondItem="dDG-n2-HUg" secondAttribute="centerY" id="Phy-sj-AbE"/>
                                     <constraint firstItem="ZeI-bM-ifs" firstAttribute="centerY" secondItem="dDG-n2-HUg" secondAttribute="centerY" id="Y6a-bb-YSu"/>
@@ -1836,7 +1836,7 @@
     </scenes>
     <resources>
         <namedColor name="POINT">
-            <color red="0.035999998450279236" green="0.7850000262260437" blue="0.94999998807907104" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.035294117647058823" green="0.78431372549019607" blue="0.94901960784313721" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="blueGray100">
             <color red="0.94900000095367432" green="0.9570000171661377" blue="0.96899998188018799" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/NoticeDetailViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/NoticeDetailViewController.swift
@@ -77,9 +77,9 @@ private extension NoticeDetailViewController {
             .disposed(by: disposeBag)
 
         output.goSafariScene
-            .bind(with: self) { owner, link in
-                guard let URL = URL(string: link) else { return }
-                owner.present(SFSafariViewController(url: URL), animated: true)
+            .compactMap { URL(string: $0)
+            .bind(with: self) { owner, url in
+                owner.present(SFSafariViewController(url: url), animated: true)
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/NoticeDetailViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/NoticeDetailViewController.swift
@@ -77,7 +77,7 @@ private extension NoticeDetailViewController {
             .disposed(by: disposeBag)
 
         output.goSafariScene
-            .compactMap { URL(string: $0)
+            .compactMap { URL(string: $0) }
             .bind(with: self) { owner, url in
                 owner.present(SFSafariViewController(url: url), animated: true)
             }

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/NoticeViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/NoticeViewController.swift
@@ -14,20 +14,23 @@ import RxSwift
 import UIKit
 import Utility
 
-public class NoticeViewController: UIViewController, ViewControllerFromStoryBoard {
+public final class NoticeViewController: UIViewController, ViewControllerFromStoryBoard {
     @IBOutlet weak var titleStringLabel: UILabel!
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var backButton: UIButton!
     @IBOutlet weak var indicator: NVActivityIndicatorView!
 
-    var viewModel: NoticeViewModel!
-    var noticeDetailComponent: NoticeDetailComponent!
-    var disposeBag = DisposeBag()
+    private var noticeDetailComponent: NoticeDetailComponent!
+    private var viewModel: NoticeViewModel!
+    private lazy var input = NoticeViewModel.Input()
+    private lazy var output = viewModel.transform(from: input)
+    private let disposeBag = DisposeBag()
 
     override public func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
-        bind()
+        outputBind()
+        inputBind()
     }
 
     public static func viewController(
@@ -46,18 +49,27 @@ public class NoticeViewController: UIViewController, ViewControllerFromStoryBoar
 }
 
 private extension NoticeViewController {
-    func bind() {
-        tableView.rx.setDelegate(self).disposed(by: disposeBag)
+    func inputBind() {
+        input.fetchNotice.onNext(())
 
-        viewModel.output.dataSource
+        tableView.rx.itemSelected
+            .do(onNext: { [tableView] indexPath in
+                tableView?.deselectRow(at: indexPath, animated: true)
+            })
+            .bind(to: input.didTapList)
+            .disposed(by: disposeBag)
+    }
+
+    func outputBind() {
+        output.dataSource
             .skip(1)
-            .do(onNext: { [weak self] model in
-                self?.indicator.stopAnimating()
+            .do(onNext: { [indicator, tableView] model in
+                indicator?.stopAnimating()
                 let space = APP_HEIGHT() - 48 - STATUS_BAR_HEGHIT() - SAFEAREA_BOTTOM_HEIGHT()
                 let height = space / 3 * 2
                 let warningView = WarningView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: height))
                 warningView.text = "공지사항이 없습니다."
-                self?.tableView.tableFooterView = model.isEmpty ? warningView : UIView(frame: CGRect(
+                tableView?.tableFooterView = model.isEmpty ? warningView : UIView(frame: CGRect(
                     x: 0,
                     y: 0,
                     width: APP_WIDTH(),
@@ -77,23 +89,23 @@ private extension NoticeViewController {
             }
             .disposed(by: disposeBag)
 
-        tableView.rx.itemSelected
-            .withLatestFrom(viewModel.output.dataSource) { ($0, $1) }
-            .subscribe(onNext: { [weak self] indexPath, model in
-                guard let self = self else { return }
-                self.tableView.deselectRow(at: indexPath, animated: true)
-                let viewController = self.noticeDetailComponent.makeView(model: model[indexPath.row])
+        output.goNoticeDetailScene
+            .bind(with: self) { owner, model in
+                let viewController = owner.noticeDetailComponent.makeView(model: model)
                 viewController.modalPresentationStyle = .overFullScreen
-                self.present(viewController, animated: true)
-            })
+                owner.present(viewController, animated: true)
+            }
             .disposed(by: disposeBag)
     }
 
     func configureUI() {
-        self.view.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
-        self.tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: 56))
-        self.tableView.verticalScrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: 56, right: 0)
-        self.backButton.setImage(DesignSystemAsset.Navigation.back.image, for: .normal)
+        view.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
+        backButton.setImage(DesignSystemAsset.Navigation.back.image, for: .normal)
+
+        tableView.rx.setDelegate(self).disposed(by: disposeBag)
+        tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: 56))
+        tableView.verticalScrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: 56, right: 0)
+
         let attributedString: NSAttributedString = NSAttributedString(
             string: "공지사항",
             attributes: [
@@ -102,10 +114,11 @@ private extension NoticeViewController {
                 .kern: -0.5
             ]
         )
-        self.titleStringLabel.attributedText = attributedString
-        self.indicator.type = .circleStrokeSpin
-        self.indicator.color = DesignSystemAsset.PrimaryColor.point.color
-        self.indicator.startAnimating()
+        titleStringLabel.attributedText = attributedString
+
+        indicator.type = .circleStrokeSpin
+        indicator.color = DesignSystemAsset.PrimaryColor.point.color
+        indicator.startAnimating()
     }
 }
 

--- a/Projects/Features/StorageFeature/Sources/ViewModels/NoticeDetailViewModel.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewModels/NoticeDetailViewModel.swift
@@ -13,75 +13,79 @@ import NoticeDomainInterface
 import RxCocoa
 import RxSwift
 import Utility
+import LogManager
 
 public final class NoticeDetailViewModel {
-    let input = Input()
-    let output = Output()
+    private let model: FetchNoticeEntity
     private let disposeBag = DisposeBag()
 
     deinit {
         DEBUG_LOG("❌ \(Self.self) Deinit")
     }
 
+    public init(model: FetchNoticeEntity) {
+        self.model = model
+    }
+
     public struct Input {
         let fetchNoticeDetail: PublishSubject<Void> = PublishSubject()
+        let didTapImage: PublishSubject<IndexPath> = PublishSubject()
     }
 
     public struct Output {
         let dataSource: BehaviorRelay<[NoticeDetailSectionModel]> = BehaviorRelay(value: [])
         let imageSizes: BehaviorRelay<[CGSize]> = BehaviorRelay(value: [])
+        let goSafariScene: PublishSubject<String> = PublishSubject()
     }
 
-    public init(
-        model: FetchNoticeEntity
-    ) {
-        let sectionModel = [NoticeDetailSectionModel(
-            model: model,
-            items: model.origins
-        )]
-
+    public func transform(from input: Input) -> Output {
+        let output = Output()
+        let sectionModel = [NoticeDetailSectionModel(model: model, items: model.origins)]
         let imageURLs: [URL] = model.origins.map { URL(string: $0.url) }.compactMap { $0 }
 
         input.fetchNoticeDetail
             .flatMap { [weak self] _ -> Observable<[CGSize]> in
-                guard let self else { return Observable.empty() }
-                return imageURLs.isEmpty ? Observable.just([]) : self.downloadImage(urls: imageURLs)
+                guard let self = self else { return .never() }
+                return Observable.zip(
+                    imageURLs.map { self.downloadImageSize(url: $0) }
+                )
             }
-            .subscribe(onNext: { [weak self] imageSizes in
-                self?.output.imageSizes.accept(imageSizes)
-                self?.output.dataSource.accept(sectionModel)
-            })
+            .bind { imageSizes in
+                output.imageSizes.accept(imageSizes)
+                output.dataSource.accept(sectionModel)
+            }
             .disposed(by: disposeBag)
+
+        input.didTapImage
+            .withLatestFrom(output.dataSource) { ($0, $1) }
+            .map { $0.1[$0.0.section].items[$0.0.item] }
+            .filter { !$0.link.isEmpty }
+            .map { $0.link }
+            .bind(to: output.goSafariScene)
+            .disposed(by: disposeBag)
+
+        return output
     }
 }
 
 private extension NoticeDetailViewModel {
-    func downloadImage(urls: [URL]) -> Observable<[CGSize]> {
-        var sizes: [CGSize] = []
-        return Observable.create { observer -> Disposable in
-            urls.forEach {
-                KingfisherManager.shared.retrieveImage(
-                    with: $0,
-                    completionHandler: { result in
-                        switch result {
-                        case let .success(value):
-                            sizes.append(CGSize(width: value.image.size.width, height: value.image.size.height))
-                            if urls.count == sizes.count {
-                                observer.onNext(sizes)
-                                observer.onCompleted()
-                            }
-                        case let .failure(error):
-                            DEBUG_LOG(error.localizedDescription)
-                            sizes.append(.zero)
-                            if urls.count == sizes.count {
-                                observer.onNext(sizes)
-                                observer.onCompleted()
-                            }
-                        }
-                    }
-                )
+    func downloadImageSize(url: URL) -> Observable<CGSize> {
+        return Observable.create { observer in
+            KingfisherManager.shared.retrieveImage(
+                with: url
+            ) { result in
+                switch result {
+                case let .success(value):
+                    observer.onNext(value.image.size)
+                    observer.onCompleted()
+
+                case let .failure(error):
+                    LogManager.printDebug(error.localizedDescription)
+                    observer.onNext(.zero)
+                    observer.onCompleted()
+                }
             }
-            return Disposables.create {}
+            return Disposables.create()
         }
     }
 }

--- a/Projects/Features/StorageFeature/Sources/ViewModels/NoticeDetailViewModel.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewModels/NoticeDetailViewModel.swift
@@ -9,11 +9,11 @@
 import BaseFeature
 import Foundation
 import Kingfisher
+import LogManager
 import NoticeDomainInterface
 import RxCocoa
 import RxSwift
 import Utility
-import LogManager
 
 public final class NoticeDetailViewModel {
     private let model: FetchNoticeEntity

--- a/Projects/Features/StorageFeature/Sources/ViewModels/NoticeViewModel.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewModels/NoticeViewModel.swift
@@ -9,31 +9,47 @@
 import BaseFeature
 import Foundation
 import NoticeDomainInterface
-import RxCocoa
+import RxRelay
 import RxSwift
 import Utility
 
-public class NoticeViewModel {
-    let input = Input()
-    let output = Output()
-    var disposeBag = DisposeBag()
-    var fetchNoticeUseCase: FetchNoticeUseCase
-
-    public struct Input {}
-
-    public struct Output {
-        var dataSource: BehaviorRelay<[FetchNoticeEntity]> = BehaviorRelay(value: [])
-    }
+public final class NoticeViewModel {
+    private let fetchNoticeUseCase: FetchNoticeUseCase
+    private let disposeBag = DisposeBag()
 
     public init(
         fetchNoticeUseCase: any FetchNoticeUseCase
     ) {
         self.fetchNoticeUseCase = fetchNoticeUseCase
+    }
 
-        self.fetchNoticeUseCase.execute(type: .all)
-            .catchAndReturn([])
-            .asObservable()
+    public struct Input {
+        let fetchNotice: PublishSubject<Void> = PublishSubject()
+        let didTapList: PublishSubject<IndexPath> = PublishSubject()
+    }
+
+    public struct Output {
+        let dataSource: BehaviorRelay<[FetchNoticeEntity]> = BehaviorRelay(value: [])
+        let goNoticeDetailScene: PublishSubject<FetchNoticeEntity> = PublishSubject()
+    }
+
+    public func transform(from input: Input) -> Output {
+        let output = Output()
+
+        input.fetchNotice
+            .flatMap { [fetchNoticeUseCase] _ -> Single<[FetchNoticeEntity]> in
+                return fetchNoticeUseCase.execute(type: .all)
+                    .catchAndReturn([])
+            }
             .bind(to: output.dataSource)
             .disposed(by: disposeBag)
+
+        input.didTapList
+            .withLatestFrom(output.dataSource) { ($0, $1) }
+            .map { $0.1[$0.0.row] }
+            .bind(to: output.goNoticeDetailScene)
+            .disposed(by: disposeBag)
+
+        return output
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요
NoticeDomain 변경사항 반영하다보니 이건 뭐지 싶어서 리팩.

Resolves: #596 

## 📃 작업내용
대상: 공지팝업, 공지리스트, 공지상세 
- 뷰모델의 역할을 명확히 해보려 노력함.
- UI코드는 건드리지 않음. (닫기버튼 좌측으로 옮긴것 제외)

## 🙋‍♂️ 리뷰노트
공지상세(컬렉션 뷰)의 셀은 이미지로만(여러개 가능) 이루어지고, 현재는 다운로드가 완료된 다음 사이즈를 알아내 컬렉션 뷰를 셋팅하는 형태인데,
이거 셀프사이징 가능한가요? 아는분?

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
