### PR TITLE
🔀 :: (#685)  Multipurpose VC에서 Usecase를 제거합니다.

### DIFF
--- a/Projects/App/Sources/Application/AppComponent+Base.swift
+++ b/Projects/App/Sources/Application/AppComponent+Base.swift
@@ -3,8 +3,8 @@ import BaseFeatureInterface
 import Foundation
 
 public extension AppComponent {
-    var multiPurposePopUpFactory: any MultiPurposePopUpFactory {
-        MultiPurposePopUpComponent(parent: self)
+    var multiPurposePopUpFactory: any MultiPurposePopupFactory {
+        MultiPurposePopupComponent(parent: self)
     }
 
     var textPopUpFactory: any TextPopUpFactory {

--- a/Projects/Features/BaseFeature/Interface/MultipurposePopUp/MultiPurposePopupFactory.swift
+++ b/Projects/Features/BaseFeature/Interface/MultipurposePopUp/MultiPurposePopupFactory.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public protocol MultiPurposePopUpFactory {
+public protocol MultiPurposePopupFactory {
     func makeView(
         type: PurposeType,
         key: String,

--- a/Projects/Features/BaseFeature/Sources/Components/ContainSongsComponent.swift
+++ b/Projects/Features/BaseFeature/Sources/Components/ContainSongsComponent.swift
@@ -7,7 +7,7 @@ import UIKit
 import UserDomainInterface
 
 public protocol ContainSongsDependency: Dependency {
-    var multiPurposePopUpFactory: any MultiPurposePopUpFactory { get }
+    var multiPurposePopUpFactory: any MultiPurposePopupFactory { get }
     var fetchPlayListUseCase: any FetchPlayListUseCase { get }
     var addSongIntoPlaylistUseCase: any AddSongIntoPlaylistUseCase { get }
     var logoutUseCase: any LogoutUseCase { get }

--- a/Projects/Features/BaseFeature/Sources/Components/MultiPurposePopUpComponent.swift
+++ b/Projects/Features/BaseFeature/Sources/Components/MultiPurposePopUpComponent.swift
@@ -6,14 +6,8 @@ import PlaylistDomainInterface
 import UIKit
 import UserDomainInterface
 
-public protocol MultiPurposePopUpDependency: Dependency {
-    var createPlaylistUseCase: any CreatePlaylistUseCase { get }
-    var setUserNameUseCase: any SetUserNameUseCase { get }
-    var updateTitleAndPrivateUseCase: any UpdateTitleAndPrivateUseCase { get }
-    var logoutUseCase: any LogoutUseCase { get }
-}
 
-public final class MultiPurposePopUpComponent: Component<MultiPurposePopUpDependency>, MultiPurposePopUpFactory {
+public final class MultiPurposePopUpComponent: Component<EmptyDependency>, MultiPurposePopUpFactory {
     public func makeView(
         type: PurposeType,
         key: String,
@@ -22,12 +16,7 @@ public final class MultiPurposePopUpComponent: Component<MultiPurposePopUpDepend
         return MultiPurposePopupViewController.viewController(
             viewModel: .init(
                 type: type,
-                key: key,
-                createPlaylistUseCase: dependency.createPlaylistUseCase,
-                setUserNameUseCase: dependency.setUserNameUseCase,
-                updateTitleAndPrivateUseCase: dependency.updateTitleAndPrivateUseCase,
-                logoutUseCase: dependency.logoutUseCase
-            ),
+                key: key),
             completion: completion
         )
     }

--- a/Projects/Features/BaseFeature/Sources/Components/MultiPurposePopupComponent.swift
+++ b/Projects/Features/BaseFeature/Sources/Components/MultiPurposePopupComponent.swift
@@ -6,7 +6,6 @@ import PlaylistDomainInterface
 import UIKit
 import UserDomainInterface
 
-
 public final class MultiPurposePopupComponent: Component<EmptyDependency>, MultiPurposePopupFactory {
     public func makeView(
         type: PurposeType,
@@ -16,7 +15,8 @@ public final class MultiPurposePopupComponent: Component<EmptyDependency>, Multi
         return MultiPurposePopupViewController.viewController(
             viewModel: .init(
                 type: type,
-                key: key),
+                key: key
+            ),
             completion: completion
         )
     }

--- a/Projects/Features/BaseFeature/Sources/Components/MultiPurposePopupComponent.swift
+++ b/Projects/Features/BaseFeature/Sources/Components/MultiPurposePopupComponent.swift
@@ -7,7 +7,7 @@ import UIKit
 import UserDomainInterface
 
 
-public final class MultiPurposePopUpComponent: Component<EmptyDependency>, MultiPurposePopUpFactory {
+public final class MultiPurposePopupComponent: Component<EmptyDependency>, MultiPurposePopupFactory {
     public func makeView(
         type: PurposeType,
         key: String,

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -176,14 +176,14 @@ extension ContainSongsViewController: ContainPlayListHeaderViewDelegate {
         self.showEntryKitModal(content: multiPurposePopVc, height: 296)
     }
 }
-
-extension ContainSongsViewController: MultiPurposePopupViewDelegate {
-    public func didTokenExpired() {
-        self.dismiss(animated: true) { [weak self] in
-
-            guard let self else { return }
-
-            self.delegate?.tokenExpired()
-        }
-    }
-}
+#warning("토근 만료 처리")
+//extension ContainSongsViewController: MultiPurposePopupViewDelegate {
+//    public func didTokenExpired() {
+//        self.dismiss(animated: true) { [weak self] in
+//
+//            guard let self else { return }
+//
+//            self.delegate?.tokenExpired()
+//        }
+//    }
+//}

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -176,8 +176,9 @@ extension ContainSongsViewController: ContainPlayListHeaderViewDelegate {
         self.showEntryKitModal(content: multiPurposePopVc, height: 296)
     }
 }
+
 #warning("토근 만료 처리")
-//extension ContainSongsViewController: MultiPurposePopupViewDelegate {
+// extension ContainSongsViewController: MultiPurposePopupViewDelegate {
 //    public func didTokenExpired() {
 //        self.dismiss(animated: true) { [weak self] in
 //
@@ -186,4 +187,4 @@ extension ContainSongsViewController: ContainPlayListHeaderViewDelegate {
 //            self.delegate?.tokenExpired()
 //        }
 //    }
-//}
+// }

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -173,7 +173,7 @@ extension ContainSongsViewController: ContainPlayListHeaderViewDelegate {
         ) as? MultiPurposePopupViewController else {
             return
         }
-        self.showEntryKitModal(content: multiPurposePopVc, height: 296)
+        showBottomSheet(content: multiPurposePopVc, size: .fixed(296))
     }
 }
 

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -19,7 +19,7 @@ public final class ContainSongsViewController: BaseViewController, ViewControlle
     @IBOutlet weak var songCountLabel: UILabel!
     @IBOutlet weak var subTitleLabel: UILabel!
 
-    var multiPurposePopUpFactory: MultiPurposePopUpFactory!
+    var multiPurposePopUpFactory: MultiPurposePopupFactory!
 
     var viewModel: ContainSongsViewModel!
     lazy var input = ContainSongsViewModel.Input()
@@ -36,7 +36,7 @@ public final class ContainSongsViewController: BaseViewController, ViewControlle
     }
 
     public static func viewController(
-        multiPurposePopUpFactory: MultiPurposePopUpFactory,
+        multiPurposePopUpFactory: MultiPurposePopupFactory,
         viewModel: ContainSongsViewModel
     ) -> ContainSongsViewController {
         let viewController = ContainSongsViewController.viewController(

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
@@ -126,13 +126,13 @@ extension MultiPurposePopupViewController {
         self.indicator.type = .circleStrokeSpin
         self.indicator.color = .white
     }
-    
+
     private func bindInput() {
         limitCount = viewModel.type == .nickname ? 8 : 12
         limitLabel.text = "/\(limitCount)"
 
         input.textString
-            .bind(with: self) {  owner, str in
+            .bind(with: self) { owner, str in
                 let errorColor = DesignSystemAsset.PrimaryColor.increase.color
                 let passColor = DesignSystemAsset.PrimaryColor.decrease.color
 
@@ -178,28 +178,24 @@ extension MultiPurposePopupViewController {
     }
 
     private func bindAction() {
-        
         textField.rx.text.orEmpty
             .skip(1) // 바인드 할 때 발생하는 첫 이벤트를 무시
             .bind(to: input.textString)
             .disposed(by: disposeBag)
-        
-        
+
         saveButton.rx
             .tap
             .withLatestFrom(input.textString)
             .bind(with: self) { owner, text in
-                
-                #warning("디스미스 안됨 큰일났ㄸ")
-                SwiftEntryKit.dismiss() {
-                    guard let completion = owner.completion else {
 
+                #warning("디스미스 안됨 큰일났ㄸ")
+                SwiftEntryKit.dismiss {
+                    guard let completion = owner.completion else {
                         return
                     }
                     completion(text)
                 }
             }
             .disposed(by: disposeBag)
-
     }
 }

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
@@ -126,13 +126,13 @@ extension MultiPurposePopupViewController {
         self.indicator.type = .circleStrokeSpin
         self.indicator.color = .white
     }
-
+    
     private func bindInput() {
         limitCount = viewModel.type == .nickname ? 8 : 12
         limitLabel.text = "/\(limitCount)"
 
         input.textString
-            .bind(with: self) { owner, str in
+            .bind(with: self) {  owner, str in
                 let errorColor = DesignSystemAsset.PrimaryColor.increase.color
                 let passColor = DesignSystemAsset.PrimaryColor.decrease.color
 
@@ -178,25 +178,28 @@ extension MultiPurposePopupViewController {
     }
 
     private func bindAction() {
+        
         textField.rx.text.orEmpty
             .skip(1) // 바인드 할 때 발생하는 첫 이벤트를 무시
             .bind(to: input.textString)
             .disposed(by: disposeBag)
-
+        
+        
         saveButton.rx
             .tap
             .withLatestFrom(input.textString)
-            .asDriver(onErrorJustReturn: "")
             .bind(with: self) { owner, text in
-
+                
                 #warning("디스미스 안됨 큰일났ㄸ")
-                SwiftEntryKit.dismiss {
+                SwiftEntryKit.dismiss() {
                     guard let completion = owner.completion else {
+
                         return
                     }
                     completion(text)
                 }
             }
             .disposed(by: disposeBag)
+
     }
 }

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
@@ -4,7 +4,6 @@ import NVActivityIndicatorView
 import RxCocoa
 import RxKeyboard
 import RxSwift
-import SwiftEntryKit
 import UIKit
 import Utility
 
@@ -65,8 +64,7 @@ public final class MultiPurposePopupViewController: UIViewController, ViewContro
 
 extension MultiPurposePopupViewController {
     private func configureUI() {
-        self.view.layer.cornerRadius = 24
-        self.view.clipsToBounds = true
+        textField.becomeFirstResponder()
 
         titleLabel.text = viewModel.type.title
         titleLabel.font = DesignSystemFontFamily.Pretendard.medium.font(size: 18)
@@ -187,9 +185,7 @@ extension MultiPurposePopupViewController {
             .tap
             .withLatestFrom(input.textString)
             .bind(with: self) { owner, text in
-
-                #warning("디스미스 안됨 큰일났ㄸ")
-                SwiftEntryKit.dismiss {
+                owner.dismiss(animated: true) {
                     guard let completion = owner.completion else {
                         return
                     }

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
@@ -126,13 +126,13 @@ extension MultiPurposePopupViewController {
         self.indicator.type = .circleStrokeSpin
         self.indicator.color = .white
     }
-    
+
     private func bindInput() {
         limitCount = viewModel.type == .nickname ? 8 : 12
         limitLabel.text = "/\(limitCount)"
 
         input.textString
-            .bind(with: self) {  owner, str in
+            .bind(with: self) { owner, str in
                 let errorColor = DesignSystemAsset.PrimaryColor.increase.color
                 let passColor = DesignSystemAsset.PrimaryColor.decrease.color
 
@@ -178,29 +178,25 @@ extension MultiPurposePopupViewController {
     }
 
     private func bindAction() {
-        
         textField.rx.text.orEmpty
             .skip(1) // 바인드 할 때 발생하는 첫 이벤트를 무시
             .bind(to: input.textString)
             .disposed(by: disposeBag)
-        
-        
+
         saveButton.rx
             .tap
             .withLatestFrom(input.textString)
             .asDriver(onErrorJustReturn: "")
             .bind(with: self) { owner, text in
-                
-                #warning("디스미스 안됨 큰일났ㄸ")
-                SwiftEntryKit.dismiss() {
-                    guard let completion = owner.completion else {
 
+                #warning("디스미스 안됨 큰일났ㄸ")
+                SwiftEntryKit.dismiss {
+                    guard let completion = owner.completion else {
                         return
                     }
                     completion(text)
                 }
             }
             .disposed(by: disposeBag)
-
     }
 }

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
@@ -45,6 +45,8 @@ public final class MultiPurposePopupViewController: UIViewController, ViewContro
     override public func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
+        bindInput()
+        bindAction()
     }
 
     public static func viewController(
@@ -68,15 +70,15 @@ extension MultiPurposePopupViewController {
 
         titleLabel.text = viewModel.type.title
         titleLabel.font = DesignSystemFontFamily.Pretendard.medium.font(size: 18)
-        titleLabel.textColor = DesignSystemAsset.GrayColor.gray900.color
+        titleLabel.textColor = DesignSystemAsset.BlueGrayColor.gray900.color
 
         subTitleLabel.text = viewModel.type.subTitle
         subTitleLabel.font = DesignSystemFontFamily.Pretendard.light.font(size: 16)
-        subTitleLabel.textColor = DesignSystemAsset.GrayColor.gray400.color
+        subTitleLabel.textColor = DesignSystemAsset.BlueGrayColor.gray400.color
 
         let headerFontSize: CGFloat = 20
         let focusedplaceHolderAttributes = [
-            NSAttributedString.Key.foregroundColor: DesignSystemAsset.GrayColor.gray400.color,
+            NSAttributedString.Key.foregroundColor: DesignSystemAsset.BlueGrayColor.gray400.color,
             NSAttributedString.Key.font: DesignSystemFontFamily.Pretendard.medium.font(size: headerFontSize)
         ] // 포커싱 플레이스홀더 폰트 및 color 설정
 
@@ -88,13 +90,13 @@ extension MultiPurposePopupViewController {
         ) // 플레이스 홀더 설정
         self.textField.font = DesignSystemFontFamily.Pretendard.medium.font(size: headerFontSize)
 
-        self.dividerView.backgroundColor = DesignSystemAsset.GrayColor.gray200.color
+        self.dividerView.backgroundColor = DesignSystemAsset.BlueGrayColor.gray200.color
 
         self.cancelButton.layer.cornerRadius = 12
         self.cancelButton.titleLabel?.text = "취소"
         self.cancelButton.titleLabel?.font = DesignSystemFontFamily.Pretendard.bold.font(size: 12)
         self.cancelButton.layer.cornerRadius = 4
-        self.cancelButton.layer.borderColor = DesignSystemAsset.GrayColor.gray200.color.cgColor
+        self.cancelButton.layer.borderColor = DesignSystemAsset.BlueGrayColor.gray200.color.cgColor
         self.cancelButton.layer.borderWidth = 1
         self.cancelButton.backgroundColor = .white
         self.cancelButton.isHidden = true
@@ -103,13 +105,10 @@ extension MultiPurposePopupViewController {
         self.confirmLabel.isHidden = true
 
         self.limitLabel.font = DesignSystemFontFamily.Pretendard.light.font(size: 12)
-        self.limitLabel.textColor = DesignSystemAsset.GrayColor.gray500.color
+        self.limitLabel.textColor = DesignSystemAsset.BlueGrayColor.gray500.color
 
         self.countLabel.font = DesignSystemFontFamily.Pretendard.light.font(size: 12)
         self.countLabel.textColor = DesignSystemAsset.PrimaryColor.point.color
-        bindRx()
-
-        bindRxEvent()
 
         saveButton.layer.cornerRadius = 12
         saveButton.clipsToBounds = true
@@ -117,78 +116,91 @@ extension MultiPurposePopupViewController {
             string: viewModel.type.btnText,
             attributes: [
                 .font: DesignSystemFontFamily.Pretendard.medium.font(size: 18),
-                .foregroundColor: DesignSystemAsset.GrayColor.gray25.color
+                .foregroundColor: DesignSystemAsset.BlueGrayColor.gray25.color
             ]
         ), for: .normal)
 
         saveButton.setBackgroundColor(DesignSystemAsset.PrimaryColor.point.color, for: .normal)
-        saveButton.setBackgroundColor(DesignSystemAsset.GrayColor.gray300.color, for: .disabled)
+        saveButton.setBackgroundColor(DesignSystemAsset.BlueGrayColor.gray300.color, for: .disabled)
 
         self.indicator.type = .circleStrokeSpin
         self.indicator.color = .white
     }
-
-    private func bindRx() {
+    
+    private func bindInput() {
         limitCount = viewModel.type == .nickname ? 8 : 12
         limitLabel.text = "/\(limitCount)"
 
         input.textString
-            .subscribe { [weak self] (str: String) in
-                guard let self = self else {
-                    return
-                }
-
+            .bind(with: self) {  owner, str in
                 let errorColor = DesignSystemAsset.PrimaryColor.increase.color
                 let passColor = DesignSystemAsset.PrimaryColor.decrease.color
 
-                self.countLabel.text = "\(str.count)자"
+                owner.countLabel.text = "\(str.count)자"
 
                 if str.isEmpty {
-                    self.cancelButton.isHidden = true
-                    self.confirmLabel.isHidden = true
-                    self.saveButton.isEnabled = false
-                    self.dividerView.backgroundColor = DesignSystemAsset.GrayColor.gray200.color
-                    self.countLabel.textColor = DesignSystemAsset.PrimaryColor.point.color
+                    owner.cancelButton.isHidden = true
+                    owner.confirmLabel.isHidden = true
+                    owner.saveButton.isEnabled = false
+                    owner.dividerView.backgroundColor = DesignSystemAsset.BlueGrayColor.gray200.color
+                    owner.countLabel.textColor = DesignSystemAsset.PrimaryColor.point.color
                     return
 
                 } else {
-                    self.cancelButton.isHidden = false
-                    self.confirmLabel.isHidden = false
-                    self.countLabel.isHidden = false
+                    owner.cancelButton.isHidden = false
+                    owner.confirmLabel.isHidden = false
+                    owner.countLabel.isHidden = false
                 }
 
                 if str.isWhiteSpace {
-                    self.dividerView.backgroundColor = errorColor
-                    self.confirmLabel.text = "제목이 비어있습니다."
-                    self.confirmLabel.textColor = errorColor
-                    self.countLabel.textColor = errorColor
-                    self.saveButton.isEnabled = false
+                    owner.dividerView.backgroundColor = errorColor
+                    owner.confirmLabel.text = "제목이 비어있습니다."
+                    owner.confirmLabel.textColor = errorColor
+                    owner.countLabel.textColor = errorColor
+                    owner.saveButton.isEnabled = false
 
-                } else if str.count > self.limitCount {
-                    self.dividerView.backgroundColor = errorColor
-                    self.confirmLabel.text = "글자 수를 초과하였습니다."
-                    self.confirmLabel.textColor = errorColor
-                    self.countLabel.textColor = errorColor
-                    self.saveButton.isEnabled = false
+                } else if str.count > owner.limitCount {
+                    owner.dividerView.backgroundColor = errorColor
+                    owner.confirmLabel.text = "글자 수를 초과하였습니다."
+                    owner.confirmLabel.textColor = errorColor
+                    owner.countLabel.textColor = errorColor
+                    owner.saveButton.isEnabled = false
 
                 } else {
-                    self.dividerView.backgroundColor = passColor
-                    self.confirmLabel.text = self.viewModel.type == .nickname ? "사용할 수 있는 닉네임입니다." : "사용할 수 있는 제목입니다."
-                    self.confirmLabel.textColor = passColor
-                    self.countLabel.textColor = DesignSystemAsset.PrimaryColor.point.color
-                    self.saveButton.isEnabled = true
+                    owner.dividerView.backgroundColor = passColor
+                    owner.confirmLabel.text = owner.viewModel.type == .nickname ? "사용할 수 있는 닉네임입니다." : "사용할 수 있는 제목입니다."
+                    owner.confirmLabel.textColor = passColor
+                    owner.countLabel.textColor = DesignSystemAsset.PrimaryColor.point.color
+                    owner.saveButton.isEnabled = true
                 }
 
             }.disposed(by: disposeBag)
-
-
     }
 
-    private func bindRxEvent() {
+    private func bindAction() {
+        
         textField.rx.text.orEmpty
             .skip(1) // 바인드 할 때 발생하는 첫 이벤트를 무시
             .bind(to: input.textString)
-            .disposed(by: self.disposeBag)
+            .disposed(by: disposeBag)
+        
+        
+        saveButton.rx
+            .tap
+            .withLatestFrom(input.textString)
+            .asDriver(onErrorJustReturn: "")
+            .bind(with: self) { owner, text in
+                
+                #warning("디스미스 안됨 큰일났ㄸ")
+                SwiftEntryKit.dismiss() {
+                    guard let completion = owner.completion else {
+
+                        return
+                    }
+                    completion(text)
+                }
+            }
+            .disposed(by: disposeBag)
 
     }
 }

--- a/Projects/Features/BaseFeature/Sources/ViewModels/MultiPurposePopupViewModel.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewModels/MultiPurposePopupViewModel.swift
@@ -19,7 +19,6 @@ public final class MultiPurposePopupViewModel: ViewModelType {
     }
 
     public struct Output {
-        let isFoucused: BehaviorRelay<Bool> = BehaviorRelay(value: false)
     }
 
     public init(
@@ -35,8 +34,6 @@ public final class MultiPurposePopupViewModel: ViewModelType {
     }
 
     public func transform(from input: Input) -> Output {
-        let logoutRelay = PublishRelay<Error>()
-
         var output = Output()
 
 

--- a/Projects/Features/BaseFeature/Sources/ViewModels/MultiPurposePopupViewModel.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewModels/MultiPurposePopupViewModel.swift
@@ -12,14 +12,11 @@ public final class MultiPurposePopupViewModel: ViewModelType {
     var type: PurposeType
     var key: String
 
-
-
     public struct Input {
         let textString: BehaviorRelay<String> = BehaviorRelay(value: "")
     }
 
-    public struct Output {
-    }
+    public struct Output {}
 
     public init(
         type: PurposeType,
@@ -35,7 +32,6 @@ public final class MultiPurposePopupViewModel: ViewModelType {
 
     public func transform(from input: Input) -> Output {
         var output = Output()
-
 
         return output
     }

--- a/Projects/Features/MyInfoFeature/Sources/Components/MyInfoComponent.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Components/MyInfoComponent.swift
@@ -8,7 +8,7 @@ import UIKit
 public protocol MyInfoDependency: Dependency {
     var signInFactory: any SignInFactory { get }
     var textPopUpFactory: any TextPopUpFactory { get }
-    var multiPurposePopUpFactory: any MultiPurposePopUpFactory { get }
+    var multiPurposePopUpFactory: any MultiPurposePopupFactory { get }
     var faqFactory: any FaqFactory { get }
     var noticeFactory: any NoticeFactory { get }
     var questionFactory: any QuestionFactory { get }

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -233,7 +233,7 @@ extension MyInfoViewController: EditSheetViewDelegate {
             break
         case .profile:
             let vc = profilePopUpComponent.makeView()
-            showBottomSheet(content: vc, size: .fixed(352))
+            showBottomSheet(content: vc, size: .fixed(352 + SAFEAREA_BOTTOM_HEIGHT()))
         case .nickname:
             guard let vc = multiPurposePopUpFactory
                 .makeView(type: .nickname, key: "", completion: nil) as? MultiPurposePopupViewController

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -16,7 +16,7 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
     let myInfoView = MyInfoView()
     private var profilePopUpComponent: ProfilePopComponent!
     private var textPopUpFactory: TextPopUpFactory!
-    private var multiPurposePopUpFactory: MultiPurposePopUpFactory!
+    private var multiPurposePopUpFactory: MultiPurposePopupFactory!
     private var signInFactory: SignInFactory!
     private var faqFactory: FaqFactory! // 자주 묻는 질문
     private var noticeFactory: NoticeFactory! // 공지사항
@@ -50,7 +50,7 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
         reactor: MyInfoReactor,
         profilePopUpComponent: ProfilePopComponent,
         textPopUpFactory: TextPopUpFactory,
-        multiPurposePopUpFactory: MultiPurposePopUpFactory,
+        multiPurposePopUpFactory: MultiPurposePopupFactory,
         signInFactory: SignInFactory,
         faqFactory: FaqFactory,
         noticeFactory: NoticeFactory,

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -233,12 +233,12 @@ extension MyInfoViewController: EditSheetViewDelegate {
             break
         case .profile:
             let vc = profilePopUpComponent.makeView()
-            self.showEntryKitModal(content: vc, height: 352)
+            showBottomSheet(content: vc, size: .fixed(352))
         case .nickname:
             guard let vc = multiPurposePopUpFactory
                 .makeView(type: .nickname, key: "", completion: nil) as? MultiPurposePopupViewController
             else { return }
-            self.showEntryKitModal(content: vc, height: 296)
+            showBottomSheet(content: vc, size: .fixed(296))
         }
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Components/MyPlaylistDetailComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/MyPlaylistDetailComponent.swift
@@ -17,7 +17,7 @@ public protocol MyPlaylistDetailDependency: Dependency {
 
     var logoutUseCase: any LogoutUseCase { get }
 
-    var multiPurposePopUpFactory: any MultiPurposePopUpFactory { get }
+    var multiPurposePopUpFactory: any MultiPurposePopupFactory { get }
     var containSongsFactory: any ContainSongsFactory { get }
 
     var textPopUpFactory: any TextPopUpFactory { get }

--- a/Projects/Features/PlaylistFeature/Sources/Components/PlayListDetailComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/PlayListDetailComponent.swift
@@ -14,7 +14,7 @@ public protocol PlaylistDetailDependency: Dependency {
     var removeSongsUseCase: any RemoveSongsUseCase { get }
     var logoutUseCase: any LogoutUseCase { get }
 
-    var multiPurposePopUpFactory: any MultiPurposePopUpFactory { get }
+    var multiPurposePopUpFactory: any MultiPurposePopupFactory { get }
     var containSongsFactory: any ContainSongsFactory { get }
 
     var textPopUpFactory: any TextPopUpFactory { get }

--- a/Projects/Features/StorageFeature/Sources/Components/PlaylistStorageComponent.swift
+++ b/Projects/Features/StorageFeature/Sources/Components/PlaylistStorageComponent.swift
@@ -9,7 +9,7 @@ import UIKit
 import UserDomainInterface
 
 public protocol PlaylistStorageDependency: Dependency {
-    var multiPurposePopUpFactory: any MultiPurposePopUpFactory { get }
+    var multiPurposePopUpFactory: any MultiPurposePopupFactory { get }
     var playlistDetailFactory: any PlaylistDetailFactory { get }
     var fetchPlayListUseCase: any FetchPlayListUseCase { get }
     var editPlayListOrderUseCase: any EditPlayListOrderUseCase { get }

--- a/Projects/Features/StorageFeature/Sources/Components/StorageComponent.swift
+++ b/Projects/Features/StorageFeature/Sources/Components/StorageComponent.swift
@@ -9,7 +9,7 @@ import UIKit
 public protocol StorageDependency: Dependency {
     var signInFactory: any SignInFactory { get }
     var playlistStorageComponent: PlaylistStorageComponent { get }
-    var multiPurposePopUpFactory: any MultiPurposePopUpFactory { get }
+    var multiPurposePopUpFactory: any MultiPurposePopupFactory { get }
     var favoriteComponent: FavoriteComponent { get }
     var textPopUpFactory: any TextPopUpFactory { get }
 }

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/PlaylistStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/PlaylistStorageViewController.swift
@@ -22,7 +22,7 @@ final class PlaylistStorageViewController: BaseStoryboardReactorViewController<P
     @IBOutlet weak var activityIndicator: NVActivityIndicatorView!
 
     private var refreshControl = UIRefreshControl()
-    var multiPurposePopUpFactory: MultiPurposePopUpFactory!
+    var multiPurposePopUpFactory: MultiPurposePopupFactory!
     var textPopUpFactory: TextPopUpFactory!
     var playlistDetailFactory: PlaylistDetailFactory!
     var signInFactory: SignInFactory!
@@ -38,7 +38,7 @@ final class PlaylistStorageViewController: BaseStoryboardReactorViewController<P
 
     static func viewController(
         reactor: PlaylistStorageReactor,
-        multiPurposePopUpFactory: MultiPurposePopUpFactory,
+        multiPurposePopUpFactory: MultiPurposePopupFactory,
         playlistDetailFactory: PlaylistDetailFactory,
         textPopUpFactory: TextPopUpFactory,
         signInFactory: SignInFactory

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
@@ -48,7 +48,7 @@ final class StorageViewController: TabmanViewController, ViewControllerFromStory
 
     public var bottomSheetView: BottomSheetView!
     private var playlistStorageComponent: PlaylistStorageComponent!
-    private var multiPurposePopUpFactory: MultiPurposePopUpFactory!
+    private var multiPurposePopUpFactory: MultiPurposePopupFactory!
     private var favoriteComponent: FavoriteComponent!
     private var textPopUpFactory: TextPopUpFactory!
 
@@ -81,7 +81,7 @@ final class StorageViewController: TabmanViewController, ViewControllerFromStory
     public static func viewController(
         reactor: StorageReactor,
         playlistStorageComponent: PlaylistStorageComponent,
-        multiPurposePopUpFactory: MultiPurposePopUpFactory,
+        multiPurposePopUpFactory: MultiPurposePopupFactory,
         favoriteComponent: FavoriteComponent,
         textPopUpFactory: TextPopUpFactory,
         signInFactory: SignInFactory

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
@@ -61,7 +61,7 @@ public extension UIViewController {
         attributes.screenBackground = .color(color: EKColor(rgb: 0x000000).with(alpha: 0.4))
         attributes.entryBackground = .color(color: EKColor(rgb: 0xFFFFFF))
         attributes.screenInteraction = .dismiss
-        attributes.entryInteraction = .absorbTouches
+        attributes.entryInteraction = .dismiss
         attributes.positionConstraints.verticalOffset = 0
         attributes.positionConstraints.safeArea = .empty(fillSafeArea: true)
         attributes.roundCorners = .top(radius: 24)

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
@@ -54,43 +54,6 @@ public extension UIViewController {
         )
     }
 
-    func showEntryKitModal(content: UIViewController, height: CGFloat) {
-        var attributes: EKAttributes
-        attributes = .bottomFloat
-        attributes.displayDuration = .infinity
-        attributes.screenBackground = .color(color: EKColor(rgb: 0x000000).with(alpha: 0.4))
-        attributes.entryBackground = .color(color: EKColor(rgb: 0xFFFFFF))
-        attributes.screenInteraction = .dismiss
-        attributes.entryInteraction = .absorbTouches
-        attributes.positionConstraints.verticalOffset = 0
-        attributes.positionConstraints.safeArea = .empty(fillSafeArea: true)
-        attributes.roundCorners = .top(radius: 24)
-        attributes.positionConstraints.keyboardRelation = .bind(offset: .none)
-        attributes.entranceAnimation = .init(
-            translate: .init(
-                duration: 0.4,
-                spring: .init(damping: 0.8, initialVelocity: 0)
-            )
-        )
-        attributes.exitAnimation = .init(
-            translate: .init(
-                duration: 0.4,
-                spring: .init(damping: 0.8, initialVelocity: 0)
-            )
-        )
-        attributes.positionConstraints.size = .init(
-            width: .offset(value: 0),
-            height: .constant(value: height)
-        )
-        attributes.positionConstraints.maxSize = .init(
-            width: .offset(value: 0),
-            height: .constant(value: height)
-        )
-
-        HapticManager.shared.impact(style: .light)
-        SwiftEntryKit.display(entry: content, using: attributes)
-    }
-
     func showToast(text: String, font: UIFont, verticalOffset: CGFloat? = nil) {
         var attributes = EKAttributes.bottomFloat
         attributes.displayDuration = 2

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
@@ -61,7 +61,7 @@ public extension UIViewController {
         attributes.screenBackground = .color(color: EKColor(rgb: 0x000000).with(alpha: 0.4))
         attributes.entryBackground = .color(color: EKColor(rgb: 0xFFFFFF))
         attributes.screenInteraction = .dismiss
-        attributes.entryInteraction = .dismiss
+        attributes.entryInteraction = .absorbTouches
         attributes.positionConstraints.verticalOffset = 0
         attributes.positionConstraints.safeArea = .empty(fillSafeArea: true)
         attributes.roundCorners = .top(radius: 24)


### PR DESCRIPTION
## 💡 배경 및 개요

많은 Usecase가 모여 있어 유지보수가 어려웠습니다.

Resolves: #685

## 📃 작업내용

유즈 케이스를 제거 하고 컴플리션으로 입력된 문자열을 넘겨줍니다.

## 🙋‍♂️ 리뷰노트

SwiftEntryKIt 자체 Dismiss가 호출되지 않아 동작의 버그가 있어 #690 브랜치 해결 후
디스미스 과정을 추후 반영합니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
