### PR TITLE
🔀 :: (#500) AuthDomain api 변경사항 반영

### DIFF
--- a/Projects/App/Sources/Application/AppComponent+Auth.swift
+++ b/Projects/App/Sources/Application/AppComponent+Auth.swift
@@ -50,7 +50,7 @@ public extension AppComponent {
             FetchTokenUseCaseImpl(authRepository: authRepository)
         }
     }
-    
+
     var regenerateAccessTokenUseCase: any ReGenerateAccessTokenUseCase {
         shared {
             ReGenerateAccessTokenUseCaseImpl(authRepository: authRepository)

--- a/Projects/App/Sources/Application/AppComponent+Auth.swift
+++ b/Projects/App/Sources/Application/AppComponent+Auth.swift
@@ -50,6 +50,12 @@ public extension AppComponent {
             FetchTokenUseCaseImpl(authRepository: authRepository)
         }
     }
+    
+    var regenerateAccessTokenUseCase: any ReGenerateAccessTokenUseCase {
+        shared {
+            ReGenerateAccessTokenUseCaseImpl(authRepository: authRepository)
+        }
+    }
 
     var fetchNaverUserInfoUseCase: any FetchNaverUserInfoUseCase {
         shared {

--- a/Projects/Domains/AuthDomain/Interface/DataSource/RemoteAuthDataSource.swift
+++ b/Projects/Domains/AuthDomain/Interface/DataSource/RemoteAuthDataSource.swift
@@ -2,6 +2,6 @@ import Foundation
 import RxSwift
 
 public protocol RemoteAuthDataSource {
-    func fetchToken(token: String, type: ProviderType) -> Single<AuthLoginEntity>
+    func fetchToken(providerType: ProviderType, token: String) -> Single<AuthLoginEntity>
     func fetchNaverUserInfo(tokenType: String, accessToken: String) -> Single<NaverUserInfoEntity>
 }

--- a/Projects/Domains/AuthDomain/Interface/DataSource/RemoteAuthDataSource.swift
+++ b/Projects/Domains/AuthDomain/Interface/DataSource/RemoteAuthDataSource.swift
@@ -3,5 +3,6 @@ import RxSwift
 
 public protocol RemoteAuthDataSource {
     func fetchToken(providerType: ProviderType, token: String) -> Single<AuthLoginEntity>
+    func reGenerateAccessToken() -> Single<AuthLoginEntity>
     func fetchNaverUserInfo(tokenType: String, accessToken: String) -> Single<NaverUserInfoEntity>
 }

--- a/Projects/Domains/AuthDomain/Interface/Entity/AuthLoginEntity.swift
+++ b/Projects/Domains/AuthDomain/Interface/Entity/AuthLoginEntity.swift
@@ -1,11 +1,3 @@
-//
-//  RecommendPlayListEntity.swift
-//  DomainModuleTests
-//
-//  Created by yongbeomkwak on 2023/02/10.
-//  Copyright © 2023 yongbeomkwak. All rights reserved.
-//
-
 import Foundation
 
 public struct AuthLoginEntity: Equatable {

--- a/Projects/Domains/AuthDomain/Interface/Repository/AuthRepository.swift
+++ b/Projects/Domains/AuthDomain/Interface/Repository/AuthRepository.swift
@@ -2,7 +2,7 @@ import Foundation
 import RxSwift
 
 public protocol AuthRepository {
-    func fetchToken(token: String, type: ProviderType) -> Single<AuthLoginEntity>
+    func fetchToken(providerType: ProviderType, token: String) -> Single<AuthLoginEntity>
     func fetchNaverUserInfo(tokenType: String, accessToken: String) -> Single<NaverUserInfoEntity>
     func logout() -> Completable
     func checkIsExistAccessToken() -> Single<Bool>

--- a/Projects/Domains/AuthDomain/Interface/Repository/AuthRepository.swift
+++ b/Projects/Domains/AuthDomain/Interface/Repository/AuthRepository.swift
@@ -3,6 +3,7 @@ import RxSwift
 
 public protocol AuthRepository {
     func fetchToken(providerType: ProviderType, token: String) -> Single<AuthLoginEntity>
+    func reGenerateAccessToken() -> Single<AuthLoginEntity>
     func fetchNaverUserInfo(tokenType: String, accessToken: String) -> Single<NaverUserInfoEntity>
     func logout() -> Completable
     func checkIsExistAccessToken() -> Single<Bool>

--- a/Projects/Domains/AuthDomain/Interface/UseCase/FetchNaverUserInfoUseCase.swift
+++ b/Projects/Domains/AuthDomain/Interface/UseCase/FetchNaverUserInfoUseCase.swift
@@ -1,6 +1,7 @@
 import Foundation
 import RxSwift
 
+@available(*, deprecated, message: "구현체를 사용하는 곳이 없음")
 public protocol FetchNaverUserInfoUseCase {
     func execute(tokenType: String, accessToken: String) -> Single<NaverUserInfoEntity>
 }

--- a/Projects/Domains/AuthDomain/Interface/UseCase/FetchTokenUseCase.swift
+++ b/Projects/Domains/AuthDomain/Interface/UseCase/FetchTokenUseCase.swift
@@ -2,5 +2,5 @@ import Foundation
 import RxSwift
 
 public protocol FetchTokenUseCase {
-    func execute(token: String, type: ProviderType) -> Single<AuthLoginEntity>
+    func execute(providerType: ProviderType, token: String) -> Single<AuthLoginEntity>
 }

--- a/Projects/Domains/AuthDomain/Interface/UseCase/ReGenerateAccessTokenUseCase.swift
+++ b/Projects/Domains/AuthDomain/Interface/UseCase/ReGenerateAccessTokenUseCase.swift
@@ -1,0 +1,6 @@
+import Foundation
+import RxSwift
+
+public protocol ReGenerateAccessTokenUseCase {
+    func execute() -> Single<AuthLoginEntity>
+}

--- a/Projects/Domains/AuthDomain/Sources/API/AuthAPI.swift
+++ b/Projects/Domains/AuthDomain/Sources/API/AuthAPI.swift
@@ -7,7 +7,7 @@ import Moya
 public enum AuthAPI {
     case fetchToken(providerType: ProviderType, token: String)
     case reGenerateAccessToken
-    
+
     case fetchNaverUserInfo(tokenType: String, accessToken: String)
 }
 
@@ -21,11 +21,10 @@ extension AuthAPI: WMAPI {
         switch self {
         case .fetchToken:
             return URL(string: BASE_URL())!
-        
+
         case .reGenerateAccessToken:
             return URL(string: BASE_URL())!
-            
-        
+
         case .fetchNaverUserInfo:
             return URL(string: "https://openapi.naver.com")!
         }

--- a/Projects/Domains/AuthDomain/Sources/API/AuthAPI.swift
+++ b/Projects/Domains/AuthDomain/Sources/API/AuthAPI.swift
@@ -5,13 +5,13 @@ import Foundation
 import Moya
 
 public enum AuthAPI {
-    case fetchToken(token: String, type: ProviderType)
+    case fetchToken(providerType: ProviderType, token: String)
     case fetchNaverUserInfo(tokenType: String, accessToken: String)
 }
 
-public struct AuthRequset: Encodable {
-    var token: String
+private struct FetchTokenRequestParameters: Encodable {
     var provider: String
+    var token: String
 }
 
 extension AuthAPI: WMAPI {
@@ -36,7 +36,7 @@ extension AuthAPI: WMAPI {
     public var urlPath: String {
         switch self {
         case .fetchToken:
-            return "/login/mobile"
+            return "/app"
         case .fetchNaverUserInfo:
             return ""
         }
@@ -62,8 +62,13 @@ extension AuthAPI: WMAPI {
 
     public var task: Moya.Task {
         switch self {
-        case let .fetchToken(token: id, type: type):
-            return .requestJSONEncodable(AuthRequset(token: id, provider: type.rawValue))
+        case let .fetchToken(providerType: providerType, token: id):
+            return .requestJSONEncodable(
+                FetchTokenRequestParameters(
+                    provider: providerType.rawValue,
+                    token: id
+                )
+            )
         case .fetchNaverUserInfo:
             return .requestPlain
         }

--- a/Projects/Domains/AuthDomain/Sources/API/AuthAPI.swift
+++ b/Projects/Domains/AuthDomain/Sources/API/AuthAPI.swift
@@ -6,6 +6,8 @@ import Moya
 
 public enum AuthAPI {
     case fetchToken(providerType: ProviderType, token: String)
+    case reGenerateAccessToken
+    
     case fetchNaverUserInfo(tokenType: String, accessToken: String)
 }
 
@@ -19,6 +21,11 @@ extension AuthAPI: WMAPI {
         switch self {
         case .fetchToken:
             return URL(string: BASE_URL())!
+        
+        case .reGenerateAccessToken:
+            return URL(string: BASE_URL())!
+            
+        
         case .fetchNaverUserInfo:
             return URL(string: "https://openapi.naver.com")!
         }
@@ -30,6 +37,8 @@ extension AuthAPI: WMAPI {
             return .auth
         case .fetchNaverUserInfo:
             return .naver
+        case .reGenerateAccessToken:
+            return .auth
         }
     }
 
@@ -39,6 +48,8 @@ extension AuthAPI: WMAPI {
             return "/app"
         case .fetchNaverUserInfo:
             return ""
+        case .reGenerateAccessToken:
+            return "/token"
         }
     }
 
@@ -48,6 +59,8 @@ extension AuthAPI: WMAPI {
             return .post
         case .fetchNaverUserInfo:
             return .get
+        case .reGenerateAccessToken:
+            return .post
         }
     }
 
@@ -70,6 +83,8 @@ extension AuthAPI: WMAPI {
                 )
             )
         case .fetchNaverUserInfo:
+            return .requestPlain
+        case .reGenerateAccessToken:
             return .requestPlain
         }
     }

--- a/Projects/Domains/AuthDomain/Sources/DataSource/RemoteAuthDataSourceImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/DataSource/RemoteAuthDataSourceImpl.swift
@@ -9,6 +9,12 @@ public final class RemoteAuthDataSourceImpl: BaseRemoteDataSource<AuthAPI>, Remo
             .map(AuthLoginResponseDTO.self)
             .map { $0.toDomain() }
     }
+    
+    public func reGenerateAccessToken() -> Single<AuthLoginEntity> {
+        request(.reGenerateAccessToken)
+            .map(AuthLoginResponseDTO.self)
+            .map { $0.toDomain() }
+    }
 
     public func fetchNaverUserInfo(tokenType: String, accessToken: String) -> Single<NaverUserInfoEntity> {
         request(.fetchNaverUserInfo(tokenType: tokenType, accessToken: accessToken))

--- a/Projects/Domains/AuthDomain/Sources/DataSource/RemoteAuthDataSourceImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/DataSource/RemoteAuthDataSourceImpl.swift
@@ -4,8 +4,8 @@ import Foundation
 import RxSwift
 
 public final class RemoteAuthDataSourceImpl: BaseRemoteDataSource<AuthAPI>, RemoteAuthDataSource {
-    public func fetchToken(token: String, type: ProviderType) -> Single<AuthLoginEntity> {
-        request(.fetchToken(token: token, type: type))
+    public func fetchToken(providerType: ProviderType, token: String) -> Single<AuthLoginEntity> {
+        request(.fetchToken(providerType: providerType, token: token))
             .map(AuthLoginResponseDTO.self)
             .map { $0.toDomain() }
     }

--- a/Projects/Domains/AuthDomain/Sources/DataSource/RemoteAuthDataSourceImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/DataSource/RemoteAuthDataSourceImpl.swift
@@ -9,7 +9,7 @@ public final class RemoteAuthDataSourceImpl: BaseRemoteDataSource<AuthAPI>, Remo
             .map(AuthLoginResponseDTO.self)
             .map { $0.toDomain() }
     }
-    
+
     public func reGenerateAccessToken() -> Single<AuthLoginEntity> {
         request(.reGenerateAccessToken)
             .map(AuthLoginResponseDTO.self)

--- a/Projects/Domains/AuthDomain/Sources/Repository/AuthRepositoryImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/Repository/AuthRepositoryImpl.swift
@@ -26,7 +26,7 @@ public final class AuthRepositoryImpl: AuthRepository {
     }
 
     public func reGenerateAccessToken() -> Single<AuthLoginEntity> {
-        remoteAuthDataSource.
+        remoteAuthDataSource.reGenerateAccessToken()
     }
 
     public func fetchNaverUserInfo(tokenType: String, accessToken: String) -> Single<NaverUserInfoEntity> {

--- a/Projects/Domains/AuthDomain/Sources/Repository/AuthRepositoryImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/Repository/AuthRepositoryImpl.swift
@@ -24,6 +24,10 @@ public final class AuthRepositoryImpl: AuthRepository {
     public func fetchToken(providerType: ProviderType, token: String) -> Single<AuthLoginEntity> {
         remoteAuthDataSource.fetchToken(providerType: providerType, token: token)
     }
+    
+    public func reGenerateAccessToken() -> Single<AuthLoginEntity> {
+        remoteAuthDataSource.
+    }
 
     public func fetchNaverUserInfo(tokenType: String, accessToken: String) -> Single<NaverUserInfoEntity> {
         remoteAuthDataSource.fetchNaverUserInfo(tokenType: tokenType, accessToken: accessToken)

--- a/Projects/Domains/AuthDomain/Sources/Repository/AuthRepositoryImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/Repository/AuthRepositoryImpl.swift
@@ -21,8 +21,8 @@ public final class AuthRepositoryImpl: AuthRepository {
         self.remoteAuthDataSource = remoteAuthDataSource
     }
 
-    public func fetchToken(token: String, type: ProviderType) -> Single<AuthLoginEntity> {
-        remoteAuthDataSource.fetchToken(token: token, type: type)
+    public func fetchToken(providerType: ProviderType, token: String) -> Single<AuthLoginEntity> {
+        remoteAuthDataSource.fetchToken(providerType: providerType, token: token)
     }
 
     public func fetchNaverUserInfo(tokenType: String, accessToken: String) -> Single<NaverUserInfoEntity> {

--- a/Projects/Domains/AuthDomain/Sources/Repository/AuthRepositoryImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/Repository/AuthRepositoryImpl.swift
@@ -24,7 +24,7 @@ public final class AuthRepositoryImpl: AuthRepository {
     public func fetchToken(providerType: ProviderType, token: String) -> Single<AuthLoginEntity> {
         remoteAuthDataSource.fetchToken(providerType: providerType, token: token)
     }
-    
+
     public func reGenerateAccessToken() -> Single<AuthLoginEntity> {
         remoteAuthDataSource.
     }

--- a/Projects/Domains/AuthDomain/Sources/ResponseDTO/AuthLoginResponseDTO.swift
+++ b/Projects/Domains/AuthDomain/Sources/ResponseDTO/AuthLoginResponseDTO.swift
@@ -1,26 +1,22 @@
-//
-//  ArtistListResponseDTO.swift
-//  DataMappingModule
-//
-//  Created by KTH on 2023/02/01.
-//  Copyright © 2023 yongbeomkwak. All rights reserved.
-//
-
 import AuthDomainInterface
 import Foundation
 
 public struct AuthLoginResponseDTO: Decodable, Equatable {
-    public let token: String
-
+    public let accessToken: String
+    public let expiresIn: TimeInterval
+    public let refreshToken: String
+    
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        return lhs.token == rhs.token
+        lhs.accessToken == rhs.accessToken
+        && lhs.expiresIn == rhs.expiresIn
+        && lhs.refreshToken == rhs.refreshToken
     }
 }
 
 public extension AuthLoginResponseDTO {
     func toDomain() -> AuthLoginEntity {
         AuthLoginEntity(
-            token: token
+            token: accessToken
         )
     }
 }

--- a/Projects/Domains/AuthDomain/Sources/ResponseDTO/AuthLoginResponseDTO.swift
+++ b/Projects/Domains/AuthDomain/Sources/ResponseDTO/AuthLoginResponseDTO.swift
@@ -4,7 +4,7 @@ import Foundation
 public struct AuthLoginResponseDTO: Decodable, Equatable {
     public let accessToken: String
     public let expiresIn: TimeInterval
-    public let refreshToken: String
+    public let refreshToken: String?
 
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.accessToken == rhs.accessToken

--- a/Projects/Domains/AuthDomain/Sources/ResponseDTO/AuthLoginResponseDTO.swift
+++ b/Projects/Domains/AuthDomain/Sources/ResponseDTO/AuthLoginResponseDTO.swift
@@ -5,11 +5,11 @@ public struct AuthLoginResponseDTO: Decodable, Equatable {
     public let accessToken: String
     public let expiresIn: TimeInterval
     public let refreshToken: String
-    
+
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.accessToken == rhs.accessToken
-        && lhs.expiresIn == rhs.expiresIn
-        && lhs.refreshToken == rhs.refreshToken
+            && lhs.expiresIn == rhs.expiresIn
+            && lhs.refreshToken == rhs.refreshToken
     }
 }
 

--- a/Projects/Domains/AuthDomain/Sources/UseCase/FetchTokenUseCaseImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/UseCase/FetchTokenUseCaseImpl.swift
@@ -17,7 +17,7 @@ public struct FetchTokenUseCaseImpl: FetchTokenUseCase {
         self.authRepository = authRepository
     }
 
-    public func execute(token: String, type: ProviderType) -> Single<AuthLoginEntity> {
-        authRepository.fetchToken(token: token, type: type)
+    public func execute(providerType: ProviderType, token: String) -> Single<AuthLoginEntity> {
+        authRepository.fetchToken(providerType: providerType, token: token)
     }
 }

--- a/Projects/Domains/AuthDomain/Sources/UseCase/FetchTokenUseCaseImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/UseCase/FetchTokenUseCaseImpl.swift
@@ -1,11 +1,3 @@
-//
-//  FetchArtistListUseCaseImpl.swift
-//  DataModule
-//
-//  Created by KTH on 2023/02/08.
-//  Copyright © 2023 yongbeomkwak. All rights reserved.
-//
-
 import AuthDomainInterface
 import Foundation
 import RxSwift

--- a/Projects/Domains/AuthDomain/Sources/UseCase/ReGenerateAccessTokenUseCaseImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/UseCase/ReGenerateAccessTokenUseCaseImpl.swift
@@ -1,0 +1,15 @@
+import AuthDomainInterface
+import Foundation
+import RxSwift
+
+public struct ReGenerateAccessTokenUseCaseImpl: ReGenerateAccessTokenUseCase {
+    private let authRepository: any AuthRepository
+
+    public init(authRepository: any AuthRepository) {
+        self.authRepository = authRepository
+    }
+
+    public func execute() -> Single<AuthLoginEntity> {
+        authRepository.reGenerateAccessToken()
+    }
+}

--- a/Projects/Domains/AuthDomain/Testing/FetchTokenUseCaseSpy.swift
+++ b/Projects/Domains/AuthDomain/Testing/FetchTokenUseCaseSpy.swift
@@ -2,7 +2,7 @@ import AuthDomainInterface
 import RxSwift
 
 public struct FetchTokenUseCaseSpy: FetchTokenUseCase {
-    public func execute(token: String, type: ProviderType) -> Single<AuthLoginEntity> {
+    public func execute(providerType: ProviderType, token: String) -> Single<AuthLoginEntity> {
         return .just(AuthLoginEntity(token: ""))
     }
 }

--- a/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
@@ -65,7 +65,7 @@ public final class LoginViewModel: NSObject, ViewModelType { // 네이버 델리
             .debug("🚚 oauthToken")
             .filter { !$0.1.isEmpty }
             .flatMap { [fetchTokenUseCase] provider, token in
-                fetchTokenUseCase.execute(token: token, type: provider)
+                fetchTokenUseCase.execute(providerType: provider, token: token)
                     .catchAndReturn(AuthLoginEntity(token: ""))
                     .asObservable()
             }


### PR DESCRIPTION
## 💡 배경 및 개요
AuthDomain API 변경사항을 처리했어요
Resolves: #500

## 📃 작업내용
- 앱 로그인 API 변경사항 반영
- 액세스토큰 재발급 API 추가

## 🙋‍♂️ 리뷰노트
- 노션 xcconfig 업데이트
- AuthAPI에 `fetchNaverUserInfo(tokenType: String, accessToken: String)` 라는 메소드가 있는데, 현재 사용중인 곳도 없고 앞으로 사용될 것 같지 않아 삭제 예정입니다.


## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
