### PR TITLE
🔀 :: (#551) PanModal 라이브러리를 FittedSheets로 대체

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -64,6 +64,15 @@
       }
     },
     {
+      "identity" : "fittedsheets",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gordontucker/FittedSheets.git",
+      "state" : {
+        "revision" : "5d7f5a6307ad510aa05de5a4a16ac40846d3b2d3",
+        "version" : "2.6.1"
+      }
+    },
+    {
       "identity" : "googleappmeasurement",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",

--- a/Package.resolved
+++ b/Package.resolved
@@ -235,15 +235,6 @@
       }
     },
     {
-      "identity" : "panmodal",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/slackhq/PanModal.git",
-      "state" : {
-        "revision" : "b012aecb6b67a8e46369227f893c12544846613f",
-        "version" : "1.2.7"
-      }
-    },
-    {
       "identity" : "promises",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         .package(url: "https://github.com/Moya/Moya.git", from: "15.0.3"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.11.0"),
         .package(url: "https://github.com/slackhq/PanModal.git", from: "1.2.0"),
+        .package(url: "https://github.com/gordontucker/FittedSheets.git", from: "2.6.1"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git",from: "6.7.1"),
         .package(url: "https://github.com/devxoul/Then", from: "3.0.0"),
         .package(url: "https://github.com/SnapKit/SnapKit.git", from: "5.7.1"),

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,6 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Moya/Moya.git", from: "15.0.3"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.11.0"),
-        .package(url: "https://github.com/slackhq/PanModal.git", from: "1.2.0"),
         .package(url: "https://github.com/gordontucker/FittedSheets.git", from: "2.6.1"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git",from: "6.7.1"),
         .package(url: "https://github.com/devxoul/Then", from: "3.0.0"),

--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
@@ -9,6 +9,7 @@ public extension TargetDependency.SPM {
     static let Moya = TargetDependency.external(name: "Moya")
     static let RxMoya = TargetDependency.external(name: "RxMoya")
     static let PanModal = TargetDependency.external(name: "PanModal")
+    static let FittedSheets = TargetDependency.external(name: "FittedSheets")
     static let RxSwift = TargetDependency.external(name: "RxSwift")
     static let RxCocoa = TargetDependency.external(name: "RxCocoa")
     static let Kingfisher = TargetDependency.external(name: "Kingfisher")

--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
@@ -8,7 +8,6 @@ public extension TargetDependency.SPM {
     // MARK: External
     static let Moya = TargetDependency.external(name: "Moya")
     static let RxMoya = TargetDependency.external(name: "RxMoya")
-    static let PanModal = TargetDependency.external(name: "PanModal")
     static let FittedSheets = TargetDependency.external(name: "FittedSheets")
     static let RxSwift = TargetDependency.external(name: "RxSwift")
     static let RxCocoa = TargetDependency.external(name: "RxCocoa")

--- a/Projects/Features/BaseFeature/Interface/TextPopUp/TextPopUpFactory.swift
+++ b/Projects/Features/BaseFeature/Interface/TextPopUp/TextPopUpFactory.swift
@@ -4,7 +4,6 @@ public protocol TextPopUpFactory {
     func makeView(
         text: String?,
         cancelButtonIsHidden: Bool,
-        allowsDragAndTapToDismiss: Bool?,
         confirmButtonText: String?,
         cancelButtonText: String?,
         completion: (() -> Void)?,

--- a/Projects/Features/BaseFeature/Resources/Base.storyboard
+++ b/Projects/Features/BaseFeature/Resources/Base.storyboard
@@ -481,7 +481,6 @@
                             <constraint firstItem="rWb-JT-gub" firstAttribute="leading" secondItem="ybh-tp-dX5" secondAttribute="leading" id="Ahz-2H-L81"/>
                             <constraint firstItem="rWb-JT-gub" firstAttribute="top" secondItem="ybh-tp-dX5" secondAttribute="top" id="Gll-Rk-UHl"/>
                             <constraint firstItem="ybh-tp-dX5" firstAttribute="trailing" secondItem="rWb-JT-gub" secondAttribute="trailing" id="UDb-NZ-Y69"/>
-                            <constraint firstItem="ybh-tp-dX5" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="rWb-JT-gub" secondAttribute="bottom" id="jWU-1z-irD"/>
                         </constraints>
                     </view>
                     <connections>

--- a/Projects/Features/BaseFeature/Resources/Base.storyboard
+++ b/Projects/Features/BaseFeature/Resources/Base.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -339,6 +339,7 @@
                             <constraint firstItem="bzT-MY-nfF" firstAttribute="top" secondItem="gkT-eU-P4o" secondAttribute="top" id="7Sg-Qj-9ki"/>
                             <constraint firstItem="bzT-MY-nfF" firstAttribute="leading" secondItem="gkT-eU-P4o" secondAttribute="leading" id="TLo-M7-80o"/>
                             <constraint firstItem="gkT-eU-P4o" firstAttribute="trailing" secondItem="bzT-MY-nfF" secondAttribute="trailing" id="aJP-GL-FCF"/>
+                            <constraint firstItem="gkT-eU-P4o" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="bzT-MY-nfF" secondAttribute="bottom" id="pm0-Cd-K6T"/>
                         </constraints>
                     </view>
                     <connections>
@@ -500,7 +501,7 @@
     <resources>
         <image name="cross_close" width="32" height="32"/>
         <namedColor name="POINT">
-            <color red="0.035999998450279236" green="0.7850000262260437" blue="0.94999998807907104" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.035294117647058823" green="0.78431372549019607" blue="0.94901960784313721" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="WAKTAVERSE">
             <color red="0.0" green="0.9570000171661377" blue="0.72899997234344482" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -512,7 +513,7 @@
             <color red="0.99199998378753662" green="0.99199998378753662" blue="0.99199998378753662" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="gray400">
-            <color red="0.59600001573562622" green="0.63499999046325684" blue="0.70200002193450928" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="gray800">
             <color red="0.11400000005960464" green="0.16099999845027924" blue="0.22400000691413879" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Projects/Features/BaseFeature/Resources/Base.storyboard
+++ b/Projects/Features/BaseFeature/Resources/Base.storyboard
@@ -400,7 +400,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="cfO-nl-nfD">
-                                        <rect key="frame" x="20" y="126" width="303" height="19"/>
+                                        <rect key="frame" x="20" y="126.33333333333336" width="303" height="18.666666666666671"/>
                                         <color key="textColor" name="gray800"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
@@ -427,13 +427,19 @@
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dXA-NK-1pe">
-                                        <rect key="frame" x="20" y="90" width="42" height="21"/>
+                                        <rect key="frame" x="20" y="84" width="42" height="24"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="24" id="9PB-tI-7We"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XrV-Zc-jwE">
-                                        <rect key="frame" x="20" y="24" width="42" height="21"/>
+                                        <rect key="frame" x="20" y="24" width="42" height="28"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="28" id="nPs-Zl-t09"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -443,6 +449,7 @@
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="ij3-fi-jC1" secondAttribute="trailing" constant="20" id="0cV-AG-oXd"/>
                                     <constraint firstItem="Kn4-E0-QGV" firstAttribute="centerY" secondItem="AUz-tK-BNV" secondAttribute="centerY" id="3hl-TH-OSP"/>
+                                    <constraint firstItem="dXA-NK-1pe" firstAttribute="top" secondItem="XrV-Zc-jwE" secondAttribute="bottom" constant="32" id="6Ki-ib-7EC"/>
                                     <constraint firstItem="GKw-Bn-dI7" firstAttribute="centerX" secondItem="xs4-m5-Jmc" secondAttribute="centerX" id="6dJ-aL-Dwn"/>
                                     <constraint firstItem="O6b-uG-uWT" firstAttribute="leading" secondItem="cfO-nl-nfD" secondAttribute="trailing" constant="5" id="6yN-Iy-hpx"/>
                                     <constraint firstItem="ij3-fi-jC1" firstAttribute="bottom" secondItem="AUz-tK-BNV" secondAttribute="top" constant="4" id="ADz-D1-Znw"/>
@@ -452,7 +459,6 @@
                                     <constraint firstItem="Kn4-E0-QGV" firstAttribute="leading" secondItem="Iat-p0-Uk6" secondAttribute="trailing" id="J4h-q5-5bp"/>
                                     <constraint firstItem="dXA-NK-1pe" firstAttribute="leading" secondItem="rWb-JT-gub" secondAttribute="leading" constant="20" id="MiA-Vz-kXQ"/>
                                     <constraint firstAttribute="bottom" secondItem="xs4-m5-Jmc" secondAttribute="bottom" constant="10" id="NV4-CY-70Q"/>
-                                    <constraint firstItem="cfO-nl-nfD" firstAttribute="top" secondItem="dXA-NK-1pe" secondAttribute="bottom" constant="15" id="QQB-YJ-T3c"/>
                                     <constraint firstItem="ij3-fi-jC1" firstAttribute="leading" secondItem="rWb-JT-gub" secondAttribute="leading" constant="20" id="Vsd-1u-9UH"/>
                                     <constraint firstItem="ij3-fi-jC1" firstAttribute="top" secondItem="cfO-nl-nfD" secondAttribute="bottom" constant="11" id="Xob-yg-ouk"/>
                                     <constraint firstItem="GKw-Bn-dI7" firstAttribute="centerY" secondItem="xs4-m5-Jmc" secondAttribute="centerY" id="aJv-7M-AbD"/>
@@ -475,6 +481,7 @@
                             <constraint firstItem="rWb-JT-gub" firstAttribute="leading" secondItem="ybh-tp-dX5" secondAttribute="leading" id="Ahz-2H-L81"/>
                             <constraint firstItem="rWb-JT-gub" firstAttribute="top" secondItem="ybh-tp-dX5" secondAttribute="top" id="Gll-Rk-UHl"/>
                             <constraint firstItem="ybh-tp-dX5" firstAttribute="trailing" secondItem="rWb-JT-gub" secondAttribute="trailing" id="UDb-NZ-Y69"/>
+                            <constraint firstItem="ybh-tp-dX5" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="rWb-JT-gub" secondAttribute="bottom" id="jWU-1z-irD"/>
                         </constraints>
                     </view>
                     <connections>

--- a/Projects/Features/BaseFeature/Sources/Components/TextPopUpComponent.swift
+++ b/Projects/Features/BaseFeature/Sources/Components/TextPopUpComponent.swift
@@ -6,7 +6,6 @@ public final class TextPopUpComponent: Component<EmptyDependency>, TextPopUpFact
     public func makeView(
         text: String?,
         cancelButtonIsHidden: Bool,
-        allowsDragAndTapToDismiss: Bool?,
         confirmButtonText: String?,
         cancelButtonText: String?,
         completion: (() -> Void)?,
@@ -15,7 +14,6 @@ public final class TextPopUpComponent: Component<EmptyDependency>, TextPopUpFact
         return TextPopupViewController.viewController(
             text: text ?? "",
             cancelButtonIsHidden: cancelButtonIsHidden,
-            allowsDragAndTapToDismiss: allowsDragAndTapToDismiss ?? true,
             confirmButtonText: confirmButtonText ?? "확인",
             cancelButtonText: cancelButtonText ?? "취소",
             completion: completion,

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/TextPopupViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/TextPopupViewController.swift
@@ -12,7 +12,6 @@ public final class TextPopupViewController: UIViewController, ViewControllerFrom
     var cancelButtonIsHidden: Bool = false
     var completion: (() -> Void)?
     var cancelCompletion: (() -> Void)?
-    var allowsDragAndTapToDismiss: Bool = true
     var cancelButtonText: String = ""
     var confirmButtonText: String = ""
 
@@ -29,7 +28,6 @@ public final class TextPopupViewController: UIViewController, ViewControllerFrom
     public static func viewController(
         text: String = "",
         cancelButtonIsHidden: Bool,
-        allowsDragAndTapToDismiss: Bool = true,
         confirmButtonText: String = "확인",
         cancelButtonText: String = "취소",
         completion: (() -> Void)? = nil,
@@ -39,7 +37,6 @@ public final class TextPopupViewController: UIViewController, ViewControllerFrom
         let viewController = TextPopupViewController.viewController(storyBoardName: "Base", bundle: Bundle.module)
         viewController.contentString = text
         viewController.cancelButtonIsHidden = cancelButtonIsHidden
-        viewController.allowsDragAndTapToDismiss = allowsDragAndTapToDismiss
         viewController.completion = completion
         viewController.cancelCompletion = cancelCompletion
         viewController.confirmButtonText = confirmButtonText
@@ -48,13 +45,15 @@ public final class TextPopupViewController: UIViewController, ViewControllerFrom
     }
 
     @IBAction func cancelButtonAction(_ sender: Any) {
-        dismiss(animated: true)
-        cancelCompletion?()
+        dismiss(animated: true, completion: { [cancelCompletion] in
+            cancelCompletion?()
+        })
     }
 
     @IBAction func confirmButtonAction(_ sender: Any) {
-        dismiss(animated: true)
-        completion?()
+        dismiss(animated: true, completion: { [completion] in
+            completion?()
+        })
     }
 }
 
@@ -155,10 +154,10 @@ extension TextPopupViewController: PanModalPresentable {
     }
 
     public var allowsDragToDismiss: Bool {
-        return allowsDragAndTapToDismiss
+        return true
     }
 
     public var allowsTapToDismiss: Bool {
-        return allowsDragAndTapToDismiss
+        return true
     }
 }

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/TextPopupViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/TextPopupViewController.swift
@@ -1,5 +1,4 @@
 import DesignSystem
-import PanModal
 import UIKit
 import Utility
 
@@ -105,59 +104,5 @@ extension TextPopupViewController {
             ]
         )
         contentLabel.attributedText = contentAttributedString
-    }
-}
-
-extension TextPopupViewController: PanModalPresentable {
-    override public var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
-    }
-
-    public var panModalBackgroundColor: UIColor {
-        return colorFromRGB(0x000000, alpha: 0.4)
-    }
-
-    public var panScrollable: UIScrollView? {
-        return nil
-    }
-
-    public var longFormHeight: PanModalHeight {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineHeightMultiple = 1.3
-        paragraphStyle.alignment = .center
-
-        let contentAttributedString = NSMutableAttributedString(
-            string: contentString,
-            attributes: [
-                .font: DesignSystem.DesignSystemFontFamily.Pretendard.medium.font(size: 18),
-                .foregroundColor: DesignSystemAsset.GrayColor.gray900.color,
-                .kern: -0.5,
-                .paragraphStyle: paragraphStyle
-            ]
-        )
-
-        let contentHeight: CGFloat = contentAttributedString.height(containerWidth: APP_WIDTH() - 40)
-        let spacingHeight: CGFloat = 60 + 52 + 56 + 10
-        return .contentHeight(spacingHeight + contentHeight)
-    }
-
-    public var cornerRadius: CGFloat {
-        return 24.0
-    }
-
-    public var allowsExtendedPanScrolling: Bool {
-        return true
-    }
-
-    public var showDragIndicator: Bool {
-        return false
-    }
-
-    public var allowsDragToDismiss: Bool {
-        return true
-    }
-
-    public var allowsTapToDismiss: Bool {
-        return true
     }
 }

--- a/Projects/Features/BaseFeature/Sources/Views/SongCartView.swift
+++ b/Projects/Features/BaseFeature/Sources/Views/SongCartView.swift
@@ -243,6 +243,6 @@ extension SongCartView {
             }
         )
         guard let parent = self.parentViewController() else { return }
-        parent.showPanModal(content: viewController)
+        parent.showFittedSheets(content: viewController)
     }
 }

