### PR TITLE
🔀 :: (#699) connect usecase fruit draw  외 4

### DIFF
--- a/Projects/App/Sources/Application/AppComponent+User.swift
+++ b/Projects/App/Sources/Application/AppComponent+User.swift
@@ -91,4 +91,22 @@ public extension AppComponent {
             WithdrawUserInfoUseCaseImpl(userRepository: userRepository)
         }
     }
+
+    var fetchFruitListUseCase: any FetchFruitListUseCase {
+        shared {
+            FetchFruitListUseCaseImpl(userRepository: userRepository)
+        }
+    }
+
+    var fetchFruitDrawStatusUseCase: any FetchFruitDrawStatusUseCase {
+        shared {
+            FetchFruitDrawStatusUseCaseImpl(userRepository: userRepository)
+        }
+    }
+
+    var drawFruitUseCase: any DrawFruitUseCase {
+        shared {
+            DrawFruitUseCaseImpl(userRepository: userRepository)
+        }
+    }
 }

--- a/Projects/Domains/UserDomain/Interface/DataSource/RemoteUserDataSource.swift
+++ b/Projects/Domains/UserDomain/Interface/DataSource/RemoteUserDataSource.swift
@@ -13,4 +13,7 @@ public protocol RemoteUserDataSource {
     func deleteFavoriteList(ids: [String]) -> Single<BaseEntity>
     func fetchUserInfo() -> Single<UserInfoEntity>
     func withdrawUserInfo() -> Single<BaseEntity>
+    func fetchFruitList() -> Single<[FruitEntity]>
+    func fetchFruitDrawStatus() -> Single<FruitDrawStatusEntity>
+    func drawFruit() -> Single<FruitEntity>
 }

--- a/Projects/Domains/UserDomain/Interface/Entity/FruitDrawStatusEntity.swift
+++ b/Projects/Domains/UserDomain/Interface/Entity/FruitDrawStatusEntity.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public struct FruitDrawStatusEntity {
+    public let canDraw: Bool
+    public let lastDraw: FruitDrawStatusEntity.LastDraw
+
+    public init(canDraw: Bool, lastDraw: FruitDrawStatusEntity.LastDraw) {
+        self.canDraw = canDraw
+        self.lastDraw = lastDraw
+    }
+}
+
+public extension FruitDrawStatusEntity {
+    struct LastDraw {
+        public let drawAt: Double
+        public let fruit: FruitDrawStatusEntity.LastDraw.Fruit
+
+        public init(drawAt: Double, fruit: FruitDrawStatusEntity.LastDraw.Fruit) {
+            self.drawAt = drawAt
+            self.fruit = fruit
+        }
+    }
+}
+
+public extension FruitDrawStatusEntity.LastDraw {
+    struct Fruit {
+        public let fruitID, name, imageURL: String
+
+        public init(fruitID: String, name: String, imageURL: String) {
+            self.fruitID = fruitID
+            self.name = name
+            self.imageURL = imageURL
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case fruitID = "fruitId"
+            case name
+            case imageURL = "imageUrl"
+        }
+    }
+}

--- a/Projects/Domains/UserDomain/Interface/Entity/FruitEntity.swift
+++ b/Projects/Domains/UserDomain/Interface/Entity/FruitEntity.swift
@@ -15,4 +15,5 @@ public struct FruitEntity {
 
     public let quantity: Int
     public let fruitID, name, imageURL: String
+    public var imageData: Data?
 }

--- a/Projects/Domains/UserDomain/Interface/Entity/FruitEntity.swift
+++ b/Projects/Domains/UserDomain/Interface/Entity/FruitEntity.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public struct FruitEntity {
+    public init(
+        quantity: Int,
+        fruitID: String,
+        name: String,
+        imageURL: String
+    ) {
+        self.quantity = quantity
+        self.fruitID = fruitID
+        self.name = name
+        self.imageURL = imageURL
+    }
+
+    public let quantity: Int
+    public let fruitID, name, imageURL: String
+}

--- a/Projects/Domains/UserDomain/Interface/Repository/UserRepository.swift
+++ b/Projects/Domains/UserDomain/Interface/Repository/UserRepository.swift
@@ -13,4 +13,7 @@ public protocol UserRepository {
     func deleteFavoriteList(ids: [String]) -> Single<BaseEntity>
     func fetchUserInfo() -> Single<UserInfoEntity>
     func withdrawUserInfo() -> Single<BaseEntity>
+    func fetchFruitList() -> Single<[FruitEntity]>
+    func fetchFruitDrawStatus() -> Single<FruitDrawStatusEntity>
+    func drawFruit() -> Single<FruitEntity>
 }

--- a/Projects/Domains/UserDomain/Interface/UseCase/DrawFruitUseCase.swift
+++ b/Projects/Domains/UserDomain/Interface/UseCase/DrawFruitUseCase.swift
@@ -1,0 +1,5 @@
+import RxSwift
+
+public protocol DrawFruitUseCase {
+    func execute() -> Single<FruitEntity>
+}

--- a/Projects/Domains/UserDomain/Interface/UseCase/FetchFruitDrawStatusUseCase.swift
+++ b/Projects/Domains/UserDomain/Interface/UseCase/FetchFruitDrawStatusUseCase.swift
@@ -1,0 +1,5 @@
+import RxSwift
+
+public protocol FetchFruitDrawStatusUseCase {
+    func execute() -> Single<FruitDrawStatusEntity>
+}

--- a/Projects/Domains/UserDomain/Interface/UseCase/FetchFruitListUseCase.swift
+++ b/Projects/Domains/UserDomain/Interface/UseCase/FetchFruitListUseCase.swift
@@ -1,0 +1,5 @@
+import RxSwift
+
+public protocol FetchFruitListUseCase {
+    func execute() -> Single<[FruitEntity]>
+}

--- a/Projects/Domains/UserDomain/Sources/API/UserAPI.swift
+++ b/Projects/Domains/UserDomain/Sources/API/UserAPI.swift
@@ -15,6 +15,9 @@ public enum UserAPI {
     case setProfile(image: String)
     case setUserName(name: String)
     case withdrawUserInfo
+    case fetchFruitList
+    case fetchFruitDrawStatus
+    case drawFruit
 }
 
 extension UserAPI: WMAPI {
@@ -43,7 +46,13 @@ extension UserAPI: WMAPI {
         case .setUserName:
             return "/profile/name"
         case .withdrawUserInfo:
-            return "/user/delete"
+            return "/delete"
+        case .fetchFruitList:
+            return "/fruit/list"
+        case .fetchFruitDrawStatus:
+            return "/fruit/status"
+        case .drawFruit:
+            return "/fruit/draw"
         }
     }
 
@@ -69,6 +78,12 @@ extension UserAPI: WMAPI {
             return .patch
         case .withdrawUserInfo:
             return .delete
+        case .fetchFruitList:
+            return .get
+        case .fetchFruitDrawStatus:
+            return .get
+        case .drawFruit:
+            return .post
         }
     }
 
