### PR TITLE
🔀 :: (#566) 보관함의 상단탭을 변경해도 Reactor.State에 반영되지 않던 문제를 수정합니다.

### DIFF
--- a/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
@@ -76,7 +76,7 @@ final class StorageViewController: TabmanViewController, ViewControllerFromStory
         direction: PageboyViewController.NavigationDirection,
         animated: Bool
     ) {
-        // TODO: 편집 모드 처리
+        self.reactor?.action.onNext(.switchTab(index))
     }
 
     public static func viewController(


### PR DESCRIPTION
## 💡 배경 및 개요
내 정보 화면에서 좋아요 바로가기 버튼을 누르면 생기는 버그를 조사하다가 발견해 수정합니다. 

Resolves: #566

## 📃 작업내용
- Tabman 라이브러리에서 제공하는 페이지 변경 감지 메소드를 이용. 
- 메소드가 호출되면 reactor로 액션을 보내 Reactor.State 의 상단 탭 인덱스를 변경하도록 합니다.


## 🙋‍♂️ 리뷰노트


## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
