### PR TITLE
🔀 :: (666) 로그인이 안되던 문제 해결

### DIFF
--- a/Projects/Domains/AuthDomain/Sources/API/AuthAPI.swift
+++ b/Projects/Domains/AuthDomain/Sources/API/AuthAPI.swift
@@ -9,9 +9,8 @@ public enum AuthAPI {
     case reGenerateAccessToken
 }
 
-#warning("오타 서버에서 고치면 대응 예정")
 private struct FetchTokenRequestParameters: Encodable {
-    var privoder: String
+    var provider: String
     var token: String
 }
 
@@ -51,7 +50,7 @@ extension AuthAPI: WMAPI {
         case let .fetchToken(providerType: providerType, token: id):
             return .requestJSONEncodable(
                 FetchTokenRequestParameters(
-                    privoder: providerType.rawValue,
+                    provider: providerType.rawValue,
                     token: id
                 )
             )

--- a/Projects/Domains/AuthDomain/Sources/API/AuthAPI.swift
+++ b/Projects/Domains/AuthDomain/Sources/API/AuthAPI.swift
@@ -9,8 +9,9 @@ public enum AuthAPI {
     case reGenerateAccessToken
 }
 
+#warning("오타 서버에서 고치면 대응 예정")
 private struct FetchTokenRequestParameters: Encodable {
-    var provider: String
+    var privoder: String
     var token: String
 }
 
@@ -50,7 +51,7 @@ extension AuthAPI: WMAPI {
         case let .fetchToken(providerType: providerType, token: id):
             return .requestJSONEncodable(
                 FetchTokenRequestParameters(
-                    provider: providerType.rawValue,
+                    privoder: providerType.rawValue,
                     token: id
                 )
             )

--- a/Projects/Domains/UserDomain/Sources/ResponseDTO/FetchUserResponseDTO.swift
+++ b/Projects/Domains/UserDomain/Sources/ResponseDTO/FetchUserResponseDTO.swift
@@ -1,29 +1,28 @@
 import Foundation
 import UserDomainInterface
 
-#warning("리스폰스에 platform 추가 되면 옵셔널 해제 필요")
 public struct FetchUserResponseDTO: Decodable, Equatable {
-    public let id, itemCount, createdAt: Int
-    public let name, profile: String
-    public var platform: String?
+    public let itemCount, createdAt: Int
+    public let id, name, profile, platform: String
 
     public static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.id == rhs.id
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, name, itemCount
+        case platform = "loginType"
+        case id = "handle"
+        case name, itemCount
         case profile = "profileUrl"
         case createdAt
-        // case platform
     }
 }
 
 public extension FetchUserResponseDTO {
     func toDomain() -> UserInfoEntity {
         UserInfoEntity(
-            id: String(id),
-            platform: platform ?? "알수없음",
+            id: id,
+            platform: platform,
             name: name,
             profile: profile,
             version: 0

--- a/Projects/Domains/UserDomain/Sources/ResponseDTO/FetchUserResponseDTO.swift
+++ b/Projects/Domains/UserDomain/Sources/ResponseDTO/FetchUserResponseDTO.swift
@@ -1,43 +1,32 @@
-//
-//  FetchUserResponseDTO.swift
-//  DataMappingModule
-//
-//  Created by yongbeomkwak on 12/8/23.
-//  Copyright © 2023 yongbeomkwak. All rights reserved.
-//
-
 import Foundation
 import UserDomainInterface
 
+#warning("리스폰스에 platform 추가 되면 옵셔널 해제 필요")
 public struct FetchUserResponseDTO: Decodable, Equatable {
-    public let id, platform, name: String
-    public let profile: FetchUserResponseDTO.Profile?
+    public let id, itemCount, createdAt: Int
+    public let name, profile: String
+    public var platform: String?
 
     public static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.id == rhs.id
     }
 
     enum CodingKeys: String, CodingKey {
-        case id = "userId"
-        case platform, name, profile
-    }
-}
-
-public extension FetchUserResponseDTO {
-    struct Profile: Codable {
-        public let type: String
-        public let version: Int
+        case id, name, itemCount
+        case profile = "profileUrl"
+        case createdAt
+        //case platform
     }
 }
 
 public extension FetchUserResponseDTO {
     func toDomain() -> UserInfoEntity {
         UserInfoEntity(
-            id: id,
-            platform: platform,
+            id: String(id),
+            platform: platform ?? "알수없음",
             name: name,
-            profile: profile?.type ?? "",
-            version: profile?.version ?? 0
+            profile: profile,
+            version: 0
         )
     }
 }

--- a/Projects/Domains/UserDomain/Sources/ResponseDTO/FetchUserResponseDTO.swift
+++ b/Projects/Domains/UserDomain/Sources/ResponseDTO/FetchUserResponseDTO.swift
@@ -15,7 +15,7 @@ public struct FetchUserResponseDTO: Decodable, Equatable {
         case id, name, itemCount
         case profile = "profileUrl"
         case createdAt
-        //case platform
+        // case platform
     }
 }
 

--- a/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
@@ -63,7 +63,7 @@ extension LoginViewController {
                 guard let self = self else { return }
                 self.showToast(text: msg, font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
             }).disposed(by: disposeBag)
-        
+
         output
             .shouldDismiss
             .bind(with: self) { owner, _ in

--- a/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
@@ -63,6 +63,12 @@ extension LoginViewController {
                 guard let self = self else { return }
                 self.showToast(text: msg, font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
             }).disposed(by: disposeBag)
+        
+        output
+            .shouldDismiss
+            .bind(with: self) { owner, _ in
+                owner.dismiss(animated: true)
+            }.disposed(by: disposeBag)
     }
 
     private func configureLogin() {

--- a/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
@@ -91,7 +91,7 @@ public final class LoginViewModel: NSObject, ViewModelType { // 네이버 델리
                 output.showErrorToast.accept(error.errorDescription ?? "알수 없는 오류가 발생하였습니다.")
                 output.shouldDismiss.accept(())
             }).disposed(by: disposeBag)
-        
+
         return output
     }
 

--- a/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
@@ -39,7 +39,8 @@ public final class LoginViewModel: NSObject, ViewModelType { // 네이버 델리
     }
 
     public struct Output {
-        let showErrorToast: PublishRelay<String>
+        let showErrorToast: PublishRelay<String> = .init()
+        let shouldDismiss: PublishRelay<Void> = .init()
     }
 
     public init(
@@ -54,7 +55,7 @@ public final class LoginViewModel: NSObject, ViewModelType { // 네이버 델리
     }
 
     public func transform(from input: Input) -> Output {
-        let showErrorToast = PublishRelay<String>()
+        let output = Output()
         inputTransfrom(input: input)
 
         // MARK: (Naver, Google, Apple)Token WMToken으로 치환
@@ -63,35 +64,35 @@ public final class LoginViewModel: NSObject, ViewModelType { // 네이버 델리
             .filter { !$0.1.isEmpty }
             .flatMap { [fetchTokenUseCase] provider, token in
                 fetchTokenUseCase.execute(providerType: provider, token: token)
-                    .catchAndReturn(AuthLoginEntity(token: ""))
+                    .catch { (error: Error) in
+                        return Single.error(error)
+                    }
                     .asObservable()
             }
             .flatMap { [fetchUserInfoUseCase] _ in
                 fetchUserInfoUseCase.execute()
-                    .catchAndReturn(
-                        UserInfoEntity(
-                            id: "",
-                            platform: "apple",
-                            name: "ifari",
-                            profile: "panchi",
-                            version: 1
-                        )
-                    )
+                    .catch { (error: Error) in
+                        return Single.error(error)
+                    }
                     .asObservable()
             }
-            .bind {
-                LogManager.setUserID(userID: $0.id)
+            .subscribe(onNext: { entity in
+                LogManager.setUserID(userID: entity.id)
                 PreferenceManager.shared.setUserInfo(
-                    ID: AES256.encrypt(string: $0.id),
-                    platform: $0.platform,
-                    profile: $0.profile,
-                    name: AES256.encrypt(string: $0.name),
-                    version: $0.version
+                    ID: AES256.encrypt(string: entity.id),
+                    platform: entity.platform,
+                    profile: entity.profile,
+                    name: AES256.encrypt(string: entity.name),
+                    version: entity.version
                 )
-            }
-            .disposed(by: disposeBag)
-
-        return Output(showErrorToast: showErrorToast)
+                output.shouldDismiss.accept(())
+            }, onError: { error in
+                let error = error.asWMError
+                output.showErrorToast.accept(error.errorDescription ?? "알수 없는 오류가 발생하였습니다.")
+                output.shouldDismiss.accept(())
+            }).disposed(by: disposeBag)
+        
+        return output
     }
 
     // MARK: Input Binding


### PR DESCRIPTION
## 💡 배경 및 개요
로그인이 필요한 작업들이 많이 남아서 급히 픽스했습니다.

Resolves: #666

## 📃 작업내용

- ~로그인 api request body 에 오탈자가 있어 대응해뒀습니다. 바뀌면 다시 대응해야함.~ 오탈자 수정되었습니다.
- 유저정보 DTO가 바뀌어 맞게 수정했습니다.

## 🙋‍♂️ 리뷰노트

- #663 
- 위 이슈랑 연관되는 문제인데, **itemCount, createdAt 등 신규 생성 필드에 대해선 Entity에 대응이 안되어있어** PreferenceManager.userInfo 에도 저장이 안됩니다. Entity 수정 시 건드려야 할 곳이 많아 해당 PR에선 다루지 않았습니다.
```Swift
// 서버 리스폰스
{
  "loginType": "string",
  "handle": "string",
  "name": "string",
  "itemCount": 0,
  "profileUrl": "string",
  "createdAt": 0
}
// DTO
public struct FetchUserResponseDTO: Decodable, Equatable {
    public let itemCount, createdAt: Int
    public let id, name, profile, platform: String

    enum CodingKeys: String, CodingKey {
        case platform = "loginType"
        case id = "handle"
        case name, itemCount
        case profile = "profileUrl"
        case createdAt
    }
}

public extension FetchUserResponseDTO {
    func toDomain() -> UserInfoEntity {
        UserInfoEntity(
            id: id,
            platform: platform,
            name: name,
            profile: profile,
            version: 0
        )
    }
}
// Entity
public struct UserInfoEntity: Equatable {
    public let id, platform, name, profile: String
    public let version: Int

   public init(... ) { ... }

}
// PreferenceManager.UserInfo
public struct UserInfo: Codable, Equatable {
    public let ID: String
    public let platform: String
    public let profile: String
    public let name: String
    public let version: Int
}
```

## ✅ PR 체크리스트
- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