@@ -103,6 +118,12 @@ extension UserAPI: WMAPI {
         case let .setUserName(name):
             return .requestJSONEncodable(SetUserNameRequestDTO(name: name))
         case .withdrawUserInfo:
+            return .requestPlain
+        case .fetchFruitList:
+            return .requestPlain
+        case .fetchFruitDrawStatus:
+            return .requestPlain
+        case .drawFruit:
             return .requestPlain
         }
     }

--- a/Projects/Domains/UserDomain/Sources/DataSource/RemoteUserDataSourceImpl.swift
+++ b/Projects/Domains/UserDomain/Sources/DataSource/RemoteUserDataSourceImpl.swift
@@ -64,4 +64,22 @@ public final class RemoteUserDataSourceImpl: BaseRemoteDataSource<UserAPI>, Remo
             .map(BaseResponseDTO.self)
             .map { $0.toDomain() }
     }
+
+    public func fetchFruitList() -> Single<[FruitEntity]> {
+        return request(.fetchFruitList)
+            .map([FruitListResponseDTO].self)
+            .map { $0.map { $0.toDomain() } }
+    }
+
+    public func fetchFruitDrawStatus() -> Single<FruitDrawStatusEntity> {
+        return request(.fetchFruitDrawStatus)
+            .map(FruitDrawStatusResponseDTO.self)
+            .map { $0.toDomain() }
+    }
+
+    public func drawFruit() -> Single<FruitEntity> {
+        return request(.drawFruit)
+            .map(FruitListResponseDTO.self)
+            .map { $0.toDomain() }
+    }
 }

--- a/Projects/Domains/UserDomain/Sources/Repository/UserRepositoryImpl.swift
+++ b/Projects/Domains/UserDomain/Sources/Repository/UserRepositoryImpl.swift
@@ -1,11 +1,3 @@
-//
-//  ArtistRepositoryImpl.swift
-//  DataModule
-//
-//  Created by KTH on 2023/02/08.
-//  Copyright © 2023 yongbeomkwak. All rights reserved.
-//
-
 import BaseDomainInterface
 import ErrorModule
 import RxSwift
@@ -58,5 +50,17 @@ public final class UserRepositoryImpl: UserRepository {
 
     public func withdrawUserInfo() -> Single<BaseEntity> {
         remoteUserDataSource.withdrawUserInfo()
+    }
+
+    public func fetchFruitList() -> Single<[FruitEntity]> {
+        remoteUserDataSource.fetchFruitList()
+    }
+
+    public func fetchFruitDrawStatus() -> Single<FruitDrawStatusEntity> {
+        remoteUserDataSource.fetchFruitDrawStatus()
+    }
+
+    public func drawFruit() -> Single<FruitEntity> {
+        remoteUserDataSource.drawFruit()
     }
 }

