### PR TITLE
🔀 :: (#663) 유저 프로필 DTO 변경에 따른 대응

### DIFF
--- a/Projects/Domains/UserDomain/Interface/Entity/UserInfoEntity.swift
+++ b/Projects/Domains/UserDomain/Interface/Entity/UserInfoEntity.swift
@@ -14,18 +14,18 @@ public struct UserInfoEntity: Equatable {
         platform: String,
         name: String,
         profile: String,
-        version: Int
+        itemCount: Int
 
     ) {
         self.id = id
         self.platform = platform
         self.name = name
         self.profile = profile
-        self.version = version
+        self.itemCount = itemCount
     }
 
     public let id, platform, name, profile: String
-    public let version: Int
+    public let itemCount: Int
 
     public static func == (lhs: UserInfoEntity, rhs: UserInfoEntity) -> Bool {
         lhs.id == rhs.id

--- a/Projects/Domains/UserDomain/Sources/ResponseDTO/FetchUserResponseDTO.swift
+++ b/Projects/Domains/UserDomain/Sources/ResponseDTO/FetchUserResponseDTO.swift
@@ -25,7 +25,7 @@ public extension FetchUserResponseDTO {
             platform: platform,
             name: name,
             profile: profile,
-            version: 0
+            itemCount: itemCount
         )
     }
 }

--- a/Projects/Domains/UserDomain/Testing/FetchUserInfoUserCaseSpy.swift
+++ b/Projects/Domains/UserDomain/Testing/FetchUserInfoUserCaseSpy.swift
@@ -4,6 +4,6 @@ import UserDomainInterface
 
 public struct FetchUserInfoUseCaseSpy: FetchUserInfoUseCase {
     public func execute() -> Single<UserInfoEntity> {
-        return .just(UserInfoEntity(id: "fakeid", platform: "naver", name: "fakename", profile: "", version: 1))
+        return .just(UserInfoEntity(id: "fakeid", platform: "naver", name: "fakename", profile: "", itemCount: 1))
     }
 }

--- a/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
@@ -93,7 +93,7 @@ private extension LoginViewModel {
                     platform: entity.platform,
                     profile: entity.profile,
                     name: AES256.encrypt(string: entity.name),
-                    version: entity.version
+                    itemCount: entity.itemCount
                 )
                 output.dismissLoginScene.accept(input.arrivedTokenFromThirdParty.value.0)
                 output.showLoading.accept(false)

--- a/Projects/Features/StorageFeature/Sources/ViewModels/AfterLoginStorageViewModel.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewModels/AfterLoginStorageViewModel.swift
@@ -59,7 +59,7 @@ public final class AfterLoginViewModel: ViewModelType {
                     platform: $0.platform,
                     profile: $0.profile,
                     name: AES256.encrypt(string: $0.name),
-                    version: $0.version
+                    itemCount: $0.itemCount
                 )
             }).disposed(by: disposeBag)
 

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+PreferenceManager.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+PreferenceManager.swift
@@ -51,14 +51,14 @@ public extension PreferenceManager {
         platform: String,
         profile: String,
         name: String,
-        version: Int
+        itemCount: Int
     ) {
         let userInfo = UserInfo(
             ID: ID,
             platform: platform,
             profile: profile,
             name: name,
-            version: version
+            itemCount: itemCount
         )
         Utility.PreferenceManager.userInfo = userInfo
     }

--- a/Projects/Modules/Utility/Sources/Manager/PreferenceManager.swift
+++ b/Projects/Modules/Utility/Sources/Manager/PreferenceManager.swift
@@ -58,17 +58,6 @@ public final class UserDefaultWrapper<T: Codable> {
                 let decoder = JSONDecoder()
                 if let lodedObejct = try? decoder.decode(T.self, from: savedData) {
                     return lodedObejct
-
-                    // v2.2.1 > v2.2.2 업데이트 유저 로그아웃 방지 대응
-                } else if let loadedObject = try? JSONSerialization
-                    .jsonObject(with: savedData, options: []) as? [String: Any] {
-                    return UserInfo(
-                        ID: loadedObject["ID"] as? String ?? "",
-                        platform: loadedObject["platform"] as? String ?? "",
-                        profile: loadedObject["profile"] as? String ?? "",
-                        name: loadedObject["displayName"] as? String ?? "",
-                        version: loadedObject["version"] as? Int ?? 0
-                    ) as? T
                 }
 
             } else if UserDefaults.standard.array(forKey: key) != nil {

--- a/Projects/Modules/Utility/Sources/Manager/UserInfoManager.swift
+++ b/Projects/Modules/Utility/Sources/Manager/UserInfoManager.swift
@@ -13,7 +13,7 @@ public struct UserInfo: Codable, Equatable {
     public let platform: String
     public let profile: String
     public let name: String
-    public let version: Int
+    public let itemCount: Int
 
     public static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.ID == rhs.ID
@@ -21,17 +21,33 @@ public struct UserInfo: Codable, Equatable {
 }
 
 public extension UserInfo {
-    func update(displayName: String) -> UserInfo {
+    func update(name: String) -> UserInfo {
         return UserInfo(
             ID: self.ID,
             platform: self.platform,
             profile: self.profile,
-            name: displayName,
-            version: self.version
+            name: name,
+            itemCount: self.itemCount
         )
     }
 
     func update(profile: String) -> UserInfo {
-        return UserInfo(ID: self.ID, platform: self.platform, profile: profile, name: self.name, version: self.version)
+        return UserInfo(
+            ID: self.ID,
+            platform: self.platform,
+            profile: profile,
+            name: self.name,
+            itemCount: self.itemCount
+        )
+    }
+    
+    func update(itemCount: Int) -> UserInfo {
+        return UserInfo(
+            ID: self.ID,
+            platform: self.platform,
+            profile: self.profile,
+            name: self.name,
+            itemCount: itemCount
+        )
     }
 }

--- a/Projects/Modules/Utility/Sources/Manager/UserInfoManager.swift
+++ b/Projects/Modules/Utility/Sources/Manager/UserInfoManager.swift
@@ -40,7 +40,7 @@ public extension UserInfo {
             itemCount: self.itemCount
         )
     }
-    
+
     func update(itemCount: Int) -> UserInfo {
         return UserInfo(
             ID: self.ID,


### PR DESCRIPTION
## 💡 배경 및 개요
유저 프로필 DTO 변경에 따른 대응

Resolves: #663 

## 📃 작업내용
- version 제거, itemCount 추가
- 연관 Entity, Preference 수정

## 🙋‍♂️ 리뷰노트
- createAt은 사용처가 없어서 넣지 않음

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