--- a/Projects/Features/BaseFeature/Sources/Views/SongCartView.swift
+++ b/Projects/Features/BaseFeature/Sources/Views/SongCartView.swift
@@ -243,6 +243,6 @@ extension SongCartView {
             }
         )
         guard let parent = self.parentViewController() else { return }
-        parent.showFittedSheets(content: viewController)
+        parent.showBottomSheet(content: viewController)
     }
 }

--- a/Projects/Features/BaseFeature/Testing/TextPopUpComponentStub.swift
+++ b/Projects/Features/BaseFeature/Testing/TextPopUpComponentStub.swift
@@ -6,7 +6,6 @@ public final class TextPopUpComponentStub: TextPopUpFactory {
     public func makeView(
         text: String?,
         cancelButtonIsHidden: Bool,
-        allowsDragAndTapToDismiss: Bool?,
         confirmButtonText: String?,
         cancelButtonText: String?,
         completion: (() -> Void)?,
@@ -15,7 +14,6 @@ public final class TextPopUpComponentStub: TextPopUpFactory {
         return TextPopupViewController.viewController(
             text: text ?? "",
             cancelButtonIsHidden: cancelButtonIsHidden,
-            allowsDragAndTapToDismiss: allowsDragAndTapToDismiss ?? true,
             confirmButtonText: confirmButtonText ?? "확인",
             cancelButtonText: cancelButtonText ?? "취소",
             completion: completion,

--- a/Projects/Features/HomeFeature/Sources/ViewControllers/HomeViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewControllers/HomeViewController.swift
@@ -3,7 +3,6 @@ import ChartDomainInterface
 import DesignSystem
 import LogManager
 import NVActivityIndicatorView
-import PanModal
 import PlayListDomainInterface
 import PlaylistFeatureInterface
 import RxCocoa

--- a/Projects/Features/MainTabFeature/Resources/Main.storyboard
+++ b/Projects/Features/MainTabFeature/Resources/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -259,6 +259,7 @@
                             <constraint firstItem="CHC-RK-OHq" firstAttribute="top" secondItem="osQ-4a-9GI" secondAttribute="top" id="9bL-fg-0Ak"/>
                             <constraint firstItem="CHC-RK-OHq" firstAttribute="leading" secondItem="osQ-4a-9GI" secondAttribute="leading" id="LGN-xs-qsq"/>
                             <constraint firstAttribute="trailing" secondItem="CHC-RK-OHq" secondAttribute="trailing" id="kUO-eF-5sI"/>
+                            <constraint firstItem="osQ-4a-9GI" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="CHC-RK-OHq" secondAttribute="bottom" id="quz-qd-tAu"/>
                         </constraints>
                     </view>
                     <connections>
@@ -276,7 +277,7 @@
     </scenes>
     <resources>
         <namedColor name="POINT">
-            <color red="0.035999998450279236" green="0.7850000262260437" blue="0.94999998807907104" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.035294117647058823" green="0.78431372549019607" blue="0.94901960784313721" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="gray100">
             <color red="0.94900000095367432" green="0.9570000171661377" blue="0.96899998188018799" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
@@ -103,7 +103,7 @@ private extension MainTabBarViewController {
             .bind(with: self) { owner, model in
                 let viewController = owner.noticePopupComponent.makeView(model: model)
                 viewController.delegate = owner
-                owner.showFittedSheets(content: viewController)
+                owner.showBottomSheet(content: viewController)
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
@@ -103,7 +103,7 @@ private extension MainTabBarViewController {
             .bind(with: self) { owner, model in
                 let viewController = owner.noticePopupComponent.makeView(model: model)
                 viewController.delegate = owner
-                owner.showPanModal(content: viewController)
+                owner.showFittedSheets(content: viewController)
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/NoticePopupViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/NoticePopupViewController.swift
@@ -9,7 +9,6 @@
 import BaseFeature
 import DesignSystem
 import NoticeDomainInterface
-import PanModal
 import RxCocoa
 import RxSwift
 import SnapKit
@@ -190,35 +189,5 @@ extension NoticePopupViewController: UICollectionViewDelegateFlowLayout, UIColle
         minimumInteritemSpacingForSectionAt section: Int
     ) -> CGFloat {
         return 0
-    }
-}
-
-extension NoticePopupViewController: PanModalPresentable {
-    override public var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
-    }
-
-    public var panModalBackgroundColor: UIColor {
-        return colorFromRGB(0x000000, alpha: 0.4)
-    }
-
-    public var panScrollable: UIScrollView? {
-        return nil
-    }
-
-    public var longFormHeight: PanModalHeight {
-        return PanModalHeight.contentHeight(APP_WIDTH() + 20 + 56 + 20)
-    }
-
-    public var cornerRadius: CGFloat {
-        return 24.0
-    }
-
-    public var allowsExtendedPanScrolling: Bool {
-        return true
-    }
-
-    public var showDragIndicator: Bool {
-        return false
     }
 }

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -101,7 +101,6 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor> {
                         guard let vc = owner.textPopUpFactory.makeView(
                             text: "로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?",
                             cancelButtonIsHidden: false,
-                            allowsDragAndTapToDismiss: nil,
                             confirmButtonText: nil,
                             cancelButtonText: nil,
                             completion: {
@@ -112,11 +111,7 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor> {
                         ) as? TextPopupViewController else {
                             return
                         }
-
-                        vc.modalPresentationStyle = .popover
-                        owner.present(vc, animated: true)
-                        #warning("팬모달 이슈 해결되면 변경 예정")
-                        // owner.showPanModal(content: vc)
+                        owner.showFittedSheets(content: vc)
                     }
                 case .faq:
                     let vc = owner.faqComponent.makeView()

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -111,7 +111,7 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor> {
                         ) as? TextPopupViewController else {
                             return
                         }
-                        owner.showFittedSheets(content: vc)
+                        owner.showBottomSheet(content: vc)
                     }
                 case .faq:
                     let vc = owner.faqComponent.makeView()

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/Question/QuestionViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/Question/QuestionViewController.swift
@@ -254,7 +254,6 @@ extension QuestionViewController {
                     guard let textPopupViewController = self.textPopUpFactory.makeView(
                         text: text,
                         cancelButtonIsHidden: false,
-                        allowsDragAndTapToDismiss: nil,
                         confirmButtonText: "다음",
                         cancelButtonText: "충족 기준 보기",
                         completion: {
@@ -269,8 +268,8 @@ extension QuestionViewController {
                     ) as? TextPopupViewController else {
                         return
                     }
+                    self.showFittedSheets(content: textPopupViewController)
 
-                    self.showPanModal(content: textPopupViewController)
                 } else {
                     self.goToMail(source: source)
                 }
@@ -309,7 +308,6 @@ extension QuestionViewController {
             guard let textPopupViewController = self.textPopUpFactory.makeView(
                 text: "메일 계정이 설정되어 있지 않습니다.\n설정 > Mail 앱 > 계정을 설정해주세요.",
                 cancelButtonIsHidden: true,
-                allowsDragAndTapToDismiss: nil,
                 confirmButtonText: "확인",
                 cancelButtonText: nil,
                 completion: nil,
@@ -318,7 +316,7 @@ extension QuestionViewController {
                 return
             }
 
-            self.showPanModal(content: textPopupViewController)
+            self.showFittedSheets(content: textPopupViewController)
         }
     }
 }

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/Question/QuestionViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/Question/QuestionViewController.swift
@@ -268,7 +268,7 @@ extension QuestionViewController {
                     ) as? TextPopupViewController else {
                         return
                     }
-                    self.showFittedSheets(content: textPopupViewController)
+                    self.showBottomSheet(content: textPopupViewController)
 
                 } else {
                     self.goToMail(source: source)
@@ -316,7 +316,7 @@ extension QuestionViewController {
                 return
             }
 
-            self.showFittedSheets(content: textPopupViewController)
+            self.showBottomSheet(content: textPopupViewController)
         }
     }
 }

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/Request/RequestViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/Request/RequestViewController.swift
@@ -84,14 +84,14 @@ public final class RequestViewController: UIViewController, ViewControllerFromSt
 
                 guard let self else { return }
 
-                self.showFittedSheets(content: secondConfirmVc)
+                self.showBottomSheet(content: secondConfirmVc)
             },
             cancelCompletion: nil
         ) as? TextPopupViewController else {
             return
         }
 
-        self.showFittedSheets(content: firstConfirmVc)
+        self.showBottomSheet(content: firstConfirmVc)
     }
 
     var viewModel: RequestViewModel!
@@ -256,7 +256,7 @@ extension RequestViewController {
                 return
             }
 
-            self.showFittedSheets(content: textPopUpViewController)
+            self.showBottomSheet(content: textPopUpViewController)
         })
         .disposed(by: disposeBag)
 

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/Request/RequestViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/Request/RequestViewController.swift
@@ -62,7 +62,6 @@ public final class RequestViewController: UIViewController, ViewControllerFromSt
         guard let secondConfirmVc = textPopUpFactory.makeView(
             text: "정말 탈퇴하시겠습니까?",
             cancelButtonIsHidden: false,
-            allowsDragAndTapToDismiss: nil,
             confirmButtonText: nil,
             cancelButtonText: nil,
             completion: { [weak self] in
@@ -79,21 +78,20 @@ public final class RequestViewController: UIViewController, ViewControllerFromSt
         guard let firstConfirmVc = textPopUpFactory.makeView(
             text: "회원탈퇴 신청을 하시겠습니까?",
             cancelButtonIsHidden: false,
-            allowsDragAndTapToDismiss: nil,
             confirmButtonText: nil,
             cancelButtonText: nil,
             completion: { [weak self] in
 
                 guard let self else { return }
 
-                self.showPanModal(content: secondConfirmVc)
+                self.showFittedSheets(content: secondConfirmVc)
             },
             cancelCompletion: nil
         ) as? TextPopupViewController else {
             return
         }
 
-        self.showPanModal(content: firstConfirmVc)
+        self.showFittedSheets(content: firstConfirmVc)
     }
 
     var viewModel: RequestViewModel!
@@ -243,7 +241,6 @@ extension RequestViewController {
             guard let textPopUpViewController = textPopUpFactory.makeView(
                 text: (status == 200) ? "회원탈퇴가 완료되었습니다.\n이용해주셔서 감사합니다." : $0.description,
                 cancelButtonIsHidden: true,
-                allowsDragAndTapToDismiss: nil,
                 confirmButtonText: nil,
                 cancelButtonText: nil,
                 completion: { [weak self] in
@@ -259,7 +256,7 @@ extension RequestViewController {
                 return
             }
 
-            self.showPanModal(content: textPopUpViewController)
+            self.showFittedSheets(content: textPopUpViewController)
         })
         .disposed(by: disposeBag)
 

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/ServiceInfo/ServiceInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/ServiceInfo/ServiceInfoViewController.swift
@@ -105,7 +105,7 @@ extension ServiceInfoViewController {
                     return
                 }
 
-                owner.showFittedSheets(content: textPopupVC)
+                owner.showBottomSheet(content: textPopupVC)
             }).disposed(by: disposeBag)
 
         viewModel.output

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/ServiceInfo/ServiceInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/ServiceInfo/ServiceInfoViewController.swift
@@ -97,7 +97,6 @@ extension ServiceInfoViewController {
                 guard let textPopupVC = owner.textPopUpFactory.makeView(
                     text: "캐시 데이터(\(sizeString))를 지우시겠습니까?",
                     cancelButtonIsHidden: false,
-                    allowsDragAndTapToDismiss: nil,
                     confirmButtonText: nil,
                     cancelButtonText: nil,
                     completion: { owner.viewModel.input.removeCache.onNext(()) },
@@ -106,7 +105,7 @@ extension ServiceInfoViewController {
                     return
                 }
 
-                owner.showPanModal(content: textPopupVC)
+                owner.showFittedSheets(content: textPopupVC)
             }).disposed(by: disposeBag)
 
         viewModel.output

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/Setting/SettingViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/Setting/SettingViewController.swift
@@ -84,7 +84,7 @@ final class SettingViewController: BaseReactorViewController<SettingReactor> {
                 ) as? TextPopupViewController else {
                     return
                 }