--- a/Projects/Domains/UserDomain/Sources/ResponseDTO/FruitDrawStatusResponseDTO.swift
+++ b/Projects/Domains/UserDomain/Sources/ResponseDTO/FruitDrawStatusResponseDTO.swift
@@ -3,7 +3,7 @@ import UserDomainInterface
 
 public struct FruitDrawStatusResponseDTO: Decodable {
     public let canDraw: Bool
-    public let lastDraw: FruitDrawStatusResponseDTO.LastDraw
+    public let lastDraw: FruitDrawStatusResponseDTO.LastDraw?
 }
 
 public extension FruitDrawStatusResponseDTO {
@@ -30,11 +30,11 @@ public extension FruitDrawStatusResponseDTO {
         return FruitDrawStatusEntity(
             canDraw: canDraw,
             lastDraw: FruitDrawStatusEntity.LastDraw(
-                drawAt: lastDraw.drawAt,
+                drawAt: lastDraw?.drawAt ?? 0,
                 fruit: FruitDrawStatusEntity.LastDraw.Fruit(
-                    fruitID: lastDraw.fruit.fruitID,
-                    name: lastDraw.fruit.name,
-                    imageURL: lastDraw.fruit.imageURL
+                    fruitID: lastDraw?.fruit.fruitID ?? "",
+                    name: lastDraw?.fruit.name ?? "",
+                    imageURL: lastDraw?.fruit.imageURL ?? ""
                 )
             )
         )

--- a/Projects/Domains/UserDomain/Sources/ResponseDTO/FruitDrawStatusResponseDTO.swift
+++ b/Projects/Domains/UserDomain/Sources/ResponseDTO/FruitDrawStatusResponseDTO.swift
@@ -1,0 +1,42 @@
+import Foundation
+import UserDomainInterface
+
+public struct FruitDrawStatusResponseDTO: Decodable {
+    public let canDraw: Bool
+    public let lastDraw: FruitDrawStatusResponseDTO.LastDraw
+}
+
+public extension FruitDrawStatusResponseDTO {
+    struct LastDraw: Decodable {
+        public let drawAt: Double
+        public let fruit: FruitDrawStatusResponseDTO.LastDraw.Fruit
+    }
+}
+
+public extension FruitDrawStatusResponseDTO.LastDraw {
+    struct Fruit: Decodable {
+        public let fruitID, name, imageURL: String
+
+        enum CodingKeys: String, CodingKey {
+            case fruitID = "fruitId"
+            case name
+            case imageURL = "imageUrl"
+        }
+    }
+}
+
+public extension FruitDrawStatusResponseDTO {
+    func toDomain() -> FruitDrawStatusEntity {
+        return FruitDrawStatusEntity(
+            canDraw: canDraw,
+            lastDraw: FruitDrawStatusEntity.LastDraw(
+                drawAt: lastDraw.drawAt,
+                fruit: FruitDrawStatusEntity.LastDraw.Fruit(
+                    fruitID: lastDraw.fruit.fruitID,
+                    name: lastDraw.fruit.name,
+                    imageURL: lastDraw.fruit.imageURL
+                )
+            )
+        )
+    }
+}

--- a/Projects/Domains/UserDomain/Sources/ResponseDTO/FruitListResponseDTO.swift
+++ b/Projects/Domains/UserDomain/Sources/ResponseDTO/FruitListResponseDTO.swift
@@ -1,0 +1,25 @@
+import Foundation
+import UserDomainInterface
+
+public struct FruitListResponseDTO: Decodable {
+    public let quantity: Int
+    public let fruitID, name, imageURL: String
+
+    enum CodingKeys: String, CodingKey {
+        case quantity
+        case fruitID = "fruitId"
+        case name
+        case imageURL = "imageUrl"
+    }
+}
+
+public extension FruitListResponseDTO {
+    func toDomain() -> FruitEntity {
+        .init(
+            quantity: quantity,
+            fruitID: fruitID,
+            name: name,
+            imageURL: imageURL
+        )
+    }
+}

--- a/Projects/Domains/UserDomain/Sources/UseCase/DrawFruitUseCaseImpl.swift
+++ b/Projects/Domains/UserDomain/Sources/UseCase/DrawFruitUseCaseImpl.swift
@@ -1,0 +1,16 @@
+import RxSwift
+import UserDomainInterface
+
+public struct DrawFruitUseCaseImpl: DrawFruitUseCase {
+    private let userRepository: any UserRepository
+
+    public init(
+        userRepository: UserRepository
+    ) {
+        self.userRepository = userRepository
+    }
+
+    public func execute() -> Single<FruitEntity> {
+        userRepository.drawFruit()
+    }
+}

--- a/Projects/Domains/UserDomain/Sources/UseCase/FetchFruitDrawStatusUseCaseImpl.swift
+++ b/Projects/Domains/UserDomain/Sources/UseCase/FetchFruitDrawStatusUseCaseImpl.swift
@@ -1,0 +1,16 @@
+import RxSwift
+import UserDomainInterface
+
+public struct FetchFruitDrawStatusUseCaseImpl: FetchFruitDrawStatusUseCase {
+    private let userRepository: any UserRepository
+
+    public init(
+        userRepository: UserRepository
+    ) {
+        self.userRepository = userRepository
+    }
+
+    public func execute() -> Single<FruitDrawStatusEntity> {
+        userRepository.fetchFruitDrawStatus()
+    }
+}

--- a/Projects/Domains/UserDomain/Sources/UseCase/FetchFruitListUseCaseImpl.swift
+++ b/Projects/Domains/UserDomain/Sources/UseCase/FetchFruitListUseCaseImpl.swift
@@ -1,0 +1,16 @@
+import RxSwift
+import UserDomainInterface
+
+public struct FetchFruitListUseCaseImpl: FetchFruitListUseCase {
+    private let userRepository: any UserRepository
+
+    public init(
+        userRepository: UserRepository
+    ) {
+        self.userRepository = userRepository
+    }
+
+    public func execute() -> Single<[FruitEntity]> {
+        userRepository.fetchFruitList()
+    }
+}

--- a/Projects/Features/FruitDrawFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Features/FruitDrawFeature/Demo/Sources/AppDelegate.swift
@@ -10,7 +10,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
-        window?.rootViewController = FruitDrawViewController(viewModel: .init())
+        window?.rootViewController = UIViewController()
         window?.makeKeyAndVisible()
 
         return true

--- a/Projects/Features/FruitDrawFeature/Interface/FruitDrawFactory.swift
+++ b/Projects/Features/FruitDrawFeature/Interface/FruitDrawFactory.swift
@@ -1,5 +1,9 @@
 import UIKit
 
+public protocol FruitDrawViewControllerDelegate: AnyObject {
+    func completedFruitDraw(itemCount: Int)
+}
+
 public protocol FruitDrawFactory {
-    func makeView() -> UIViewController
+    func makeView(delegate: FruitDrawViewControllerDelegate) -> UIViewController
 }

--- a/Projects/Features/FruitDrawFeature/Project.swift
+++ b/Projects/Features/FruitDrawFeature/Project.swift
@@ -11,7 +11,8 @@ let project = Project.module(
             dependencies: [
                 .feature(target: .FruitDrawFeature, type: .interface),
                 .feature(target: .BaseFeature),
-                .domain(target: .UserDomain, type: .interface)
+                .domain(target: .UserDomain, type: .interface),
+                .domain(target: .AuthDomain, type: .interface)
             ]
         ),
         .demo(

--- a/Projects/Features/FruitDrawFeature/Project.swift
+++ b/Projects/Features/FruitDrawFeature/Project.swift
@@ -10,7 +10,8 @@ let project = Project.module(
             module: .feature(.FruitDrawFeature),
             dependencies: [
                 .feature(target: .FruitDrawFeature, type: .interface),
-                .feature(target: .BaseFeature)
+                .feature(target: .BaseFeature),
+                .domain(target: .UserDomain, type: .interface)
             ]
         ),
         .demo(

--- a/Projects/Features/FruitDrawFeature/Sources/Components/FruitDrawComponent.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/Components/FruitDrawComponent.swift
@@ -14,14 +14,15 @@ public protocol FruitDrawDependency: Dependency {
 }
 
 public final class FruitDrawComponent: Component<FruitDrawDependency>, FruitDrawFactory {
-    public func makeView() -> UIViewController {
+    public func makeView(delegate: any FruitDrawViewControllerDelegate) -> UIViewController {
         return FruitDrawViewController(
             viewModel: .init(
                 fetchFruitDrawStatusUseCase: dependency.fetchFruitDrawStatusUseCase,
                 drawFruitUseCase: dependency.drawFruitUseCase,
                 logoutUseCase: dependency.logoutUseCase
             ),
-            textPopUpFactory: dependency.textPopUpFactory
+            textPopUpFactory: dependency.textPopUpFactory,
+            delegate: delegate
         )
     }
 }

--- a/Projects/Features/FruitDrawFeature/Sources/Components/FruitDrawComponent.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/Components/FruitDrawComponent.swift
@@ -2,11 +2,20 @@ import Foundation
 import FruitDrawFeatureInterface
 import NeedleFoundation
 import UIKit
+import UserDomainInterface
 
-public protocol FruitDrawDependency: Dependency {}
+public protocol FruitDrawDependency: Dependency {
+    var fetchFruitDrawStatusUseCase: any FetchFruitDrawStatusUseCase { get }
+    var drawFruitUseCase: any DrawFruitUseCase { get }
+}
 
 public final class FruitDrawComponent: Component<FruitDrawDependency>, FruitDrawFactory {
     public func makeView() -> UIViewController {
-        return FruitDrawViewController(viewModel: .init())
+        return FruitDrawViewController(
+            viewModel: .init(
+                fetchFruitDrawStatusUseCase: dependency.fetchFruitDrawStatusUseCase,
+                drawFruitUseCase: dependency.drawFruitUseCase
+            )
+        )
     }
 }

--- a/Projects/Features/FruitDrawFeature/Sources/Components/FruitDrawComponent.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/Components/FruitDrawComponent.swift
@@ -1,4 +1,6 @@
+import AuthDomainInterface
 import Foundation
+import BaseFeatureInterface
 import FruitDrawFeatureInterface
 import NeedleFoundation
 import UIKit
@@ -7,6 +9,8 @@ import UserDomainInterface
 public protocol FruitDrawDependency: Dependency {
     var fetchFruitDrawStatusUseCase: any FetchFruitDrawStatusUseCase { get }
     var drawFruitUseCase: any DrawFruitUseCase { get }
+    var logoutUseCase: any LogoutUseCase { get }
+    var textPopUpFactory: any TextPopUpFactory { get }
 }
 
 public final class FruitDrawComponent: Component<FruitDrawDependency>, FruitDrawFactory {
@@ -14,8 +18,10 @@ public final class FruitDrawComponent: Component<FruitDrawDependency>, FruitDraw
         return FruitDrawViewController(
             viewModel: .init(
                 fetchFruitDrawStatusUseCase: dependency.fetchFruitDrawStatusUseCase,
-                drawFruitUseCase: dependency.drawFruitUseCase
-            )
+                drawFruitUseCase: dependency.drawFruitUseCase,
+                logoutUseCase: dependency.logoutUseCase
+            ),
+            textPopUpFactory: dependency.textPopUpFactory
         )
     }
 }

--- a/Projects/Features/FruitDrawFeature/Sources/Components/FruitDrawComponent.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/Components/FruitDrawComponent.swift
@@ -1,6 +1,6 @@
 import AuthDomainInterface
-import Foundation
 import BaseFeatureInterface
+import Foundation
 import FruitDrawFeatureInterface
 import NeedleFoundation
 import UIKit

--- a/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
@@ -160,6 +160,17 @@ public final class FruitDrawViewController: UIViewController {
 
 private extension FruitDrawViewController {
     func outputBind() {
+        output.showRewardNote
+            .bind(with: self) { owner, entity in
+                owner.drawButton.setTitle("확인", for: .normal)
+                owner.drawButton.backgroundColor = DesignSystemAsset.PrimaryColorV2.point.color
+                UIView.animate(withDuration: 0.3) {
+                    owner.lottieAnimationView.alpha = 0
+                    owner.drawButton.alpha = 1
+                }
+            }
+            .disposed(by: disposeBag)
+
         output.canDraw
             .skip(1)
             .bind(with: self) { owner, canDraw in
@@ -170,10 +181,12 @@ private extension FruitDrawViewController {
             }
             .disposed(by: disposeBag)
 
-        output.fruitSource
-            .filter { $0.quantity > 0 }
-            .bind(with: self) { owner, fruit in
-                LogManager.printDebug(fruit)
+        output.showToast
+            .bind(with: self) { owner, message in
+                owner.showToast(
+                    text: message,
+                    font: DesignSystemFontFamily.Pretendard.light.font(size: 14)
+                )
             }
             .disposed(by: disposeBag)
     }
@@ -190,8 +203,9 @@ private extension FruitDrawViewController {
         drawButton.rx.tap
             .withLatestFrom(output.canDraw)
             .filter { $0 }
-            .throttle(.seconds(1), latest: false, scheduler: MainScheduler.instance)
+            .throttle(.seconds(2), latest: false, scheduler: MainScheduler.instance)
             .bind(with: self) { owner, _ in
+                owner.input.didTapFruitDraw.onNext(())
                 owner.startLottieAnimation()
                 UIView.animate(
                     withDuration: 0.3,

--- a/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
@@ -1,4 +1,5 @@
 import BaseFeatureInterface
+import FruitDrawFeatureInterface
 import DesignSystem
 import LogManager
 import Lottie
@@ -8,10 +9,6 @@ import SnapKit
 import Then
 import UIKit
 import Utility
-
-public protocol FruitDrawViewControllerDelegate: AnyObject {
-    func completedFruitDraw(itemCount: Int)
-}
 
 public final class FruitDrawViewController: UIViewController {
     private let backgroundImageView = UIImageView().then {
@@ -148,11 +145,11 @@ public final class FruitDrawViewController: UIViewController {
 
     private let viewModel: FruitDrawViewModel
     private let textPopUpFactory: TextPopUpFactory
+    private weak var delegate: FruitDrawViewControllerDelegate?
 
     lazy var input = FruitDrawViewModel.Input()
     lazy var output = viewModel.transform(from: input)
     private let disposeBag = DisposeBag()
-    public weak var delegate: FruitDrawViewControllerDelegate?
 
     deinit {
         LogManager.printDebug("❌:: \(Self.self) deinit")
@@ -160,10 +157,12 @@ public final class FruitDrawViewController: UIViewController {
 
     public init(
         viewModel: FruitDrawViewModel,
-        textPopUpFactory: TextPopUpFactory
+        textPopUpFactory: TextPopUpFactory,
+        delegate: FruitDrawViewControllerDelegate
     ) {
         self.viewModel = viewModel
         self.textPopUpFactory = textPopUpFactory
+        self.delegate = delegate
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
@@ -41,7 +41,7 @@ public final class FruitDrawViewController: UIViewController {
         $0.image = DesignSystemAsset.FruitDraw.fruitDrawMachine.image
     }
 
-    private let drawButton = UIButton(type: .system).then {
+    private let drawOrConfirmButton = UIButton(type: .system).then {
         $0.setTitle("...", for: .normal)
         $0.setTitleColor(DesignSystemAsset.BlueGrayColor.blueGray25.color, for: .normal)
         $0.titleLabel?.font = DesignSystemFontFamily.Pretendard.medium.font(size: 18)
@@ -190,9 +190,9 @@ private extension FruitDrawViewController {
         output.canDraw
             .skip(1)
             .bind(with: self) { owner, canDraw in
-                owner.drawButton.isEnabled = canDraw
-                owner.drawButton.setTitle(canDraw ? "음표 열매 뽑기" : "오늘 뽑기 완료", for: .normal)
-                owner.drawButton.backgroundColor = canDraw ?
+                owner.drawOrConfirmButton.isEnabled = canDraw
+                owner.drawOrConfirmButton.setTitle(canDraw ? "음표 열매 뽑기" : "오늘 뽑기 완료", for: .normal)
+                owner.drawOrConfirmButton.backgroundColor = canDraw ?
                     DesignSystemAsset.PrimaryColorV2.point.color :
                     DesignSystemAsset.BlueGrayColor.gray300.color
             }
@@ -200,8 +200,8 @@ private extension FruitDrawViewController {
 
         output.showRewardNote
             .bind(with: self) { owner, entity in
-                owner.drawButton.setTitle("확인", for: .normal)
-                owner.drawButton.backgroundColor = DesignSystemAsset.PrimaryColorV2.point.color
+                owner.drawOrConfirmButton.setTitle("확인", for: .normal)
+                owner.drawOrConfirmButton.backgroundColor = DesignSystemAsset.PrimaryColorV2.point.color
                 owner.rewardDescriptioniLabel.text = "\(entity.name)를 획득했어요!"
 
                 if let data = entity.imageData {
@@ -210,7 +210,7 @@ private extension FruitDrawViewController {
 
                 UIView.animate(withDuration: 0.3) {
                     owner.lottieAnimationView.alpha = 0
-                    owner.drawButton.alpha = 1
+                    owner.drawOrConfirmButton.alpha = 1
                     owner.rewardDescriptioniLabel.alpha = 1
                     owner.rewardFruitImageView.alpha = 1
                 }
@@ -252,7 +252,7 @@ private extension FruitDrawViewController {
             }
             .disposed(by: disposeBag)
 
-        drawButton.rx.tap
+        drawOrConfirmButton.rx.tap
             .withLatestFrom(output.canDraw)
             .withLatestFrom(output.fruitSource) { ($0, $1) }
             .filter { $0.0 }
@@ -328,7 +328,7 @@ private extension FruitDrawViewController {
             descriptioniLabel,
             rewardFruitImageView,
             rewardDescriptioniLabel,
-            drawButton
+            drawOrConfirmButton
         )
         navigationBarView.setLeftViews([dismissButton])
     }
@@ -361,7 +361,7 @@ private extension FruitDrawViewController {
             $0.height.equalTo(56)
         }
 
-        drawButton.snp.makeConstraints {
+        drawOrConfirmButton.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(20)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-20)
             $0.height.equalTo(56)
@@ -503,6 +503,6 @@ private extension FruitDrawViewController {
         }
         descriptioniLabel.alpha = isHide ? 0 : 1
         drawMachineImageView.alpha = descriptioniLabel.alpha
-        drawButton.alpha = descriptioniLabel.alpha
+        drawOrConfirmButton.alpha = descriptioniLabel.alpha
     }
 }

--- a/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
@@ -165,8 +165,8 @@ private extension FruitDrawViewController {
             .bind(with: self) { owner, canDraw in
                 owner.drawButton.setTitle(canDraw ? "음표 열매 뽑기" : "오늘 뽑기 완료", for: .normal)
                 owner.drawButton.backgroundColor = canDraw ?
-                DesignSystemAsset.PrimaryColorV2.point.color :
-                DesignSystemAsset.BlueGrayColor.gray300.color
+                    DesignSystemAsset.PrimaryColorV2.point.color :
+                    DesignSystemAsset.BlueGrayColor.gray300.color
             }
             .disposed(by: disposeBag)
 

--- a/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
@@ -1,6 +1,6 @@
 import BaseFeatureInterface
-import FruitDrawFeatureInterface
 import DesignSystem
+import FruitDrawFeatureInterface
 import LogManager
 import Lottie
 import RxCocoa

--- a/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
@@ -245,9 +245,8 @@ private extension FruitDrawViewController {
             .bind(with: self) { owner, fruit in
                 let drawCompleted: Bool = fruit.quantity > 0
                 if drawCompleted {
-                    owner.dismiss(animated: true) {
-                        owner.delegate?.completedFruitDraw(itemCount: fruit.quantity)
-                    }
+                    owner.delegate?.completedFruitDraw(itemCount: fruit.quantity)
+                    owner.dismiss(animated: true)
                 } else {
                     owner.dismiss(animated: true)
                 }
@@ -263,9 +262,8 @@ private extension FruitDrawViewController {
                 let (_, fruit) = source
                 let drawCompleted: Bool = fruit.quantity > 0
                 if drawCompleted {
-                    owner.dismiss(animated: true) {
-                        owner.delegate?.completedFruitDraw(itemCount: fruit.quantity)
-                    }
+                    owner.delegate?.completedFruitDraw(itemCount: fruit.quantity)
+                    owner.dismiss(animated: true)
                 } else {
                     owner.input.didTapFruitDraw.onNext(())
                     owner.startLottieAnimation()

--- a/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
@@ -260,6 +260,7 @@ private extension FruitDrawViewController {
             .bind(with: self) { owner, source in
                 let (_, fruit) = source
                 let drawCompleted: Bool = fruit.quantity > 0
+
                 if drawCompleted {
                     owner.delegate?.completedFruitDraw(itemCount: fruit.quantity)
                     owner.dismiss(animated: true)
@@ -450,7 +451,7 @@ private extension FruitDrawViewController {
 
     func configureUI() {
         navigationController?.setNavigationBarHidden(true, animated: false)
-        startComponentAnimation()
+        perform(#selector(startComponentAnimation), with: nil, afterDelay: 0.3)
     }
 }
 
@@ -467,7 +468,7 @@ private extension FruitDrawViewController {
         }
     }
 
-    func startComponentAnimation() {
+    @objc func startComponentAnimation() {
         // Left Component
         purpleHeartImageView.moveAnimate(duration: 5.0, amount: 30, direction: .up)
         leftNoteImageView.moveAnimate(duration: 3.0, amount: 30, direction: .up)

--- a/Projects/Features/FruitDrawFeature/Sources/ViewModels/FruitDrawViewModel.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/ViewModels/FruitDrawViewModel.swift
@@ -3,8 +3,8 @@ import Foundation
 import LogManager
 import RxRelay
 import RxSwift
-import Utility
 import UserDomainInterface
+import Utility
 
 public final class FruitDrawViewModel: ViewModelType {
     private let fetchFruitDrawStatusUseCase: FetchFruitDrawStatusUseCase
@@ -31,7 +31,12 @@ public final class FruitDrawViewModel: ViewModelType {
 
     public struct Output {
         let canDraw: BehaviorRelay<Bool> = BehaviorRelay(value: false)
-        let fruitSource: BehaviorRelay<FruitEntity> = BehaviorRelay(value: .init(quantity: 0, fruitID: "", name: "", imageURL: ""))
+        let fruitSource: BehaviorRelay<FruitEntity> = BehaviorRelay(value: .init(
+            quantity: 0,
+            fruitID: "",
+            name: "",
+            imageURL: ""
+        ))
         let showToast: PublishSubject<String> = PublishSubject()
         let showRewardNote: PublishRelay<String> = PublishRelay()
     }

--- a/Projects/Features/FruitDrawFeature/Sources/ViewModels/FruitDrawViewModel.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/ViewModels/FruitDrawViewModel.swift
@@ -102,17 +102,15 @@ public final class FruitDrawViewModel: ViewModelType {
             .bind(to: output.fruitSource)
             .disposed(by: disposeBag)
 
-        let zipObservable = Observable.zip(
+        Observable.zip(
             input.endedLottieAnimation,
             output.fruitSource.skip(1)
         ) { _, entity -> FruitEntity in
             return entity
         }
-
-        zipObservable
-            .debug("FruitDrawZip")
-            .bind(to: output.showRewardNote)
-            .disposed(by: disposeBag)
+        .debug("FruitDrawZip")
+        .bind(to: output.showRewardNote)
+        .disposed(by: disposeBag)
 
         return output
     }

--- a/Projects/Features/FruitDrawFeature/Sources/ViewModels/FruitDrawViewModel.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/ViewModels/FruitDrawViewModel.swift
@@ -4,23 +4,34 @@ import LogManager
 import RxRelay
 import RxSwift
 import Utility
+import UserDomainInterface
 
 public final class FruitDrawViewModel: ViewModelType {
+    private let fetchFruitDrawStatusUseCase: FetchFruitDrawStatusUseCase
+    private let drawFruitUseCase: DrawFruitUseCase
     private let disposeBag = DisposeBag()
 
     deinit {
         LogManager.printDebug("❌:: \(Self.self) deinit")
     }
 
-    public init() {}
+    public init(
+        fetchFruitDrawStatusUseCase: any FetchFruitDrawStatusUseCase,
+        drawFruitUseCase: any DrawFruitUseCase
+    ) {
+        self.fetchFruitDrawStatusUseCase = fetchFruitDrawStatusUseCase
+        self.drawFruitUseCase = drawFruitUseCase
+    }
 
     public struct Input {
+        let fetchFruitDrawStatus: PublishSubject<Void> = PublishSubject()
         let didTapFruitDraw: PublishSubject<Void> = PublishSubject()
         let endedLottieAnimation: PublishSubject<Void> = PublishSubject()
     }
 
     public struct Output {
-        let dataSource: PublishRelay<String> = PublishRelay()
+        let canDraw: BehaviorRelay<Bool> = BehaviorRelay(value: false)
+        let fruitSource: BehaviorRelay<FruitEntity> = BehaviorRelay(value: .init(quantity: 0, fruitID: "", name: "", imageURL: ""))
         let showToast: PublishSubject<String> = PublishSubject()
         let showRewardNote: PublishRelay<String> = PublishRelay()
     }
@@ -28,17 +39,35 @@ public final class FruitDrawViewModel: ViewModelType {
     public func transform(from input: Input) -> Output {
         let output = Output()
 
-        input.didTapFruitDraw
-            .flatMap { _ in
-                // TO-DO: FruitDrawUseCase
-                return Observable.just("")
+        input.fetchFruitDrawStatus
+            .flatMap { [fetchFruitDrawStatusUseCase] _ in
+                return fetchFruitDrawStatusUseCase.execute()
+                    .catchAndReturn(
+                        .init(
+                            canDraw: false,
+                            lastDraw: .init(
+                                drawAt: 0,
+                                fruit: .init(fruitID: "", name: "", imageURL: "")
+                            )
+                        )
+                    )
             }
-            .bind(to: output.dataSource)
+            .map { $0.canDraw }
+            .bind(to: output.canDraw)
             .disposed(by: disposeBag)
 
-        Observable.zip(input.endedLottieAnimation, output.dataSource)
-            .subscribe()
+        input.didTapFruitDraw
+            .flatMap { [drawFruitUseCase] _ in
+                return drawFruitUseCase.execute()
+                    .catchAndReturn(.init(quantity: 0, fruitID: "", name: "", imageURL: ""))
+            }
+            .filter { $0.quantity > 0 }
+            .bind(to: output.fruitSource)
             .disposed(by: disposeBag)
+//
+//        Observable.zip(input.endedLottieAnimation, output.dataSource)
+//            .subscribe()
+//            .disposed(by: disposeBag)
 
         return output
     }

--- a/Projects/Features/FruitDrawFeature/Sources/ViewModels/FruitDrawViewModel.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/ViewModels/FruitDrawViewModel.swift
@@ -55,7 +55,8 @@ public final class FruitDrawViewModel: ViewModelType {
                     .asObservable()
                     .catch { error in
                         let wmError = error.asWMError
-                        output.occurredError.onNext(wmError.errorDescription ?? error.localizedDescription)
+                        let message = wmError.errorDescription ?? error.localizedDescription
+                        output.occurredError.onNext(message)
 
                         if wmError == .tokenExpired {
                             return logoutUseCase.execute()
@@ -80,7 +81,8 @@ public final class FruitDrawViewModel: ViewModelType {
                 return drawFruitUseCase.execute()
                     .catch { error in
                         let wmError = error.asWMError
-                        output.occurredError.onNext(wmError.errorDescription ?? error.localizedDescription)
+                        let message = wmError.errorDescription ?? error.localizedDescription
+                        output.occurredError.onNext(message)
 
                         if wmError == .tokenExpired {
                             return logoutUseCase.execute()

--- a/Projects/Features/FruitDrawFeature/Sources/ViewModels/FruitDrawViewModel.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/ViewModels/FruitDrawViewModel.swift
@@ -1,11 +1,11 @@
 import BaseFeature
 import Foundation
+import Kingfisher
 import LogManager
 import RxRelay
 import RxSwift
 import UserDomainInterface
 import Utility
-import Kingfisher
 
 public final class FruitDrawViewModel: ViewModelType {
     private let fetchFruitDrawStatusUseCase: FetchFruitDrawStatusUseCase
@@ -72,7 +72,7 @@ public final class FruitDrawViewModel: ViewModelType {
                 guard let self = self else { return .never() }
                 return self.downloadNoteImage(entity: entity)
             }
-            .map { (entity, data) -> FruitEntity in
+            .map { entity, data -> FruitEntity in
                 var newEntity = entity
                 newEntity.imageData = data
                 return newEntity
@@ -83,7 +83,7 @@ public final class FruitDrawViewModel: ViewModelType {
         let combineObservable = Observable.combineLatest(
             input.endedLottieAnimation,
             output.fruitSource.skip(1)
-        ) { (_, fruit) -> FruitEntity in
+        ) { _, fruit -> FruitEntity in
             return fruit
         }
 

--- a/Projects/Features/LyricHighlightingFeature/Sources/ViewControllers/LyricDecoratingViewController.swift
+++ b/Projects/Features/LyricHighlightingFeature/Sources/ViewControllers/LyricDecoratingViewController.swift
@@ -322,7 +322,7 @@ private extension LyricDecoratingViewController {
         }
 
         indicator.snp.makeConstraints {
-            $0.center.equalToSuperview()
+            $0.center.equalTo(decorateShareContentView.snp.center)
             $0.size.equalTo(30)
         }
     }

--- a/Projects/Features/LyricHighlightingFeature/Sources/ViewModels/LyricHighlightingViewModel.swift
+++ b/Projects/Features/LyricHighlightingFeature/Sources/ViewModels/LyricHighlightingViewModel.swift
@@ -42,61 +42,11 @@ public final class LyricHighlightingViewModel: ViewModelType {
         let output = Output()
         let songID: String = self.model.songID
 
-        #warning("TO-DO: catchAndReturn은 []로 수정해야함")
         input.fetchLyric
             .flatMap { [fetchLyricsUseCase] _ -> Observable<[LyricsEntity]> in
                 return fetchLyricsUseCase.execute(id: songID)
                     .asObservable()
-                    .catchAndReturn(
-                        [
-                            LyricsEntity(text: "기억나 우리 처음 만난날기억나 우리 처음 만난날기억나 우리 처음 만난날기억나 우리 처음 만난날"),
-                            LyricsEntity(text: "내게 오던 너의 그 미소가"),
-                            LyricsEntity(text: "마치 날 알고 있던 것처럼"),
-                            LyricsEntity(text: "매일 스쳐 지나가던 바람처럼"),
-                            LyricsEntity(text: "가끔은 우리 사이가 멀어질까"),
-                            LyricsEntity(text: "혼자 남아버리는 상상을 해 oh"),
-                            LyricsEntity(text: "이런 나를 잡아줘 우리 처음"),
-                            LyricsEntity(text: "만난 날처럼 내가 너를 꼭 찾을 수 있게"),
-                            LyricsEntity(text: "늘 꿈에서만 그리던"),
-                            LyricsEntity(text: "너와 함께 할 모든 날들이"),
-                            LyricsEntity(text: "더 희미해지기 전에"),
-                            LyricsEntity(text: "나 시간이 없어"),
-                            LyricsEntity(text: "지금 닿을 수는 없는 거리 일지라도"),
-                            LyricsEntity(text: "꼭 너와 함께 있다는 기분이 들어"),
-                            LyricsEntity(text: "널 주저했던 걸음, 마음.나는"),
-                            LyricsEntity(text: "왜 이리 바보 같은 지"),
-                            LyricsEntity(text: "자신이 없어"),
-                            LyricsEntity(text: "늘 같은 곳을 바라보던 너의 그 눈이 좋아"),
-                            LyricsEntity(text: "변한 세상에서 너만은 그대로 있어줘"),
-                            LyricsEntity(text: "you're my sunshine"),
-                            LyricsEntity(text: "늘 같은 곳을 헤매이던 너와 내 시간 속에"),
-                            LyricsEntity(text: "날 잊어버린다 해도"),
-                            LyricsEntity(text: "다시 한번 너를 만나러 갈 테니까"),
-                            LyricsEntity(text: "기억나 우리 처음 만난날기억나 우리 처음 만난날기억나 우리 처음 만난날기억나 우리 처음 만난날"),
-                            LyricsEntity(text: "내게 오던 너의 그 미소가"),
-                            LyricsEntity(text: "마치 날 알고 있던 것처럼"),
-                            LyricsEntity(text: "매일 스쳐 지나가던 바람처럼"),
-                            LyricsEntity(text: "가끔은 우리 사이가 멀어질까"),
-                            LyricsEntity(text: "혼자 남아버리는 상상을 해 oh"),
-                            LyricsEntity(text: "이런 나를 잡아줘 우리 처음"),
-                            LyricsEntity(text: "만난 날처럼 내가 너를 꼭 찾을 수 있게"),
-                            LyricsEntity(text: "늘 꿈에서만 그리던"),
-                            LyricsEntity(text: "너와 함께 할 모든 날들이"),
-                            LyricsEntity(text: "더 희미해지기 전에"),
-                            LyricsEntity(text: "나 시간이 없어"),
-                            LyricsEntity(text: "지금 닿을 수는 없는 거리 일지라도"),
-                            LyricsEntity(text: "꼭 너와 함께 있다는 기분이 들어"),
-                            LyricsEntity(text: "널 주저했던 걸음, 마음.나는"),
-                            LyricsEntity(text: "왜 이리 바보 같은 지"),
-                            LyricsEntity(text: "자신이 없어"),
-                            LyricsEntity(text: "늘 같은 곳을 바라보던 너의 그 눈이 좋아"),
-                            LyricsEntity(text: "변한 세상에서 너만은 그대로 있어줘"),
-                            LyricsEntity(text: "you're my sunshine"),
-                            LyricsEntity(text: "늘 같은 곳을 헤매이던 너와 내 시간 속에"),
-                            LyricsEntity(text: "날 잊어버린다 해도"),
-                            LyricsEntity(text: "다시 한번 너를 만나러 갈 테니까")
-                        ]
-                    )
+                    .catchAndReturn([])
             }
             .bind(to: output.dataSource)
             .disposed(by: disposeBag)

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -12,7 +12,8 @@ import Then
 import UIKit
 import Utility
 
-final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, EditSheetViewType, FruitDrawViewControllerDelegate {
+final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, EditSheetViewType,
+    FruitDrawViewControllerDelegate {
     let myInfoView = MyInfoView()
     private var profilePopUpComponent: ProfilePopComponent!
     private var textPopUpFactory: TextPopUpFactory!

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -12,8 +12,7 @@ import Then
 import UIKit
 import Utility
 
-final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, EditSheetViewType,
-    FruitDrawViewControllerDelegate {
+final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, EditSheetViewType {
     let myInfoView = MyInfoView()
     private var profilePopUpComponent: ProfilePopComponent!
     private var textPopUpFactory: TextPopUpFactory!
@@ -260,7 +259,7 @@ extension MyInfoViewController: EqualHandleTappedType {
     }
 }
 
-extension MyInfoViewController {
+extension MyInfoViewController: FruitDrawViewControllerDelegate {
     func completedFruitDraw(itemCount: Int) {
         LogManager.printDebug("itemCount: \(itemCount)")
     }

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -12,7 +12,7 @@ import Then
 import UIKit
 import Utility
 
-final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, EditSheetViewType {
+final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, EditSheetViewType, FruitDrawViewControllerDelegate {
     let myInfoView = MyInfoView()
     private var profilePopUpComponent: ProfilePopComponent!
     private var textPopUpFactory: TextPopUpFactory!
@@ -131,7 +131,7 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
             .bind(with: self) { owner, navigate in
                 switch navigate {
                 case .draw:
-                    let viewController = owner.fruitDrawFactory.makeView().wrapNavigationController
+                    let viewController = owner.fruitDrawFactory.makeView(delegate: owner)
                     viewController.modalPresentationStyle = .fullScreen
                     owner.present(viewController, animated: true)
                 case .like:
@@ -256,5 +256,11 @@ extension MyInfoViewController: EqualHandleTappedType {
         if viewControllersCount > 1 {
             self.navigationController?.popToRootViewController(animated: true)
         }
+    }
+}
+
+extension MyInfoViewController {
+    func completedFruitDraw(itemCount: Int) {
+        LogManager.printDebug("itemCount: \(itemCount)")
     }
 }

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -261,6 +261,7 @@ extension MyInfoViewController: EqualHandleTappedType {
 
 extension MyInfoViewController: FruitDrawViewControllerDelegate {
     func completedFruitDraw(itemCount: Int) {
+        #warning("획득한 열매 갯수입니다. 다음 처리 진행해주세요.")
         LogManager.printDebug("itemCount: \(itemCount)")
     }
 }

--- a/Projects/Features/RootFeature/Project.swift
+++ b/Projects/Features/RootFeature/Project.swift
@@ -11,8 +11,8 @@ let project = Project.module(
             spec: .init(
                 resources: ["Resources/**"],
                 dependencies: [
-                    .feature(target: .BaseFeature),
                     .feature(target: .MainTabFeature),
+                    .feature(target: .BaseFeature, type: .interface),
                     .domain(target: .AppDomain, type: .interface),
                     .domain(target: .UserDomain, type: .interface)
                 ]

--- a/Projects/Features/RootFeature/Sources/ViewControllers/IntroViewController.swift
+++ b/Projects/Features/RootFeature/Sources/ViewControllers/IntroViewController.swift
@@ -1,4 +1,3 @@
-import BaseFeature
 import BaseFeatureInterface
 import DesignSystem
 import Lottie
@@ -9,7 +8,7 @@ import Then
 import UIKit
 import Utility
 
-open class IntroViewController: BaseViewController, ViewControllerFromStoryBoard {
+open class IntroViewController: UIViewController, ViewControllerFromStoryBoard {
     @IBOutlet weak var logoContentView: UIView!
     private let parableLogoImageView = UIImageView().then {
         $0.image = DesignSystemAsset.Logo.splashParable.image
@@ -85,7 +84,7 @@ private extension IntroViewController {
                 case let .success(entity):
                     owner.lottiePlay(specialLogo: entity.specialLogo)
 
-                    var textPopupVc: TextPopupViewController
+                    var textPopupVc: UIViewController
                     let updateTitle: String = "왁타버스 뮤직이 업데이트 되었습니다."
                     let updateMessage: String = "최신 버전으로 업데이트 후 이용하시기 바랍니다.\n감사합니다."
 
@@ -120,7 +119,7 @@ private extension IntroViewController {
                                 exit(0)
                             },
                             cancelCompletion: nil
-                        ) as? TextPopupViewController ?? .init()
+                        )
 
                     case .update:
                         textPopupVc = owner.textPopUpFactory.makeView(
@@ -134,7 +133,7 @@ private extension IntroViewController {
                             cancelCompletion: {
                                 owner.input.fetchUserInfoCheck.onNext(())
                             }
-                        ) as? TextPopupViewController ?? .init()
+                        )
 
                     case .forceUpdate:
                         textPopupVc = owner.textPopUpFactory.makeView(
@@ -146,7 +145,7 @@ private extension IntroViewController {
                                 owner.goAppStore()
                             },
                             cancelCompletion: nil
-                        ) as? TextPopupViewController ?? .init()
+                        )
                     }
 
                     owner.showBottomSheet(

--- a/Projects/Features/RootFeature/Sources/ViewControllers/IntroViewController.swift
+++ b/Projects/Features/RootFeature/Sources/ViewControllers/IntroViewController.swift
@@ -209,6 +209,7 @@ private extension IntroViewController {
 
 private extension IntroViewController {
     func configureUI() {
+        navigationController?.setNavigationBarHidden(true, animated: false)
         view.addSubview(parableLogoImageView)
         parableLogoImageView.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-50)

--- a/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
@@ -1,14 +1,14 @@
 import BaseFeature
 import DesignSystem
 import LogManager
+import NVActivityIndicatorView
 import RxCocoa
 import RxSwift
 import SafariServices
-import UIKit
-import Utility
 import SnapKit
 import Then
-import NVActivityIndicatorView
+import UIKit
+import Utility
 
 public class LoginViewController: UIViewController, ViewControllerFromStoryBoard {
     @IBOutlet weak var closeButton: UIButton!
@@ -43,6 +43,7 @@ public class LoginViewController: UIViewController, ViewControllerFromStoryBoard
         }
         $0.isHidden = true
     }
+
     private lazy var activityIndicator = NVActivityIndicatorView(frame: .zero).then {
         $0.color = .white
         $0.type = .circleStrokeSpin

--- a/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewControllers/LoginViewController.swift
@@ -6,6 +6,9 @@ import RxSwift
 import SafariServices
 import UIKit
 import Utility
+import SnapKit
+import Then
+import NVActivityIndicatorView
 
 public class LoginViewController: UIViewController, ViewControllerFromStoryBoard {
     @IBOutlet weak var closeButton: UIButton!
@@ -31,6 +34,24 @@ public class LoginViewController: UIViewController, ViewControllerFromStoryBoard
     @IBOutlet weak var privacyButton: UIButton!
     @IBOutlet weak var versionLabel: UILabel!
     @IBOutlet weak var copyrightLabel: UILabel!
+
+    private lazy var loadingContentView = UIView().then {
+        $0.backgroundColor = .black.withAlphaComponent(0.4)
+        view.addSubview($0)
+        $0.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        $0.isHidden = true
+    }
+    private lazy var activityIndicator = NVActivityIndicatorView(frame: .zero).then {
+        $0.color = .white
+        $0.type = .circleStrokeSpin
+        loadingContentView.addSubview($0)
+        $0.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.size.equalTo(30)
+        }
+    }
 
     private var viewModel: LoginViewModel!
     private lazy var input = viewModel.input
@@ -74,6 +95,17 @@ private extension LoginViewController {
                     })
                 } else {
                     owner.dismiss(animated: true)
+                }
+            }
+            .disposed(by: disposeBag)
+
+        output.showLoading
+            .bind(with: self) { owner, show in
+                owner.loadingContentView.isHidden = !show
+                if show {
+                    owner.activityIndicator.startAnimating()
+                } else {
+                    owner.activityIndicator.stopAnimating()
                 }
             }
             .disposed(by: disposeBag)

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UIViewController.swift
@@ -59,6 +59,13 @@ public extension UIViewController {
         attributes.displayDuration = 2
         attributes.entryBackground = .color(color: EKColor(rgb: 0x101828).with(alpha: 0.8))
         attributes.roundCorners = .all(radius: 20)
+        attributes.entranceAnimation = EKAttributes.Animation.init(
+            translate: .init(duration: 0.3),
+            fade: .init(from: 0, to: 1, duration: 0.3)
+        )
+        attributes.exitAnimation = EKAttributes.Animation.init(
+            fade: .init(from: 1, to: 0, duration: 0.3)
+        )
 
         if let verticalOffset = verticalOffset {
             attributes.positionConstraints.verticalOffset = verticalOffset


### PR DESCRIPTION
## 💡 배경 및 개요
열매 뽑기 화면 구현

Resolves: #699 

## 📃 작업내용
- userDomain api 추가 (뽑기 가능 상태 체크, 뽑기, 열매함 리스트)
- usecase 주입 및 구현 (뽑기 가능 상태 체크, 뽑기)
- 뽑기 후 아이템 카운트 반영은 MyInfo에서 구현
- (PR 외) IntroVC > BaseFeature 의존 제거
- (PR 외) 토스트 인터렉션 변경
- (PR 외) 가사 하이라이팅 > 임시로직 제거
- (PR 외) 로그인 > 로딩 인디케이터 추가

## 🙋‍♂️ 리뷰노트
- 로티 파일(현재 임시) 받으면 작업예정

https://github.com/wakmusic/wakmusic-iOS/assets/37323252/866e584d-6464-4026-9ad8-5c2835204a7a

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요? (IntroVC > BaseFeature 의존 제거)

## 🎸 기타
