### PR TITLE
🔀 :: (#641) 필터 및 정렬 중복 방지 코드를 적용했습니다.

### DIFF
--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -87,6 +87,7 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
         let sharedState = reactor.state.share()
 
         sharedState.map(\.sortType)
+            .distinctUntilChanged()
             .bind(with: self) { owner, type in
                 owner.headerView.updateSortState(type)
             }
@@ -189,7 +190,9 @@ extension ListSearchResultViewController {
 
 extension ListSearchResultViewController: SearchSortOptionDelegate {
     func updateSortType(_ type: SortType) {
-        reactor?.action.onNext(.changeSortType(type))
+        if reactor?.currentState.sortType != type {
+            reactor?.action.onNext(.changeSortType(type))
+        }
     }
 }
 

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -177,7 +177,10 @@ extension SongSearchResultViewController {
         let dataSource = UICollectionViewDiffableDataSource<
             SongSearchResultSection,
             SongEntity
-        >(collectionView: collectionView) { (collectionView: UICollectionView, indexPath:IndexPath, item: SongEntity
+        >(collectionView: collectionView) { (
+            collectionView: UICollectionView,
+            indexPath: IndexPath,
+            item: SongEntity
         ) -> UICollectionViewCell? in
 
             return collectionView.dequeueConfiguredReusableCell(

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -82,6 +82,7 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
             .disposed(by: disposeBag)
 
         headerView.rx.selectedFilterItem
+            .distinctUntilChanged()
             .bind(with: self) { owner, type in
                 reactor.action.onNext(.changeFilterType(type))
             }
@@ -94,6 +95,7 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
         let sharedState = reactor.state.share()
 
         sharedState.map(\.sortType)
+            .distinctUntilChanged()
             .bind(with: self) { owner, type in
                 owner.headerView.updateSortState(type)
             }
@@ -175,10 +177,7 @@ extension SongSearchResultViewController {
         let dataSource = UICollectionViewDiffableDataSource<
             SongSearchResultSection,
             SongEntity
-        >(collectionView: collectionView) { (
-            collectionView: UICollectionView,
-            indexPath: IndexPath,
-            item: SongEntity
+        >(collectionView: collectionView) { (collectionView: UICollectionView, indexPath:IndexPath, item: SongEntity
         ) -> UICollectionViewCell? in
 
             return collectionView.dequeueConfiguredReusableCell(
@@ -196,7 +195,9 @@ extension SongSearchResultViewController {
 
 extension SongSearchResultViewController: SearchSortOptionDelegate {
     func updateSortType(_ type: SortType) {
-        reactor?.action.onNext(.changeSortType(type))
+        if reactor?.currentState.sortType != type {
+            reactor?.action.onNext(.changeSortType(type))
+        }
     }
 }
 


### PR DESCRIPTION
## 💡 배경 및 개요

- 같은 필터또는 정렬을 적용해도 데이터를 불러오는 버그가 있었습니다.

Resolves: #641

## 📃 작업내용

- 필터 및 정렬 중복 방지 코드를 적용했습니다.

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