-                owner.showFittedSheets(content: textPopupVC)
+                owner.showBottomSheet(content: textPopupVC)
             })
             .disposed(by: disposeBag)
 
@@ -119,13 +119,13 @@ final class SettingViewController: BaseReactorViewController<SettingReactor> {
                     confirmButtonText: nil,
                     cancelButtonText: nil,
                     completion: {
-                        owner.showFittedSheets(content: secondConfirmVC)
+                        owner.showBottomSheet(content: secondConfirmVC)
                     },
                     cancelCompletion: nil
                 ) as? TextPopupViewController else {
                     return
                 }
-                owner.showFittedSheets(content: firstConfirmVC)
+                owner.showBottomSheet(content: firstConfirmVC)
             })
             .disposed(by: disposeBag)
 
@@ -148,7 +148,7 @@ final class SettingViewController: BaseReactorViewController<SettingReactor> {
                 ) as? TextPopupViewController else {
                     return
                 }
-                owner.showFittedSheets(content: textPopUpVC)
+                owner.showBottomSheet(content: textPopUpVC)
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/Setting/SettingViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/Setting/SettingViewController.swift
@@ -75,7 +75,6 @@ final class SettingViewController: BaseReactorViewController<SettingReactor> {
                 guard let textPopupVC = owner.textPopUpFactory.makeView(
                     text: "캐시 데이터(\(cachSize))를 지우시겠습니까?",
                     cancelButtonIsHidden: false,
-                    allowsDragAndTapToDismiss: nil,
                     confirmButtonText: nil,
                     cancelButtonText: nil,
                     completion: {
@@ -85,10 +84,7 @@ final class SettingViewController: BaseReactorViewController<SettingReactor> {
                 ) as? TextPopupViewController else {
                     return
                 }
-                #warning("팬모달 이슈 해결되면 변경 예정")
-                textPopupVC.modalPresentationStyle = .popover
-                owner.present(textPopupVC, animated: true)
-                // owner.showPanModal(content: textPopupVC)
+                owner.showFittedSheets(content: textPopupVC)
             })
             .disposed(by: disposeBag)
 
@@ -108,7 +104,6 @@ final class SettingViewController: BaseReactorViewController<SettingReactor> {
                 guard let secondConfirmVC = owner.textPopUpFactory.makeView(
                     text: "정말 탈퇴하시겠습니까?",
                     cancelButtonIsHidden: false,
-                    allowsDragAndTapToDismiss: nil,
                     confirmButtonText: nil,
                     cancelButtonText: nil,
                     completion: {
@@ -121,22 +116,16 @@ final class SettingViewController: BaseReactorViewController<SettingReactor> {
                 guard let firstConfirmVC = owner.textPopUpFactory.makeView(
                     text: "회원탈퇴 신청을 하시겠습니까?",
                     cancelButtonIsHidden: false,
-                    allowsDragAndTapToDismiss: nil,
                     confirmButtonText: nil,
                     cancelButtonText: nil,
                     completion: {
-                        #warning("팬모달 이슈 해결되면 변경 예정")
-                        secondConfirmVC.modalPresentationStyle = .popover
-                        owner.present(secondConfirmVC, animated: true)
-                        // owner.showPanModal(content: secondConfirmVC)
+                        owner.showFittedSheets(content: secondConfirmVC)
                     },
                     cancelCompletion: nil
                 ) as? TextPopupViewController else {
                     return
                 }
-                #warning("팬모달 이슈 해결되면 변경 예정")
-                owner.present(firstConfirmVC, animated: true)
-                // self.showPanModal(content: firstConfirmVC)
+                owner.showFittedSheets(content: firstConfirmVC)
             })
             .disposed(by: disposeBag)
 
@@ -148,7 +137,6 @@ final class SettingViewController: BaseReactorViewController<SettingReactor> {
                 guard let textPopUpVC = owner.textPopUpFactory.makeView(
                     text: (status == 200) ? "회원탈퇴가 완료되었습니다.\n이용해주셔서 감사합니다." : description,
                     cancelButtonIsHidden: true,
-                    allowsDragAndTapToDismiss: nil,
                     confirmButtonText: nil,
                     cancelButtonText: nil,
                     completion: {
@@ -160,10 +148,7 @@ final class SettingViewController: BaseReactorViewController<SettingReactor> {
                 ) as? TextPopupViewController else {
                     return
                 }
-                #warning("팬모달 이슈 해결되면 변경 예정")
-                textPopUpVC.modalPresentationStyle = .popover
-                owner.present(textPopUpVC, animated: true)
-                // owner.showPanModal(content: textPopUpVC)
+                owner.showFittedSheets(content: textPopUpVC)
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -168,7 +168,7 @@ private extension PlayerViewController {
 
     private func bindShowTokenModal(output: PlayerViewModel.Output) {
         output.showTokenModal.sink { [weak self] message in
-            self?.showPanModal(
+            self?.showFittedSheets(
                 content: TextPopupViewController.viewController(
                     text: message,
                     cancelButtonIsHidden: true,
@@ -376,7 +376,7 @@ private extension PlayerViewController {
 
     private func bindShowConfirmModal(output: PlayerViewModel.Output) {
         output.showConfirmModal.sink { [weak self] message in
-            self?.showPanModal(content: TextPopupViewController.viewController(
+            self?.showFittedSheets(content: TextPopupViewController.viewController(
                 text: message,
                 cancelButtonIsHidden: false,
                 completion: {

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -11,7 +11,6 @@ import BaseFeatureInterface
 import Combine
 import DesignSystem
 import Kingfisher
-import PanModal
 import RxCocoa
 import RxSwift
 import SnapKit

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlayerViewController.swift
@@ -167,7 +167,7 @@ private extension PlayerViewController {
 
     private func bindShowTokenModal(output: PlayerViewModel.Output) {
         output.showTokenModal.sink { [weak self] message in
-            self?.showFittedSheets(
+            self?.showBottomSheet(
                 content: TextPopupViewController.viewController(
                     text: message,
                     cancelButtonIsHidden: true,
@@ -375,7 +375,7 @@ private extension PlayerViewController {
 
     private func bindShowConfirmModal(output: PlayerViewModel.Output) {
         output.showConfirmModal.sink { [weak self] message in
-            self?.showFittedSheets(content: TextPopupViewController.viewController(
+            self?.showBottomSheet(content: TextPopupViewController.viewController(
                 text: message,
                 cancelButtonIsHidden: false,
                 completion: {

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController+Delegate.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController+Delegate.swift
@@ -32,7 +32,7 @@ extension PlaylistViewController: SongCartViewDelegate {
                     self.hideSongCart()
                 }
             )
-            self.showPanModal(content: popup)
+            self.showFittedSheets(content: popup)
         default:
             return
         }

--- a/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController+Delegate.swift
+++ b/Projects/Features/PlayerFeature/Sources/ViewControllers/PlaylistViewController+Delegate.swift
@@ -32,7 +32,7 @@ extension PlaylistViewController: SongCartViewDelegate {
                     self.hideSongCart()
                 }
             )
-            self.showFittedSheets(content: popup)
+            self.showBottomSheet(content: popup)
         default:
             return
         }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListDetailViewController.swift
@@ -3,7 +3,6 @@ import BaseFeatureInterface
 import DesignSystem
 import Kingfisher
 import NVActivityIndicatorView
-import PanModal
 import ReactorKit
 import RxCocoa
 import RxDataSources

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListDetailViewController.swift
@@ -269,7 +269,7 @@ internal class PlayListDetailViewController: BaseStoryboardReactorViewController
                         return
                     }
 
-                    owner.showFittedSheets(content: textPopUpVC)
+                    owner.showBottomSheet(content: textPopUpVC)
 
                 } else {
                     owner.navigationController?.popViewController(animated: true)

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListDetailViewController.swift
@@ -262,7 +262,6 @@ internal class PlayListDetailViewController: BaseStoryboardReactorViewController
                     guard let textPopUpVC = owner.textPopUpFactory.makeView(
                         text: "변경된 내용을 저장할까요?",
                         cancelButtonIsHidden: false,
-                        allowsDragAndTapToDismiss: nil,
                         confirmButtonText: nil,
                         cancelButtonText: nil,
                         completion: { owner.reactor?.action.onNext(.save) },
@@ -271,7 +270,7 @@ internal class PlayListDetailViewController: BaseStoryboardReactorViewController
                         return
                     }
 
-                    owner.showPanModal(content: textPopUpVC)
+                    owner.showFittedSheets(content: textPopUpVC)
 
                 } else {
                     owner.navigationController?.popViewController(animated: true)

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController+Delegate.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController+Delegate.swift
@@ -32,7 +32,7 @@ extension PlaylistViewController: SongCartViewDelegate {
                     self.hideSongCart()
                 }
             )
-            self.showPanModal(content: popup)
+            self.showFittedSheets(content: popup)
         default:
             return
         }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController+Delegate.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController+Delegate.swift
@@ -32,7 +32,7 @@ extension PlaylistViewController: SongCartViewDelegate {
                     self.hideSongCart()
                 }
             )
-            self.showFittedSheets(content: popup)
+            self.showBottomSheet(content: popup)
         default:
             return
         }

--- a/Projects/Features/RootFeature/Sources/ViewControllers/IntroViewController.swift
+++ b/Projects/Features/RootFeature/Sources/ViewControllers/IntroViewController.swift
@@ -95,17 +95,18 @@ private extension IntroViewController {
                         return
 
                     case .offline:
-                        owner.showPanModal(
+                        owner.showFittedSheets(
                             content: owner.textPopUpFactory.makeView(
                                 text: entity.description,
                                 cancelButtonIsHidden: true,
-                                allowsDragAndTapToDismiss: false,
                                 confirmButtonText: "재시도",
                                 cancelButtonText: nil,
                                 completion: {
                                     owner.input.fetchAppCheck.onNext(())
-                                }, cancelCompletion: nil
-                            ) as? TextPopupViewController ?? .init()
+                                },
+                                cancelCompletion: nil
+                            ),
+                            dismissOnOverlayTapAndPull: false
                         )
                         return
 
@@ -113,19 +114,18 @@ private extension IntroViewController {
                         textPopupVc = owner.textPopUpFactory.makeView(
                             text: "\(entity.title)\(entity.description.isEmpty ? "" : "\n")\(entity.description)",
                             cancelButtonIsHidden: true,
-                            allowsDragAndTapToDismiss: false,
                             confirmButtonText: nil,
                             cancelButtonText: nil,
                             completion: {
                                 exit(0)
-                            }, cancelCompletion: nil
+                            },
+                            cancelCompletion: nil
                         ) as? TextPopupViewController ?? .init()
 
                     case .update:
                         textPopupVc = owner.textPopUpFactory.makeView(
                             text: "\(updateTitle)\n\(updateMessage)",
                             cancelButtonIsHidden: false,
-                            allowsDragAndTapToDismiss: false,
                             confirmButtonText: "업데이트",
                             cancelButtonText: "나중에",
                             completion: {
@@ -140,7 +140,6 @@ private extension IntroViewController {
                         textPopupVc = owner.textPopUpFactory.makeView(
                             text: "\(updateTitle)\n\(updateMessage)",
                             cancelButtonIsHidden: true,
-                            allowsDragAndTapToDismiss: false,
                             confirmButtonText: "업데이트",
                             cancelButtonText: nil,
                             completion: {
@@ -150,25 +149,28 @@ private extension IntroViewController {
                         ) as? TextPopupViewController ?? .init()
                     }
 
-                    owner.showPanModal(content: textPopupVc)
+                    owner.showFittedSheets(
+                        content: textPopupVc,
+                        dismissOnOverlayTapAndPull: false
+                    )
 
-                    #warning("도메인 변경으로 항상 failure")
+                #warning("도메인 변경으로 항상 failure > showTabBar() 호출은 추후 지워야 함")
                 case let .failure(error):
                     owner.lottiePlay(specialLogo: false)
                     owner.showTabBar()
                     /*
-                     owner.showPanModal(
-                         content: owner.textPopUpFactory.makeView(
-                             text: error.asWMError.errorDescription ?? "",
-                             cancelButtonIsHidden: true,
-                             allowsDragAndTapToDismiss: false,
-                             confirmButtonText: nil,
-                             cancelButtonText: nil,
-                             completion: nil,
-                             cancelCompletion: nil
-                         ) as? TextPopupViewController ?? .init()
-                     )
-                      */
+                    owner.showFittedSheets(
+                        content: owner.textPopUpFactory.makeView(
+                            text: error.asWMError.errorDescription ?? "",
+                            cancelButtonIsHidden: true,
+                            confirmButtonText: nil,
+                            cancelButtonText: nil,
+                            completion: nil,
+                            cancelCompletion: nil
+                        ),
+                        dismissOnOverlayTapAndPull: false
+                    )
+                     */
                 }
             })
             .disposed(by: disposeBag)
@@ -189,18 +191,18 @@ private extension IntroViewController {
                 owner.showTabBar()
 
             case let .failure(error):
-                owner.showPanModal(
+                owner.showFittedSheets(
                     content: owner.textPopUpFactory.makeView(
                         text: error.asWMError.errorDescription ?? "",
                         cancelButtonIsHidden: true,
-                        allowsDragAndTapToDismiss: false,
                         confirmButtonText: nil,
                         cancelButtonText: nil,
                         completion: {
                             owner.showTabBar()
                         },
                         cancelCompletion: nil
-                    ) as? TextPopupViewController ?? .init()
+                    ),
+                    dismissOnOverlayTapAndPull: false
                 )
             }
         })

--- a/Projects/Features/RootFeature/Sources/ViewControllers/IntroViewController.swift
+++ b/Projects/Features/RootFeature/Sources/ViewControllers/IntroViewController.swift
@@ -154,23 +154,23 @@ private extension IntroViewController {
                         dismissOnOverlayTapAndPull: false
                     )
 
-                #warning("도메인 변경으로 항상 failure > showTabBar() 호출은 추후 지워야 함")
+                    #warning("도메인 변경으로 항상 failure > showTabBar() 호출은 추후 지워야 함")
                 case let .failure(error):
                     owner.lottiePlay(specialLogo: false)
                     owner.showTabBar()
                     /*
-                    owner.showFittedSheets(
-                        content: owner.textPopUpFactory.makeView(
-                            text: error.asWMError.errorDescription ?? "",
-                            cancelButtonIsHidden: true,
-                            confirmButtonText: nil,
-                            cancelButtonText: nil,
-                            completion: nil,
-                            cancelCompletion: nil
-                        ),
-                        dismissOnOverlayTapAndPull: false
-                    )
-                     */
+                     owner.showFittedSheets(
+                         content: owner.textPopUpFactory.makeView(
+                             text: error.asWMError.errorDescription ?? "",
+                             cancelButtonIsHidden: true,
+                             confirmButtonText: nil,
+                             cancelButtonText: nil,
+                             completion: nil,
+                             cancelCompletion: nil
+                         ),
+                         dismissOnOverlayTapAndPull: false
+                     )
+                      */
                 }
             })
             .disposed(by: disposeBag)

--- a/Projects/Features/RootFeature/Sources/ViewControllers/IntroViewController.swift
+++ b/Projects/Features/RootFeature/Sources/ViewControllers/IntroViewController.swift
@@ -95,7 +95,7 @@ private extension IntroViewController {
                         return
 
                     case .offline:
-                        owner.showFittedSheets(
+                        owner.showBottomSheet(
                             content: owner.textPopUpFactory.makeView(
                                 text: entity.description,
                                 cancelButtonIsHidden: true,
@@ -149,7 +149,7 @@ private extension IntroViewController {
                         ) as? TextPopupViewController ?? .init()
                     }
 
-                    owner.showFittedSheets(
+                    owner.showBottomSheet(
                         content: textPopupVc,
                         dismissOnOverlayTapAndPull: false
                     )
@@ -159,7 +159,7 @@ private extension IntroViewController {
                     owner.lottiePlay(specialLogo: false)
                     owner.showTabBar()
                     /*
-                     owner.showFittedSheets(
+                     owner.showBottomSheet(
                          content: owner.textPopUpFactory.makeView(
                              text: error.asWMError.errorDescription ?? "",
                              cancelButtonIsHidden: true,
@@ -191,7 +191,7 @@ private extension IntroViewController {
                 owner.showTabBar()
 
             case let .failure(error):
-                owner.showFittedSheets(
+                owner.showBottomSheet(
                     content: owner.textPopUpFactory.makeView(
                         text: error.asWMError.errorDescription ?? "",
                         cancelButtonIsHidden: true,

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
@@ -188,7 +188,7 @@ extension BeforeSearchContentViewController: UITableViewDelegate {
                 return
             }
 
-            self.showFittedSheets(content: textPopupViewController)
+            self.showBottomSheet(content: textPopupViewController)
         }
 
         if (Utility.PreferenceManager.recentRecords ?? []).isEmpty {

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
@@ -180,7 +180,6 @@ extension BeforeSearchContentViewController: UITableViewDelegate {
             guard let self = self, let textPopupViewController = self.textPopUpFactory.makeView(
                 text: "전체 내역을 삭제하시겠습니까?",
                 cancelButtonIsHidden: false,
-                allowsDragAndTapToDismiss: nil,
                 confirmButtonText: nil,
                 cancelButtonText: nil,
                 completion: { Utility.PreferenceManager.recentRecords = nil },
@@ -189,7 +188,7 @@ extension BeforeSearchContentViewController: UITableViewDelegate {
                 return
             }
 
-            self.showPanModal(content: textPopupViewController)
+            self.showFittedSheets(content: textPopupViewController)
         }
 
         if (Utility.PreferenceManager.recentRecords ?? []).isEmpty {

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
@@ -2,7 +2,6 @@ import BaseFeature
 import BaseFeatureInterface
 import DesignSystem
 import NeedleFoundation
-import PanModal
 import ReactorKit
 import RxCocoa
 import RxKeyboard

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
@@ -120,7 +120,7 @@ internal final class SearchViewController: BaseStoryboardReactorViewController<S
                     ) as? TextPopupViewController else {
                         return
                     }
-                    owner.showFittedSheets(content: textPopupViewController)
+                    owner.showBottomSheet(content: textPopupViewController)
                 } else {
                     PreferenceManager.shared.addRecentRecords(word: text)
                     owner.view.endEditing(true)

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
@@ -114,7 +114,6 @@ internal final class SearchViewController: BaseStoryboardReactorViewController<S
                     guard let textPopupViewController = owner.textPopUpFactory.makeView(
                         text: "검색어를 입력해주세요.",
                         cancelButtonIsHidden: true,
-                        allowsDragAndTapToDismiss: nil,
                         confirmButtonText: nil,
                         cancelButtonText: nil,
                         completion: nil,
@@ -122,7 +121,7 @@ internal final class SearchViewController: BaseStoryboardReactorViewController<S
                     ) as? TextPopupViewController else {
                         return
                     }
-                    owner.showPanModal(content: textPopupViewController)
+                    owner.showFittedSheets(content: textPopupViewController)
                 } else {
                     PreferenceManager.shared.addRecentRecords(word: text)
                     owner.view.endEditing(true)

--- a/Projects/Features/StorageFeature/Resources/Storage.storyboard
+++ b/Projects/Features/StorageFeature/Resources/Storage.storyboard
@@ -447,6 +447,7 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="v0m-AI-tzJ" firstAttribute="top" secondItem="twt-QZ-fOG" secondAttribute="bottom" id="6Nm-Zd-Pdx"/>
+                            <constraint firstItem="bZq-II-vXy" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="twt-QZ-fOG" secondAttribute="bottom" id="E4I-Wl-36V"/>
                             <constraint firstItem="twt-QZ-fOG" firstAttribute="leading" secondItem="bZq-II-vXy" secondAttribute="leading" id="Fp9-5f-bv4"/>
                             <constraint firstItem="bZq-II-vXy" firstAttribute="trailing" secondItem="twt-QZ-fOG" secondAttribute="trailing" id="JDO-D3-tLq"/>
                             <constraint firstItem="bZq-II-vXy" firstAttribute="trailing" secondItem="v0m-AI-tzJ" secondAttribute="trailing" id="Pqu-3j-S8G"/>

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/FavoriteViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/FavoriteViewController.swift
@@ -232,7 +232,7 @@ extension FavoriteViewController: SongCartViewDelegate {
 //                return
 //            }
 
-        // self.showFittedSheets(content: textPopupViewController)
+        // self.showBottomSheet(content: textPopupViewController)
         default: return
         }
     }

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/FavoriteViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/FavoriteViewController.swift
@@ -218,7 +218,6 @@ extension FavoriteViewController: SongCartViewDelegate {
 //            guard let textPopupViewController = self.textPopUpFactory.makeView(
 //                text: "선택한 좋아요 리스트 \(count)곡이 삭제됩니다.?",
 //                cancelButtonIsHidden: false,
-//                allowsDragAndTapToDismiss: nil,
 //                confirmButtonText: nil,
 //                cancelButtonText: nil,
 //                completion: { [weak self] in
@@ -233,7 +232,7 @@ extension FavoriteViewController: SongCartViewDelegate {
 //                return
 //            }
 
-        // self.showPanModal(content: textPopupViewController)
+        // self.showFittedSheets(content: textPopupViewController)
         default: return
         }
     }

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/MyPlayListViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/MyPlayListViewController.swift
@@ -3,7 +3,6 @@ import BaseFeatureInterface
 import DesignSystem
 import LogManager
 import NVActivityIndicatorView
-import PanModal
 import PlaylistFeatureInterface
 import RxCocoa
 import RxDataSources

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/MyPlayListViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/MyPlayListViewController.swift
@@ -340,7 +340,7 @@ extension MyPlayListViewController: MyPlayListHeaderViewDelegate {
                 return
             }
 
-            self.showFittedSheets(content: vc)
+            self.showBottomSheet(content: vc)
 
             return
         }

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/MyPlayListViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/MyPlayListViewController.swift
@@ -266,7 +266,6 @@ extension MyPlayListViewController: SongCartViewDelegate {
 //            guard let textPopupViewController = self.textPopUpFactory.makeView(
 //                text: "선택한 내 리스트 \(count)개가 삭제됩니다.",
 //                cancelButtonIsHidden: false,
-//                allowsDragAndTapToDismiss: nil,
 //                confirmButtonText: nil,
 //                cancelButtonText: nil,
 //                completion: { [weak self] in
@@ -328,7 +327,6 @@ extension MyPlayListViewController: MyPlayListHeaderViewDelegate {
             guard let vc = self.textPopUpFactory.makeView(
                 text: "로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?",
                 cancelButtonIsHidden: false,
-                allowsDragAndTapToDismiss: nil,
                 confirmButtonText: nil,
                 cancelButtonText: nil,
                 completion: { [weak self] in
@@ -343,7 +341,7 @@ extension MyPlayListViewController: MyPlayListHeaderViewDelegate {
                 return
             }
 
-            self.showPanModal(content: vc)
+            self.showFittedSheets(content: vc)
 
             return
         }

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/ProfilePopViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/ProfilePopViewController.swift
@@ -8,7 +8,6 @@
 
 import DesignSystem
 import NVActivityIndicatorView
-import PanModal
 import RxCocoa
 import RxRelay
 import RxSwift
@@ -166,8 +165,6 @@ extension ProfilePopViewController {
             .subscribe(onNext: { [weak self] height in
                 guard let self = self else { return }
                 self.collectionVIewHeight.constant = height
-                self.panModalSetNeedsLayoutUpdate()
-                self.panModalTransition(to: .longForm)
                 self.view.layoutIfNeeded()
             }).disposed(by: disposeBag)
 
@@ -180,36 +177,6 @@ extension ProfilePopViewController {
                 owner.dismiss(animated: true)
             }
             .disposed(by: disposeBag)
-    }
-}
-
-extension ProfilePopViewController: PanModalPresentable {
-    override public var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
-    }
-
-    public var panModalBackgroundColor: UIColor {
-        return colorFromRGB(0x000000, alpha: 0.4)
-    }
-
-    public var panScrollable: UIScrollView? {
-        return nil
-    }
-
-    public var longFormHeight: PanModalHeight {
-        return PanModalHeight.contentHeight(collectionVIewHeight.constant + 190)
-    }
-
-    public var cornerRadius: CGFloat {
-        return 24.0
-    }
-
-    public var allowsExtendedPanScrolling: Bool {
-        return true
-    }
-
-    public var showDragIndicator: Bool {
-        return false
     }
 }
 

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
@@ -182,7 +182,7 @@ extension StorageViewController {
                     return
                 }
 
-                owner.showFittedSheets(content: vc)
+                owner.showBottomSheet(content: vc)
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
@@ -172,7 +172,6 @@ extension StorageViewController {
                 guard let vc = owner.textPopUpFactory.makeView(
                     text: "로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?",
                     cancelButtonIsHidden: false,
-                    allowsDragAndTapToDismiss: nil,
                     confirmButtonText: nil,
                     cancelButtonText: nil,
                     completion: {
@@ -184,7 +183,7 @@ extension StorageViewController {
                     return
                 }
 
-                owner.showPanModal(content: vc)
+                owner.showFittedSheets(content: vc)
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
@@ -3,7 +3,6 @@ import BaseFeatureInterface
 import DesignSystem
 import KeychainModule
 import Pageboy
-import PanModal
 import ReactorKit
 import RxSwift
 import SignInFeatureInterface

--- a/Projects/Modules/FeatureThirdPartyLib/Project.swift
+++ b/Projects/Modules/FeatureThirdPartyLib/Project.swift
@@ -9,6 +9,7 @@ let project = Project.module(
         .implements(module: .module(.FeatureThirdPartyLib), product: .framework, dependencies: [
             .SPM.Needle,
             .SPM.PanModal,
+            .SPM.FittedSheets,
             .SPM.Lottie,
             .SPM.RxSwift,
             .SPM.RxCocoa,

--- a/Projects/Modules/FeatureThirdPartyLib/Project.swift
+++ b/Projects/Modules/FeatureThirdPartyLib/Project.swift
@@ -8,7 +8,6 @@ let project = Project.module(
     targets: [
         .implements(module: .module(.FeatureThirdPartyLib), product: .framework, dependencies: [
             .SPM.Needle,
-            .SPM.PanModal,
             .SPM.FittedSheets,
             .SPM.Lottie,
             .SPM.RxSwift,

--- a/Projects/Modules/Utility/Sources/Enums/BottomSheetSize.swift
+++ b/Projects/Modules/Utility/Sources/Enums/BottomSheetSize.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum BottomSheetSize {
+    case intrinsic
+    case fixed(CGFloat)
+}

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
@@ -47,17 +47,9 @@ public extension UIViewController {
         size: BottomSheetSize = .intrinsic,
         dismissOnOverlayTapAndPull: Bool = true
     ) {
-        var toSize: SheetSize = .intrinsic
-        switch size {
-        case .intrinsic:
-            toSize = SheetSize.intrinsic
-        case let .fixed(value):
-            toSize = SheetSize.fixed(value)
-        }
-
         showFittedSheets(
             content: content,
-            size: toSize,
+            size: size,
             dismissOnOverlayTapAndPull: dismissOnOverlayTapAndPull
         )
     }
@@ -159,9 +151,17 @@ public extension UIViewController {
 private extension UIViewController {
     func showFittedSheets(
         content: UIViewController,
-        size: SheetSize = .intrinsic,
-        dismissOnOverlayTapAndPull: Bool = true
+        size: BottomSheetSize,
+        dismissOnOverlayTapAndPull: Bool
     ) {
+        var toSize: SheetSize = .intrinsic
+        switch size {
+        case .intrinsic:
+            toSize = SheetSize.intrinsic
+        case let .fixed(value):
+            toSize = SheetSize.fixed(value)
+        }
+
         let options = SheetOptions(
             // The full height of the pull bar.
             // The presented view controller will treat this area as a safearea inset on the top
@@ -196,7 +196,7 @@ private extension UIViewController {
 
         let sheetController = SheetViewController(
             controller: content,
-            sizes: [size],
+            sizes: [toSize],
             options: options
         )
 

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
@@ -8,7 +8,6 @@
 
 import FittedSheets
 import Foundation
-import PanModal
 import SwiftEntryKit
 import SwiftUI
 import UIKit
@@ -37,12 +36,6 @@ public extension UIViewController {
             Preview(viewController: self)
         }
     #endif
-
-    @available(*, deprecated, renamed: "showFittedSheets", message: "'showPanModal' renamed 'showFittedSheets'")
-    func showPanModal(content: UIViewController & PanModalPresentable) {
-        let viewController: PanModalPresentable.LayoutType = content
-        self.presentPanModal(viewController)
-    }
 
     /// PanModal의 대체
     /// - Parameter content: ViewController

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
@@ -117,10 +117,10 @@ public extension UIViewController {
         // Disable the ability to pull down to dismiss the modal
         sheetController.dismissOnPull = dismissOnOverlayTapAndPull
 
-        /// Allow pulling past the maximum height and bounce back. Defaults to true.
+        // Allow pulling past the maximum height and bounce back. Defaults to true.
         sheetController.allowPullingPastMaxHeight = false
 
-        /// Automatically grow/move the sheet to accomidate the keyboard. Defaults to true.
+        // Automatically grow/move the sheet to accomidate the keyboard. Defaults to true.
         sheetController.autoAdjustToKeyboard = true
 
         // Color of the sheet anywhere the child view controller may not show (or is transparent),

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
@@ -37,93 +37,29 @@ public extension UIViewController {
         }
     #endif
 
-    /// PanModal의 대체
+    /// showBottomSheet(): PanModal의 대체
     /// - Parameter content: ViewController
     /// - Parameter size: 내부 컨텐츠로 사이즈 결정이 가능하면 .intrinsic, 고정시켜야 하는 경우: .fixed(200), (default: .intrinsic)
     /// - Parameter dismissOnOverlayTapAndPull: 오버레이 영역 터치하거나 당겨서 닫기 허용여부 (default: true)
     /// - 버튼을 눌러서 다음 행동을 해야하는 경우 dismissOnOverlayTapAndPull 옵션을 필수로 false 설정할 것. (ex: 강제업데이트 팝업)
-    func showFittedSheets(
+    func showBottomSheet(
         content: UIViewController,
-        size: SheetSize = .intrinsic,
+        size: BottomSheetSize = .intrinsic,
         dismissOnOverlayTapAndPull: Bool = true
     ) {
-        let options = SheetOptions(
-            // The full height of the pull bar.
-            // The presented view controller will treat this area as a safearea inset on the top
-            pullBarHeight: 0,
+        var toSize: SheetSize = .intrinsic
+        switch size {
+        case .intrinsic:
+            toSize = SheetSize.intrinsic
+        case let .fixed(value):
+            toSize = SheetSize.fixed(value)
+        }
 
-            // The corner radius of the shrunken presenting view controller
-            presentingViewCornerRadius: 24,
-
-            // Extends the background behind the pull bar or not
-            shouldExtendBackground: true,
-
-            // Attempts to use intrinsic heights on navigation controllers.
-            // This does not work well in combination with keyboards without your code handling it.
-            setIntrinsicHeightOnNavigationControllers: true,
-
-            // Pulls the view controller behind the safe area top,
-            // especially useful when embedding navigation controllers
-            useFullScreenMode: true,
-
-            // Shrinks the presenting view controller, similar to the native modal
-            shrinkPresentingViewController: false,
-
-            // Determines if using inline mode or not
-            useInlineMode: false,
-
-            // Adds a padding on the left and right of the sheet with this amount. Defaults to zero (no padding)
-            horizontalPadding: 0,
-
-            // Sets the maximum width allowed for the sheet. This defaults to nil and doesn't limit the width.
-            maxWidth: nil
+        showFittedSheets(
+            content: content,
+            size: toSize,
+            dismissOnOverlayTapAndPull: dismissOnOverlayTapAndPull
         )
-
-        let sheetController = SheetViewController(
-            controller: content,
-            sizes: [size],
-            options: options
-        )
-
-        // The size of the grip in the pull bar
-        sheetController.gripSize = .zero
-
-        // The color of the grip on the pull bar
-        sheetController.gripColor = UIColor.clear
-
-        // The corner radius of the sheet
-        sheetController.cornerRadius = 24
-
-        // minimum distance above the pull bar, prevents bar from coming right up to the edge of the screen
-        sheetController.minimumSpaceAbovePullBar = 0
-
-        // Set the pullbar's background explicitly
-        sheetController.pullBarBackgroundColor = UIColor.clear
-
-        // Determine if the rounding should happen on the pullbar or the presented controller only
-        // (should only be true when the pull bar's background color is .clear)
-        sheetController.treatPullBarAsClear = false
-
-        // Disable the dismiss on background tap functionality
-        sheetController.dismissOnOverlayTap = dismissOnOverlayTapAndPull
-
-        // Disable the ability to pull down to dismiss the modal
-        sheetController.dismissOnPull = dismissOnOverlayTapAndPull
-
-        // Allow pulling past the maximum height and bounce back. Defaults to true.
-        sheetController.allowPullingPastMaxHeight = false
-
-        // Automatically grow/move the sheet to accomidate the keyboard. Defaults to true.
-        sheetController.autoAdjustToKeyboard = true
-
-        // Color of the sheet anywhere the child view controller may not show (or is transparent),
-        // such as behind the keyboard currently
-        sheetController.contentBackgroundColor = UIColor.clear
-
-        // Change the overlay color
-        sheetController.overlayColor = UIColor.black.withAlphaComponent(0.4)
-
-        self.present(sheetController, animated: true, completion: nil)
     }
 
     func showEntryKitModal(content: UIViewController, height: CGFloat) {
@@ -217,5 +153,91 @@ public extension UIViewController {
         guard let storeURL = URL(string: "https://itunes.apple.com/kr/app/id/\(appID)"),
               UIApplication.shared.canOpenURL(storeURL) else { return }
         UIApplication.shared.open(storeURL)
+    }
+}
+
+private extension UIViewController {
+    func showFittedSheets(
+        content: UIViewController,
+        size: SheetSize = .intrinsic,
+        dismissOnOverlayTapAndPull: Bool = true
+    ) {
+        let options = SheetOptions(
+            // The full height of the pull bar.
+            // The presented view controller will treat this area as a safearea inset on the top
+            pullBarHeight: 0,
+
+            // The corner radius of the shrunken presenting view controller
+            presentingViewCornerRadius: 24,
+
+            // Extends the background behind the pull bar or not
+            shouldExtendBackground: true,
+
+            // Attempts to use intrinsic heights on navigation controllers.
+            // This does not work well in combination with keyboards without your code handling it.
+            setIntrinsicHeightOnNavigationControllers: true,
+
+            // Pulls the view controller behind the safe area top,
+            // especially useful when embedding navigation controllers
+            useFullScreenMode: true,
+
+            // Shrinks the presenting view controller, similar to the native modal
+            shrinkPresentingViewController: false,
+
+            // Determines if using inline mode or not
+            useInlineMode: false,
+
+            // Adds a padding on the left and right of the sheet with this amount. Defaults to zero (no padding)
+            horizontalPadding: 0,
+
+            // Sets the maximum width allowed for the sheet. This defaults to nil and doesn't limit the width.
+            maxWidth: nil
+        )
+
+        let sheetController = SheetViewController(
+            controller: content,
+            sizes: [size],
+            options: options
+        )
+
+        // The size of the grip in the pull bar
+        sheetController.gripSize = .zero
+
+        // The color of the grip on the pull bar
+        sheetController.gripColor = UIColor.clear
+
+        // The corner radius of the sheet
+        sheetController.cornerRadius = 24
+
+        // minimum distance above the pull bar, prevents bar from coming right up to the edge of the screen
+        sheetController.minimumSpaceAbovePullBar = 0
+
+        // Set the pullbar's background explicitly
+        sheetController.pullBarBackgroundColor = UIColor.clear
+
+        // Determine if the rounding should happen on the pullbar or the presented controller only
+        // (should only be true when the pull bar's background color is .clear)
+        sheetController.treatPullBarAsClear = false
+
+        // Disable the dismiss on background tap functionality
+        sheetController.dismissOnOverlayTap = dismissOnOverlayTapAndPull
+
+        // Disable the ability to pull down to dismiss the modal
+        sheetController.dismissOnPull = dismissOnOverlayTapAndPull
+
+        // Allow pulling past the maximum height and bounce back. Defaults to true.
+        sheetController.allowPullingPastMaxHeight = false
+
+        // Automatically grow/move the sheet to accomidate the keyboard. Defaults to true.
+        sheetController.autoAdjustToKeyboard = true
+
+        // Color of the sheet anywhere the child view controller may not show (or is transparent),
+        // such as behind the keyboard currently
+        sheetController.contentBackgroundColor = UIColor.clear
+
+        // Change the overlay color
+        sheetController.overlayColor = UIColor.black.withAlphaComponent(0.4)
+
+        self.present(sheetController, animated: true, completion: nil)
     }
 }

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 yongbeomkwak. All rights reserved.
 //
 
+import FittedSheets
 import Foundation
 import PanModal
 import SwiftEntryKit
@@ -37,9 +38,99 @@ public extension UIViewController {
         }
     #endif
 
+    @available(*, deprecated, renamed: "showFittedSheets", message: "'showPanModal' renamed 'showFittedSheets'")
     func showPanModal(content: UIViewController & PanModalPresentable) {
         let viewController: PanModalPresentable.LayoutType = content
         self.presentPanModal(viewController)
+    }
+
+    /// PanModal의 대체
+    /// - Parameter content: ViewController
+    /// - Parameter size: 내부 컨텐츠로 사이즈 결정이 가능하면 .intrinsic, 고정시켜야 하는 경우: .fixed(200), (default: .intrinsic)
+    /// - Parameter dismissOnOverlayTapAndPull: 오버레이 영역 터치하거나 당겨서 닫기 허용여부 (default: true)
+    /// - 버튼을 눌러서 다음 행동을 해야하는 경우 dismissOnOverlayTapAndPull 옵션을 필수로 false 설정할 것. (ex: 강제업데이트 팝업)
+    func showFittedSheets(
+        content: UIViewController,
+        size: SheetSize = .intrinsic,
+        dismissOnOverlayTapAndPull: Bool = true
+    ) {
+        let options = SheetOptions(
+            // The full height of the pull bar.
+            // The presented view controller will treat this area as a safearea inset on the top
+            pullBarHeight: 0,
+
+            // The corner radius of the shrunken presenting view controller
+            presentingViewCornerRadius: 24,
+
+            // Extends the background behind the pull bar or not
+            shouldExtendBackground: true,
+
+            // Attempts to use intrinsic heights on navigation controllers.
+            // This does not work well in combination with keyboards without your code handling it.
+            setIntrinsicHeightOnNavigationControllers: true,
+
+            // Pulls the view controller behind the safe area top,
+            // especially useful when embedding navigation controllers
+            useFullScreenMode: true,
+
+            // Shrinks the presenting view controller, similar to the native modal
+            shrinkPresentingViewController: false,
+
+            // Determines if using inline mode or not
+            useInlineMode: false,
+
+            // Adds a padding on the left and right of the sheet with this amount. Defaults to zero (no padding)
+            horizontalPadding: 0,
+
+            // Sets the maximum width allowed for the sheet. This defaults to nil and doesn't limit the width.
+            maxWidth: nil
+        )
+
+        let sheetController = SheetViewController(
+            controller: content,
+            sizes: [size],
+            options: options
+        )
+
+        // The size of the grip in the pull bar
+        sheetController.gripSize = .zero
+
+        // The color of the grip on the pull bar
+        sheetController.gripColor = UIColor.clear
+
+        // The corner radius of the sheet
+        sheetController.cornerRadius = 24
+
+        // minimum distance above the pull bar, prevents bar from coming right up to the edge of the screen
+        sheetController.minimumSpaceAbovePullBar = 0
+
+        // Set the pullbar's background explicitly
+        sheetController.pullBarBackgroundColor = UIColor.clear
+
+        // Determine if the rounding should happen on the pullbar or the presented controller only
+        // (should only be true when the pull bar's background color is .clear)
+        sheetController.treatPullBarAsClear = false
+
+        // Disable the dismiss on background tap functionality
+        sheetController.dismissOnOverlayTap = dismissOnOverlayTapAndPull
+
+        // Disable the ability to pull down to dismiss the modal
+        sheetController.dismissOnPull = dismissOnOverlayTapAndPull
+
+        /// Allow pulling past the maximum height and bounce back. Defaults to true.
+        sheetController.allowPullingPastMaxHeight = false
+
+        /// Automatically grow/move the sheet to accomidate the keyboard. Defaults to true.
+        sheetController.autoAdjustToKeyboard = true
+
+        // Color of the sheet anywhere the child view controller may not show (or is transparent),
+        // such as behind the keyboard currently
+        sheetController.contentBackgroundColor = UIColor.clear
+
+        // Change the overlay color
+        sheetController.overlayColor = UIColor.black.withAlphaComponent(0.4)
+
+        self.present(sheetController, animated: true, completion: nil)
     }
 
     func showEntryKitModal(content: UIViewController, height: CGFloat) {


### PR DESCRIPTION
## 💡 배경 및 개요
PanModal 라이브러리의 유지보수 중단으로인해 더 이상 사용할 수 없음. 
이미 프로젝트에서 사용하던 SwiftEntryKit으로 대체하려 했으나, 이것도 문제가 있었음.
다른 대체제를 찾다보니 FittedSheets 발견.

Resolves: #551 

## 📃 작업내용
- showPanModal()이 호출되던 곳을 전부 showFittedSheets로 대체함.
- showFittedSheets 함수에 대한 설명은 주석을 달아두었음.
- TextPopupViewController에서 사용하던 [allowsDragAndTapToDismiss: Bool] 옵션은 더 이상 사용하지 않음. showFittedSheets() 호출 시 내부에서 설정하는 것으로 변경 됨.
- 래퍼 함수를 둬서 최종적으로 사용할 때, 호출해야할 함수는 showBottomSheet()로 변경.

## 🙋‍♂️ 리뷰노트
- 그나마 유지보수가 최근까지 되던 것이라 사용했는데, 어떤지 의견 구함. 
https://github.com/gordontucker/FittedSheets
- PanModal 패키지는 아직 지우지 않음. 이 PR이 승인된다면 관련 코드와 함께 지우고 머지 하도록 함.
- 레이아웃 충돌 경고가 떠서 해결 중

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
