### PR TITLE
🔀 :: (#693) 에딧 시트 숨기기 기능

### DIFF
--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -223,7 +223,7 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
             .map { MyInfoReactor.Action.settingNavigationDidTap }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
-        
+
         myInfoView.rx.scrollViewDidTap
             .bind(with: self) { owner, _ in
                 owner.hideEditSheet()

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -44,6 +44,7 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
     override public func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         navigationController?.interactivePopGestureRecognizer?.delegate = nil
+        hideEditSheet()
     }
 
     public static func viewController(
@@ -222,6 +223,11 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
             .map { MyInfoReactor.Action.settingNavigationDidTap }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
+        myInfoView.rx.scrollViewDidTap
+            .bind(with: self) { owner, _ in
+                owner.hideEditSheet()
+            }.disposed(by: disposeBag)
     }
 }
 

--- a/Projects/Features/MyInfoFeature/Sources/Views/MyInfoView.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/MyInfoView.swift
@@ -13,6 +13,7 @@ private protocol MyInfoStateProtocol {
 }
 
 private protocol MyInfoActionProtocol {
+    var scrollViewDidTap: Observable<Void> { get }
     var loginButtonDidTap: Observable<Void> { get }
     var profileImageDidTap: Observable<Void> { get }
     var drawButtonDidTap: Observable<Void> { get }
@@ -188,6 +189,12 @@ extension MyInfoView: MyInfoStateProtocol {
 }
 
 extension Reactive: MyInfoActionProtocol where Base: MyInfoView {
+    var scrollViewDidTap: Observable<Void> {
+        let tapGestureRecognizer = UITapGestureRecognizer()
+        base.scrollView.addGestureRecognizer(tapGestureRecognizer)
+        base.scrollView.isUserInteractionEnabled = true
+        return tapGestureRecognizer.rx.event.map { _ in }.asObservable()
+    }
     var loginButtonDidTap: Observable<Void> { base.loginWarningView.rx.loginButtonDidTap }
     var profileImageDidTap: Observable<Void> { base.profileView.rx.profileImageDidTap }
     var drawButtonDidTap: Observable<Void> { base.drawButtonView.rx.drawButtonDidTap }

--- a/Projects/Features/MyInfoFeature/Sources/Views/MyInfoView.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/MyInfoView.swift
@@ -195,6 +195,7 @@ extension Reactive: MyInfoActionProtocol where Base: MyInfoView {
         base.scrollView.isUserInteractionEnabled = true
         return tapGestureRecognizer.rx.event.map { _ in }.asObservable()
     }
+
     var loginButtonDidTap: Observable<Void> { base.loginWarningView.rx.loginButtonDidTap }
     var profileImageDidTap: Observable<Void> { base.profileView.rx.profileImageDidTap }
     var drawButtonDidTap: Observable<Void> { base.drawButtonView.rx.drawButtonDidTap }


### PR DESCRIPTION
## 💡 배경 및 개요

Resolves: #693 

## 📃 작업내용

https://github.com/wakmusic/wakmusic-iOS/assets/60254939/502ee782-00f2-4797-8c55-58ad09370403


내정보 화면의 빈 공간을 터치하거나 탭이 변경되면(viewDidDisappear) 내려갑니다.


## 🙋‍♂️ 리뷰노트
- 플로팅버튼의 알파값 애니메이션이 있어 viewDidDisappear 와 viewWillDisappear 를 전부 테스트 해봤는데 육안으로 식별할 수 있는 수준이 아니라서 DidDisappear로 결정했습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
