### PR TITLE
🔀 :: (#655) 아티스트 상세 빈 데이터 UI 처리

### DIFF
--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
@@ -90,7 +90,7 @@ private extension ArtistMusicContentViewController {
                 let warningView = WarningView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: height))
                 warningView.text = "아티스트 곡이 없습니다."
                 self.tableView.tableFooterView = dataSource.isEmpty ?
-                warningView : UIView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: PLAYER_HEIGHT()))
+                    warningView : UIView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: PLAYER_HEIGHT()))
                 self.activityIndidator.stopAnimating()
                 guard let songCart = self.songCartView else { return }
                 songCart.updateAllSelect(isAll: songs.count == dataSource.count)

--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
@@ -51,8 +51,8 @@ public class ArtistMusicContentViewController: BaseViewController, ViewControlle
     }
 }
 
-extension ArtistMusicContentViewController {
-    private func inputBind() {
+private extension ArtistMusicContentViewController {
+    func inputBind() {
         tableView.rx
             .setDelegate(self)
             .disposed(by: disposeBag)
@@ -80,7 +80,7 @@ extension ArtistMusicContentViewController {
             .disposed(by: disposeBag)
     }
 
-    private func outputBind() {
+    func outputBind() {
         output.dataSource
             .skip(1)
             .withLatestFrom(output.indexOfSelectedSongs) { ($0, $1) }
@@ -89,7 +89,8 @@ extension ArtistMusicContentViewController {
                 let height = self.tableView.frame.height / 3 * 2
                 let warningView = WarningView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: height))
                 warningView.text = "아티스트 곡이 없습니다."
-                self.tableView.tableFooterView = dataSource.isEmpty ? warningView : nil
+                self.tableView.tableFooterView = dataSource.isEmpty ?
+                warningView : UIView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: PLAYER_HEIGHT()))
                 self.activityIndidator.stopAnimating()
                 guard let songCart = self.songCartView else { return }
                 songCart.updateAllSelect(isAll: songs.count == dataSource.count)
@@ -129,13 +130,11 @@ extension ArtistMusicContentViewController {
             }).disposed(by: disposeBag)
     }
 
-    private func configureUI() {
-        self.activityIndidator.color = DesignSystemAsset.PrimaryColor.point.color
-        self.activityIndidator.type = .circleStrokeSpin
-        self.activityIndidator.startAnimating()
-        self.tableView.backgroundColor = .clear
-        self.tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: PLAYER_HEIGHT()))
-        self.tableView.verticalScrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: PLAYER_HEIGHT(), right: 0)
+    func configureUI() {
+        activityIndidator.color = DesignSystemAsset.PrimaryColor.point.color
+        activityIndidator.type = .circleStrokeSpin
+        activityIndidator.startAnimating()
+        tableView.backgroundColor = .clear
     }
 }
 

--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
@@ -2,13 +2,13 @@ import ArtistDomainInterface
 import BaseFeature
 import BaseFeatureInterface
 import DesignSystem
+import LogManager
 import NVActivityIndicatorView
 import RxCocoa
 import RxSwift
 import SongsDomainInterface
 import UIKit
 import Utility
-import LogManager
 
 public class ArtistMusicContentViewController: BaseViewController, ViewControllerFromStoryBoard, SongCartViewType {
     @IBOutlet weak var tableView: UITableView!

--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistViewController.swift
@@ -94,7 +94,7 @@ public final class ArtistViewController:
 
 extension ArtistViewController {
     private func configureUI() {
-        self.view.backgroundColor = DesignSystemAsset.GrayColor.gray100.color
+        view.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
         activityIndicator.color = DesignSystemAsset.PrimaryColor.point.color
         activityIndicator.type = .circleStrokeSpin
         activityIndicator.startAnimating()
@@ -108,8 +108,8 @@ extension ArtistViewController {
         layout.headerHeight = 0
         layout.footerHeight = 56.0
 
-        self.collectionView.setCollectionViewLayout(layout, animated: false)
-        self.collectionView.showsVerticalScrollIndicator = false
+        collectionView.setCollectionViewLayout(layout, animated: false)
+        collectionView.showsVerticalScrollIndicator = false
     }
 }
 


### PR DESCRIPTION
## 💡 배경 및 개요
🔀 :: (#655) 아티스트 상세 빈 데이터 UI 처리

Resolves: #655 

## 📃 작업내용
![Simulator Screenshot - iPhone 15 Pro Max - 2024-06-23 at 20 21 31](https://github.com/wakmusic/wakmusic-iOS/assets/37323252/7a374a7f-2153-4bd5-908c-ca6230680556)

## 🙋‍♂️ 리뷰노트
x

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
