### PR TITLE
🔀 :: (#735)  기본 플레이리스트 이미지 팝업을 만들고 연결합니다. 

### DIFF
--- a/Projects/App/Sources/Application/AppComponent+Playlist.swift
+++ b/Projects/App/Sources/Application/AppComponent+Playlist.swift
@@ -47,6 +47,10 @@ public extension AppComponent {
     var checkThumbnailFactory: any CheckThumbnailFactory {
         CheckThumbnailComponent(parent: self)
     }
+    
+    var defaultPlaylistImageFactory: any DefaultPlaylistImageFactory {
+        DefaultPlaylistImageComponent(parent: self)
+    }
 
     var remotePlaylistDataSource: any RemotePlaylistDataSource {
         shared {

--- a/Projects/App/Sources/Application/AppComponent+Playlist.swift
+++ b/Projects/App/Sources/Application/AppComponent+Playlist.swift
@@ -47,7 +47,7 @@ public extension AppComponent {
     var checkThumbnailFactory: any CheckThumbnailFactory {
         CheckThumbnailComponent(parent: self)
     }
-    
+
     var defaultPlaylistImageFactory: any DefaultPlaylistImageFactory {
         DefaultPlaylistImageComponent(parent: self)
     }

--- a/Projects/Features/PlaylistFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Features/PlaylistFeature/Demo/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let viewController = Inject.ViewControllerHost(
             UINavigationController(
-                rootViewController: UIViewController()
+                rootViewController: DefaultPlaylistImageViewController(reactor: DefaultPlaylistImageReactor())
             )
         )
         window?.rootViewController = viewController

--- a/Projects/Features/PlaylistFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Features/PlaylistFeature/Demo/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let viewController = Inject.ViewControllerHost(
             UINavigationController(
-                rootViewController: DefaultPlaylistImageViewController(reactor: DefaultPlaylistImageReactor())
+                rootViewController: UIViewController()
             )
         )
         window?.rootViewController = viewController

--- a/Projects/Features/PlaylistFeature/Interface/DefaultPlaylistImageFactory.swift
+++ b/Projects/Features/PlaylistFeature/Interface/DefaultPlaylistImageFactory.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+public protocol DefaultPlaylistImageDelegate: AnyObject {
+    func receive(_ name:String,_ url: String)
+}
+
+public protocol DefaultPlaylistImageFactory {
+    func makeView(_ delegate: any DefaultPlaylistImageDelegate ) -> UIViewController
+}
+

--- a/Projects/Features/PlaylistFeature/Interface/DefaultPlaylistImageFactory.swift
+++ b/Projects/Features/PlaylistFeature/Interface/DefaultPlaylistImageFactory.swift
@@ -1,10 +1,9 @@
 import UIKit
 
 public protocol DefaultPlaylistImageDelegate: AnyObject {
-    func receive(_ name:String,_ url: String)
+    func receive(_ name: String, _ url: String)
 }
 
 public protocol DefaultPlaylistImageFactory {
-    func makeView(_ delegate: any DefaultPlaylistImageDelegate ) -> UIViewController
+    func makeView(_ delegate: any DefaultPlaylistImageDelegate) -> UIViewController
 }
-

--- a/Projects/Features/PlaylistFeature/Sources/Components/DefaultPlaylistImageComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/DefaultPlaylistImageComponent.swift
@@ -5,17 +5,13 @@ import PlaylistFeatureInterface
 import UIKit
 
 public protocol DefaultPlaylistImageDependency: Dependency {
-    
     #warning("usecase 주입")
     //
 }
 
-
-public final class DefaultPlaylistImageComponent: Component<DefaultPlaylistImageDependency>, DefaultPlaylistImageFactory {
+public final class DefaultPlaylistImageComponent: Component<DefaultPlaylistImageDependency>,
+    DefaultPlaylistImageFactory {
     public func makeView(_ delegate: any DefaultPlaylistImageDelegate) -> UIViewController {
-        
         DefaultPlaylistImageViewController(delegate: delegate, reactor: DefaultPlaylistImageReactor())
-        
     }
-    
 }

--- a/Projects/Features/PlaylistFeature/Sources/Components/DefaultPlaylistImageComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/DefaultPlaylistImageComponent.swift
@@ -1,0 +1,21 @@
+import BaseFeature
+import BaseFeatureInterface
+import NeedleFoundation
+import PlaylistFeatureInterface
+import UIKit
+
+public protocol DefaultPlaylistImageDependency: Dependency {
+    
+    #warning("usecase 주입")
+    //
+}
+
+
+public final class DefaultPlaylistImageComponent: Component<DefaultPlaylistImageDependency>, DefaultPlaylistImageFactory {
+    public func makeView(_ delegate: any DefaultPlaylistImageDelegate) -> UIViewController {
+        
+        DefaultPlaylistImageViewController(delegate: delegate, reactor: DefaultPlaylistImageReactor())
+        
+    }
+    
+}

--- a/Projects/Features/PlaylistFeature/Sources/Components/MyPlaylistDetailComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/MyPlaylistDetailComponent.swift
@@ -20,6 +20,7 @@ public protocol MyPlaylistDetailDependency: Dependency {
     var containSongsFactory: any ContainSongsFactory { get }
     var thumbnailPopupFactory: any ThumbnailPopupFactory { get }
     var checkThumbnailFactory: any CheckThumbnailFactory { get }
+    var defaultPlaylistImageFactory: any DefaultPlaylistImageFactory { get }
 
     var textPopUpFactory: any TextPopUpFactory { get }
 }
@@ -40,7 +41,8 @@ public final class MyPlaylistDetailComponent: Component<MyPlaylistDetailDependen
             containSongsFactory: dependency.containSongsFactory,
             textPopUpFactory: dependency.textPopUpFactory,
             thumbnailPopupFactory: dependency.thumbnailPopupFactory,
-            checkThumbnailFactory: dependency.checkThumbnailFactory
+            checkThumbnailFactory: dependency.checkThumbnailFactory,
+            defaultPlaylistImageFactory: dependency.defaultPlaylistImageFactory
         )
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/DefaultPlaylistImageReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/DefaultPlaylistImageReactor.swift
@@ -5,17 +5,17 @@ import ReactorKit
 final class DefaultPlaylistImageReactor: Reactor {
     enum Action {
         case viewDidload
-        case select(String)
+        case selectedIndex(Int)
     }
 
     enum Mutation {
         case updateDataSource([String])
-        case updateSelectedItem(String)
+        case updateSelectedItem(Int)
     }
 
     struct State {
         var dataSource: [String]
-        var selectedItem: String
+        var selectedIndex: Int
     }
 
     var initialState: State
@@ -23,7 +23,7 @@ final class DefaultPlaylistImageReactor: Reactor {
     init() {
         initialState = State(
             dataSource: [],
-            selectedItem: ""
+            selectedIndex: 0
         )
     }
 
@@ -32,8 +32,8 @@ final class DefaultPlaylistImageReactor: Reactor {
         case .viewDidload:
             return updateDataSource()
 
-        case let .select(id):
-            return .just(.updateSelectedItem(id))
+        case let .selectedIndex(index):
+            return .just(.updateSelectedItem(index))
         }
     }
 
@@ -44,7 +44,7 @@ final class DefaultPlaylistImageReactor: Reactor {
         case let .updateDataSource(dataSource):
             newState.dataSource = dataSource
         case let .updateSelectedItem(id):
-            newState.selectedItem = id
+            newState.selectedIndex = id
         }
 
         return newState

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/DefaultPlaylistImageReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/DefaultPlaylistImageReactor.swift
@@ -1,69 +1,55 @@
+import DesignSystem
 import Foundation
 import ReactorKit
-import DesignSystem
-
 
 final class DefaultPlaylistImageReactor: Reactor {
-    
     enum Action {
         case viewDidload
     }
-    
+
     enum Mutation {
-        
         case updateDataSource([String])
-        
     }
-    
+
     struct State {
         var dataSource: [String]
     }
-    
+
     var initialState: State
-    
+
     init() {
         initialState = State(
-        dataSource: []
+            dataSource: []
         )
     }
-    
+
     func mutate(action: Action) -> Observable<Mutation> {
-        
         switch action {
-            case .viewDidload:
-                return updateDataSource()
+        case .viewDidload:
+            return updateDataSource()
         }
-        
     }
-    
+
     func reduce(state: State, mutation: Mutation) -> State {
-        
         var newState = state
-        
+
         switch mutation {
-            
         case let .updateDataSource(dataSource):
             newState.dataSource = dataSource
-            
         }
-     
+
         return newState
     }
-    
 }
 
 extension DefaultPlaylistImageReactor {
     func updateDataSource() -> Observable<Mutation> {
-        
         var dataSource: [String] = []
-        
-        
-        for i in 0...10 {
+
+        for i in 0 ... 10 {
             dataSource.append("theme_\(i)")
         }
-        
-        
+
         return .just(.updateDataSource(dataSource))
-        
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/DefaultPlaylistImageReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/DefaultPlaylistImageReactor.swift
@@ -11,7 +11,6 @@ final class DefaultPlaylistImageReactor: Reactor {
     enum Mutation {
         case updateDataSource([String])
         case updateSelectedItem(String)
-        
     }
 
     struct State {
@@ -32,7 +31,7 @@ final class DefaultPlaylistImageReactor: Reactor {
         switch action {
         case .viewDidload:
             return updateDataSource()
-        
+
         case let .select(id):
             return .just(.updateSelectedItem(id))
         }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/DefaultPlaylistImageReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/DefaultPlaylistImageReactor.swift
@@ -11,11 +11,13 @@ final class DefaultPlaylistImageReactor: Reactor {
     enum Mutation {
         case updateDataSource([String])
         case updateSelectedItem(Int)
+        case updateLoadingState(Bool)
     }
 
     struct State {
         var dataSource: [String]
         var selectedIndex: Int
+        var isLoading: Bool
     }
 
     var initialState: State
@@ -23,7 +25,8 @@ final class DefaultPlaylistImageReactor: Reactor {
     init() {
         initialState = State(
             dataSource: [],
-            selectedIndex: 0
+            selectedIndex: 0,
+            isLoading: false
         )
     }
 
@@ -45,6 +48,8 @@ final class DefaultPlaylistImageReactor: Reactor {
             newState.dataSource = dataSource
         case let .updateSelectedItem(id):
             newState.selectedIndex = id
+        case let .updateLoadingState(flag):
+            newState.isLoading = flag
         }
 
         return newState
@@ -59,6 +64,10 @@ extension DefaultPlaylistImageReactor {
             dataSource.append("theme_\(i)")
         }
 
-        return .just(.updateDataSource(dataSource))
+        return .concat([
+            .just(.updateLoadingState(true)),
+            .just(.updateDataSource(dataSource)),
+            .just(.updateLoadingState(false))
+        ])
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/DefaultPlaylistImageReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/DefaultPlaylistImageReactor.swift
@@ -5,21 +5,26 @@ import ReactorKit
 final class DefaultPlaylistImageReactor: Reactor {
     enum Action {
         case viewDidload
+        case select(String)
     }
 
     enum Mutation {
         case updateDataSource([String])
+        case updateSelectedItem(String)
+        
     }
 
     struct State {
         var dataSource: [String]
+        var selectedItem: String
     }
 
     var initialState: State
 
     init() {
         initialState = State(
-            dataSource: []
+            dataSource: [],
+            selectedItem: ""
         )
     }
 
@@ -27,6 +32,9 @@ final class DefaultPlaylistImageReactor: Reactor {
         switch action {
         case .viewDidload:
             return updateDataSource()
+        
+        case let .select(id):
+            return .just(.updateSelectedItem(id))
         }
     }
 
@@ -36,6 +44,8 @@ final class DefaultPlaylistImageReactor: Reactor {
         switch mutation {
         case let .updateDataSource(dataSource):
             newState.dataSource = dataSource
+        case let .updateSelectedItem(id):
+            newState.selectedItem = id
         }
 
         return newState
@@ -46,7 +56,7 @@ extension DefaultPlaylistImageReactor {
     func updateDataSource() -> Observable<Mutation> {
         var dataSource: [String] = []
 
-        for i in 0 ... 10 {
+        for i in 0 ... 100 {
             dataSource.append("theme_\(i)")
         }
 

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/DefaultPlaylistImageReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/DefaultPlaylistImageReactor.swift
@@ -1,0 +1,69 @@
+import Foundation
+import ReactorKit
+import DesignSystem
+
+
+final class DefaultPlaylistImageReactor: Reactor {
+    
+    enum Action {
+        case viewDidload
+    }
+    
+    enum Mutation {
+        
+        case updateDataSource([String])
+        
+    }
+    
+    struct State {
+        var dataSource: [String]
+    }
+    
+    var initialState: State
+    
+    init() {
+        initialState = State(
+        dataSource: []
+        )
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        
+        switch action {
+            case .viewDidload:
+                return updateDataSource()
+        }
+        
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        
+        var newState = state
+        
+        switch mutation {
+            
+        case let .updateDataSource(dataSource):
+            newState.dataSource = dataSource
+            
+        }
+     
+        return newState
+    }
+    
+}
+
+extension DefaultPlaylistImageReactor {
+    func updateDataSource() -> Observable<Mutation> {
+        
+        var dataSource: [String] = []
+        
+        
+        for i in 0...10 {
+            dataSource.append("theme_\(i)")
+        }
+        
+        
+        return .just(.updateDataSource(dataSource))
+        
+    }
+}

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
@@ -70,8 +70,6 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
         self.view.backgroundColor = .white
         reactor?.action.onNext(.viewDidload)
 
-        #warning("리엑터로 액션 보내줘야함")
-        // 미리 최초 선택하는 이벤트 여기 맞을지..
         collectionView.selectItem(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .top)
     }
 
@@ -128,6 +126,8 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
     override func bindAction(reactor: DefaultPlaylistImageReactor) {
         super.bindAction(reactor: reactor)
 
+        let sharedState = reactor.state.share()
+        
         dismissButton.rx
             .tap
             .bind(with: self) { owner, _ in
@@ -137,8 +137,18 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
 
         confirmButton.rx
             .tap
-            .bind(with: self) { owner, _ in
-                #warning("추후 델리기에트로 dismiss 후 전달")
+            .withLatestFrom(sharedState.map(\.dataSource))
+            .withLatestFrom(sharedState.map(\.selectedIndex)){($0,$1)}
+            .bind(with: self) { owner, info in
+               
+                let (dataSource, index) = (info.0, info.1)
+                
+                let (name, url) = ("임시 명",  dataSource[index])
+                
+                owner.dismiss(animated: true) {
+                    owner.delegate?.receive(name, url)
+                }
+                
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
@@ -3,10 +3,13 @@ import DesignSystem
 import SnapKit
 import Then
 import UIKit
+import PlaylistFeatureInterface
 
-#warning("델리게이트 만들기")
 
 final class DefaultPlaylistImageViewController: BaseReactorViewController<DefaultPlaylistImageReactor> {
+    
+    weak var delegate: (DefaultPlaylistImageDelegate)?
+    
     private var wmNavigationbarView: WMNavigationBarView = WMNavigationBarView().then {
         $0.setTitle("이미지 선택")
     }
@@ -53,6 +56,11 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
             item: itemIdentifier
         )
         return cell
+    }
+    
+    init(delegate: DefaultPlaylistImageDelegate? = nil, reactor: DefaultPlaylistImageReactor) {
+        self.delegate = delegate
+        super.init(reactor: reactor)
     }
 
 
@@ -155,7 +163,7 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
         sharedState.map(\.isLoading)
             .distinctUntilChanged()
             .bind(with: self) { owner, flag in
-                flag == true ? owner.indicator.stopAnimating() : owner.indicator.stopAnimating()
+                 flag == true ? owner.indicator.stopAnimating() : owner.indicator.stopAnimating()
             }
             .disposed(by: disposeBag)
 

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
@@ -151,6 +151,13 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
                 owner.thumbnailDiffableDataSource.apply(snapShot)
             }
             .disposed(by: disposeBag)
+        
+        sharedState.map(\.isLoading)
+            .distinctUntilChanged()
+            .bind(with: self) { owner, flag in
+                flag == true ? owner.indicator.stopAnimating() : owner.indicator.stopAnimating()
+            }
+            .disposed(by: disposeBag)
 
         sharedState.map(\.selectedIndex)
             .distinctUntilChanged()

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
@@ -199,19 +199,20 @@ extension DefaultPlaylistImageViewController {
 
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
+            
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(76.0)
+                heightDimension: .fractionalWidth(0.25)
             )
 
             var group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 4)
+        
             group.interItemSpacing = .fixed(10)
 
             let section = NSCollectionLayoutSection(group: group)
-            section.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 20, bottom: .zero, trailing: 20)
+            section.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 20, bottom: 20, trailing: 20)
 
-            section.interGroupSpacing = 10.0
-
+            
             return section
         }
         return layout

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
@@ -6,7 +6,6 @@ import UIKit
 
 #warning("델리게이트 만들기")
 
-
 final class DefaultPlaylistImageViewController: BaseReactorViewController<DefaultPlaylistImageReactor> {
     private var wmNavigationbarView: WMNavigationBarView = WMNavigationBarView().then {
         $0.setTitle("이미지 선택")
@@ -54,12 +53,11 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
         super.viewDidLoad()
         self.view.backgroundColor = .white
         reactor?.action.onNext(.viewDidload)
-        
+
         #warning("그림자 넣기")
         #warning("리엑터로 액션 보내줘야함")
         // 미리 최초 선택하는 이벤트 여기 맞을지..
         collectionView.selectItem(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .top)
-        
     }
 
     override func addView() {
@@ -96,10 +94,10 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
         }
     }
-    
+
     override func bind(reactor: DefaultPlaylistImageReactor) {
         super.bind(reactor: reactor)
-        
+
         collectionView.rx
             .setDelegate(self)
             .disposed(by: disposeBag)
@@ -129,8 +127,7 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
         sharedState.map(\.dataSource)
             .distinctUntilChanged()
             .bind(with: self) { owner, dataSource in
-                                
-                
+
                 var snapShot = NSDiffableDataSourceSnapshot<Int, String>()
 
                 snapShot.appendSections([0])
@@ -138,17 +135,14 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
                 snapShot.appendItems(dataSource)
 
                 owner.thumbnailDiffableDataSource.apply(snapShot)
-                
             }
             .disposed(by: disposeBag)
-        
-        
+
         sharedState.map(\.selectedItem)
             .distinctUntilChanged()
             .bind(with: self) { owner, item in
-                                
+
                 print("Item: \(item)")
-                
             }
             .disposed(by: disposeBag)
     }
@@ -191,15 +185,12 @@ extension DefaultPlaylistImageViewController {
     }
 }
 
-
-extension DefaultPlaylistImageViewController : UICollectionViewDelegate {
+extension DefaultPlaylistImageViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-     
         guard let itemIdentifier = thumbnailDiffableDataSource.itemIdentifier(for: indexPath) else {
             return
         }
-        
+
         reactor?.action.onNext(.select(itemIdentifier))
-        
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
@@ -199,20 +199,18 @@ extension DefaultPlaylistImageViewController {
 
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
-            
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
                 heightDimension: .fractionalWidth(0.25)
             )
 
             var group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 4)
-        
+
             group.interItemSpacing = .fixed(10)
 
             let section = NSCollectionLayoutSection(group: group)
             section.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 20, bottom: 20, trailing: 20)
 
-            
             return section
         }
         return layout

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
@@ -1,15 +1,13 @@
 import BaseFeature
 import DesignSystem
+import PlaylistFeatureInterface
 import SnapKit
 import Then
 import UIKit
-import PlaylistFeatureInterface
-
 
 final class DefaultPlaylistImageViewController: BaseReactorViewController<DefaultPlaylistImageReactor> {
-    
-    weak var delegate: (DefaultPlaylistImageDelegate)?
-    
+    weak var delegate: DefaultPlaylistImageDelegate?
+
     private var wmNavigationbarView: WMNavigationBarView = WMNavigationBarView().then {
         $0.setTitle("이미지 선택")
     }
@@ -19,17 +17,16 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
             .withTintColor(DesignSystemAsset.BlueGrayColor.blueGray900.color, renderingMode: .alwaysOriginal)
         $0.setImage(dismissImage, for: .normal)
     }
-    
+
     private let shadowImageVIew: UIImageView = UIImageView().then {
         $0.contentMode = .scaleToFill
         $0.image = DesignSystemAsset.LyricHighlighting.lyricDecoratingBottomShadow.image
-        
     }
 
     private let buttonContainerView: UIView = UIView().then {
         $0.backgroundColor = .white
     }
-    
+
     private let confirmButton: UIButton = UIButton().then {
         $0.setTitle("확인", for: .normal)
         $0.setTitleColor(.white, for: .normal)
@@ -57,13 +54,11 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
         )
         return cell
     }
-    
+
     init(delegate: DefaultPlaylistImageDelegate? = nil, reactor: DefaultPlaylistImageReactor) {
         self.delegate = delegate
         super.init(reactor: reactor)
     }
-
-
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -79,7 +74,7 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
         self.view.addSubviews(wmNavigationbarView, collectionView, buttonContainerView)
         wmNavigationbarView.setLeftViews([dismissButton])
 
-        buttonContainerView.addSubviews(shadowImageVIew,confirmButton)
+        buttonContainerView.addSubviews(shadowImageVIew, confirmButton)
     }
 
     override func setLayout() {
@@ -100,7 +95,7 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
             $0.top.equalTo(collectionView.snp.bottom)
             $0.bottom.leading.trailing.equalToSuperview()
         }
-        
+
         shadowImageVIew.snp.makeConstraints {
             $0.top.equalToSuperview().offset(-14)
             $0.leading.trailing.equalToSuperview()
@@ -127,7 +122,7 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
         super.bindAction(reactor: reactor)
 
         let sharedState = reactor.state.share()
-        
+
         dismissButton.rx
             .tap
             .bind(with: self) { owner, _ in
@@ -138,17 +133,16 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
         confirmButton.rx
             .tap
             .withLatestFrom(sharedState.map(\.dataSource))
-            .withLatestFrom(sharedState.map(\.selectedIndex)){($0,$1)}
+            .withLatestFrom(sharedState.map(\.selectedIndex)) { ($0, $1) }
             .bind(with: self) { owner, info in
-               
+
                 let (dataSource, index) = (info.0, info.1)
-                
-                let (name, url) = ("임시 명",  dataSource[index])
-                
+
+                let (name, url) = ("임시 명", dataSource[index])
+
                 owner.dismiss(animated: true) {
                     owner.delegate?.receive(name, url)
                 }
-                
             }
             .disposed(by: disposeBag)
     }
@@ -169,11 +163,11 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
                 owner.thumbnailDiffableDataSource.apply(snapShot)
             }
             .disposed(by: disposeBag)
-        
+
         sharedState.map(\.isLoading)
             .distinctUntilChanged()
             .bind(with: self) { owner, flag in
-                 flag == true ? owner.indicator.stopAnimating() : owner.indicator.stopAnimating()
+                flag == true ? owner.indicator.stopAnimating() : owner.indicator.stopAnimating()
             }
             .disposed(by: disposeBag)
 
@@ -226,7 +220,6 @@ extension DefaultPlaylistImageViewController {
 
 extension DefaultPlaylistImageViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-
         reactor?.action.onNext(.selectedIndex(indexPath.row))
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
@@ -16,9 +16,24 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
             .withTintColor(DesignSystemAsset.BlueGrayColor.blueGray900.color, renderingMode: .alwaysOriginal)
         $0.setImage(dismissImage, for: .normal)
     }
+    
+    private let shadowImageVIew: UIImageView = UIImageView().then {
+        $0.contentMode = .scaleToFill
+        $0.image = DesignSystemAsset.LyricHighlighting.lyricDecoratingBottomShadow.image
+        
+    }
 
     private let buttonContainerView: UIView = UIView().then {
         $0.backgroundColor = .white
+    }
+    
+    private let confirmButton: UIButton = UIButton().then {
+        $0.setTitle("확인", for: .normal)
+        $0.setTitleColor(.white, for: .normal)
+        $0.titleLabel?.font = .setFont(.t4(weight: .medium))
+        $0.layer.cornerRadius = 12
+        $0.clipsToBounds = true
+        $0.backgroundColor = DesignSystemAsset.PrimaryColorV2.point.color
     }
 
     private lazy var collectionView: UICollectionView = createCollectionView()
@@ -40,21 +55,13 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
         return cell
     }
 
-    private let confirmButton: UIButton = UIButton().then {
-        $0.setTitle("확인", for: .normal)
-        $0.setTitleColor(.white, for: .normal)
-        $0.titleLabel?.font = .setFont(.t4(weight: .medium))
-        $0.layer.cornerRadius = 12
-        $0.clipsToBounds = true
-        $0.backgroundColor = DesignSystemAsset.PrimaryColorV2.point.color
-    }
+
 
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = .white
         reactor?.action.onNext(.viewDidload)
 
-        #warning("그림자 넣기")
         #warning("리엑터로 액션 보내줘야함")
         // 미리 최초 선택하는 이벤트 여기 맞을지..
         collectionView.selectItem(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .top)
@@ -66,7 +73,7 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
         self.view.addSubviews(wmNavigationbarView, collectionView, buttonContainerView)
         wmNavigationbarView.setLeftViews([dismissButton])
 
-        buttonContainerView.addSubviews(confirmButton)
+        buttonContainerView.addSubviews(shadowImageVIew,confirmButton)
     }
 
     override func setLayout() {
@@ -87,8 +94,15 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
             $0.top.equalTo(collectionView.snp.bottom)
             $0.bottom.leading.trailing.equalToSuperview()
         }
+        
+        shadowImageVIew.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(-14)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(view.snp.bottom)
+        }
 
         confirmButton.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(20)
             $0.top.horizontalEdges.equalToSuperview().inset(20)
             $0.height.equalTo(56)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
@@ -138,11 +152,11 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
             }
             .disposed(by: disposeBag)
 
-        sharedState.map(\.selectedItem)
+        sharedState.map(\.selectedIndex)
             .distinctUntilChanged()
-            .bind(with: self) { owner, item in
+            .bind(with: self) { owner, index in
 
-                print("Item: \(item)")
+                print("Item: \(index)")
             }
             .disposed(by: disposeBag)
     }
@@ -187,10 +201,7 @@ extension DefaultPlaylistImageViewController {
 
 extension DefaultPlaylistImageViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let itemIdentifier = thumbnailDiffableDataSource.itemIdentifier(for: indexPath) else {
-            return
-        }
 
-        reactor?.action.onNext(.select(itemIdentifier))
+        reactor?.action.onNext(.selectedIndex(indexPath.row))
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
@@ -1,29 +1,26 @@
-import UIKit
-import Then
-import SnapKit
 import BaseFeature
 import DesignSystem
+import SnapKit
+import Then
+import UIKit
 
 final class DefaultPlaylistImageViewController: BaseReactorViewController<DefaultPlaylistImageReactor> {
-    
     private var wmNavigationbarView: WMNavigationBarView = WMNavigationBarView().then {
         $0.setTitle("이미지 선택")
     }
-    
+
     private let dismissButton = UIButton().then {
         let dismissImage = DesignSystemAsset.MusicDetail.dismiss.image
             .withTintColor(DesignSystemAsset.BlueGrayColor.blueGray900.color, renderingMode: .alwaysOriginal)
         $0.setImage(dismissImage, for: .normal)
     }
-    
+
     private let buttonContainerView: UIView = UIView().then {
         $0.backgroundColor = .white
     }
-    
-    private lazy var collectionView: UICollectionView = createCollectionView()
-    
 
-    
+    private lazy var collectionView: UICollectionView = createCollectionView()
+
     private let thumbnailCellRegistration = UICollectionView.CellRegistration<
         DefaultThumbnailCell, String
     > { cell, _, itemIdentifier in
@@ -40,7 +37,7 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
         )
         return cell
     }
-    
+
     private let confirmButton: UIButton = UIButton().then {
         $0.setTitle("확인", for: .normal)
         $0.setTitleColor(.white, for: .normal)
@@ -49,127 +46,117 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
         $0.clipsToBounds = true
         $0.backgroundColor = DesignSystemAsset.PrimaryColorV2.point.color
     }
-    
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = .white
         reactor?.action.onNext(.viewDidload)
-        
     }
- 
+
     override func addView() {
         super.addView()
-        
-        self.view.addSubviews(wmNavigationbarView, collectionView ,buttonContainerView)
+
+        self.view.addSubviews(wmNavigationbarView, collectionView, buttonContainerView)
         wmNavigationbarView.setLeftViews([dismissButton])
-        
+
         buttonContainerView.addSubviews(confirmButton)
     }
-    
+
     override func setLayout() {
         super.setLayout()
-        
+
         wmNavigationbarView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(48)
         }
-        
+
         collectionView.snp.makeConstraints {
             $0.top.equalTo(wmNavigationbarView.snp.bottom)
             $0.leading.trailing.equalToSuperview()
         }
-        
-        
-        buttonContainerView.snp.makeConstraints  {
+
+        buttonContainerView.snp.makeConstraints {
             $0.top.equalTo(collectionView.snp.bottom)
             $0.bottom.leading.trailing.equalToSuperview()
         }
-        
+
         confirmButton.snp.makeConstraints {
             $0.top.horizontalEdges.equalToSuperview().inset(20)
             $0.height.equalTo(56)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
         }
     }
-    
+
     override func bindAction(reactor: DefaultPlaylistImageReactor) {
         super.bindAction(reactor: reactor)
-        
+
         dismissButton.rx
             .tap
             .bind(with: self) { owner, _ in
                 owner.dismiss(animated: true)
             }
             .disposed(by: disposeBag)
-        
-        
+
         confirmButton.rx
             .tap
             .bind(with: self) { owner, _ in
                 #warning("추후 델리기에트로 dismiss 후 전달")
             }
             .disposed(by: disposeBag)
-        
     }
-    
+
     override func bindState(reactor: DefaultPlaylistImageReactor) {
-        
         let sharedState = reactor.state.share()
-        
+
         sharedState.map(\.dataSource)
-            .bind(with:self) { owner, dataSource in
-                
+            .bind(with: self) { owner, dataSource in
+
                 var snapShot = NSDiffableDataSourceSnapshot<Int, String>()
-                
+
                 snapShot.appendSections([0])
-                
+
                 snapShot.appendItems(dataSource)
-                
+
                 owner.thumbnailDiffableDataSource.apply(snapShot)
-                
             }
             .disposed(by: disposeBag)
-        
-        
     }
-    
-    
 }
 
 extension DefaultPlaylistImageViewController {
-    
     private func createCollectionView() -> UICollectionView {
         return UICollectionView(frame: .zero, collectionViewLayout: createLayout())
     }
-    
-    private func createLayout() -> UICollectionViewLayout {
-        let layout = UICollectionViewCompositionalLayout { (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
 
-            
-            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.25), heightDimension: .fractionalWidth(0.25))
-                                                      
+    private func createLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewCompositionalLayout { (
+            sectionIndex: Int,
+            layoutEnvironment: NSCollectionLayoutEnvironment
+        ) -> NSCollectionLayoutSection? in
+
+            let itemSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(0.25),
+                heightDimension: .fractionalWidth(0.25)
+            )
+
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
-            
-            
-            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                                   heightDimension: .absolute(76.0))
-            
-            
-            var group =   NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 4)
-            group.interItemSpacing  = .fixed(10)
-           
-            
+
+            let groupSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .absolute(76.0)
+            )
+
+            var group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 4)
+            group.interItemSpacing = .fixed(10)
+
             let section = NSCollectionLayoutSection(group: group)
             section.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 20, bottom: .zero, trailing: 20)
-            
+
             section.interGroupSpacing = 10.0
-            
-            
+
             return section
         }
         return layout
     }
-    
 }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
@@ -1,0 +1,175 @@
+import UIKit
+import Then
+import SnapKit
+import BaseFeature
+import DesignSystem
+
+final class DefaultPlaylistImageViewController: BaseReactorViewController<DefaultPlaylistImageReactor> {
+    
+    private var wmNavigationbarView: WMNavigationBarView = WMNavigationBarView().then {
+        $0.setTitle("이미지 선택")
+    }
+    
+    private let dismissButton = UIButton().then {
+        let dismissImage = DesignSystemAsset.MusicDetail.dismiss.image
+            .withTintColor(DesignSystemAsset.BlueGrayColor.blueGray900.color, renderingMode: .alwaysOriginal)
+        $0.setImage(dismissImage, for: .normal)
+    }
+    
+    private let buttonContainerView: UIView = UIView().then {
+        $0.backgroundColor = .white
+    }
+    
+    private lazy var collectionView: UICollectionView = createCollectionView()
+    
+
+    
+    private let thumbnailCellRegistration = UICollectionView.CellRegistration<
+        DefaultThumbnailCell, String
+    > { cell, _, itemIdentifier in
+        cell.configure(itemIdentifier)
+    }
+
+    private lazy var thumbnailDiffableDataSource = UICollectionViewDiffableDataSource<Int, String>(
+        collectionView: collectionView
+    ) { [thumbnailCellRegistration] collectionView, indexPath, itemIdentifier in
+        let cell = collectionView.dequeueConfiguredReusableCell(
+            using: thumbnailCellRegistration,
+            for: indexPath,
+            item: itemIdentifier
+        )
+        return cell
+    }
+    
+    private let confirmButton: UIButton = UIButton().then {
+        $0.setTitle("확인", for: .normal)
+        $0.setTitleColor(.white, for: .normal)
+        $0.titleLabel?.font = .setFont(.t4(weight: .medium))
+        $0.layer.cornerRadius = 12
+        $0.clipsToBounds = true
+        $0.backgroundColor = DesignSystemAsset.PrimaryColorV2.point.color
+    }
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .white
+        reactor?.action.onNext(.viewDidload)
+        
+    }
+ 
+    override func addView() {
+        super.addView()
+        
+        self.view.addSubviews(wmNavigationbarView, collectionView ,buttonContainerView)
+        wmNavigationbarView.setLeftViews([dismissButton])
+        
+        buttonContainerView.addSubviews(confirmButton)
+    }
+    
+    override func setLayout() {
+        super.setLayout()
+        
+        wmNavigationbarView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(48)
+        }
+        
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(wmNavigationbarView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        
+        buttonContainerView.snp.makeConstraints  {
+            $0.top.equalTo(collectionView.snp.bottom)
+            $0.bottom.leading.trailing.equalToSuperview()
+        }
+        
+        confirmButton.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview().inset(20)
+            $0.height.equalTo(56)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
+        }
+    }
+    
+    override func bindAction(reactor: DefaultPlaylistImageReactor) {
+        super.bindAction(reactor: reactor)
+        
+        dismissButton.rx
+            .tap
+            .bind(with: self) { owner, _ in
+                owner.dismiss(animated: true)
+            }
+            .disposed(by: disposeBag)
+        
+        
+        confirmButton.rx
+            .tap
+            .bind(with: self) { owner, _ in
+                #warning("추후 델리기에트로 dismiss 후 전달")
+            }
+            .disposed(by: disposeBag)
+        
+    }
+    
+    override func bindState(reactor: DefaultPlaylistImageReactor) {
+        
+        let sharedState = reactor.state.share()
+        
+        sharedState.map(\.dataSource)
+            .bind(with:self) { owner, dataSource in
+                
+                var snapShot = NSDiffableDataSourceSnapshot<Int, String>()
+                
+                snapShot.appendSections([0])
+                
+                snapShot.appendItems(dataSource)
+                
+                owner.thumbnailDiffableDataSource.apply(snapShot)
+                
+            }
+            .disposed(by: disposeBag)
+        
+        
+    }
+    
+    
+}
+
+extension DefaultPlaylistImageViewController {
+    
+    private func createCollectionView() -> UICollectionView {
+        return UICollectionView(frame: .zero, collectionViewLayout: createLayout())
+    }
+    
+    private func createLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewCompositionalLayout { (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
+
+            
+            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.25), heightDimension: .fractionalWidth(0.25))
+                                                      
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+            
+            
+            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                                   heightDimension: .absolute(76.0))
+            
+            
+            var group =   NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 4)
+            group.interItemSpacing  = .fixed(10)
+           
+            
+            let section = NSCollectionLayoutSection(group: group)
+            section.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 20, bottom: .zero, trailing: 20)
+            
+            section.interGroupSpacing = 10.0
+            
+            
+            return section
+        }
+        return layout
+    }
+    
+}

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -32,6 +32,8 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
     private let thumbnailPopupFactory: any ThumbnailPopupFactory
 
     private let checkThumbnailFactory: any CheckThumbnailFactory
+    
+    private let defaultPlaylistImageFactory: any DefaultPlaylistImageFactory
 
     private var wmNavigationbarView: WMNavigationBarView = WMNavigationBarView()
 
@@ -81,13 +83,15 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
         containSongsFactory: any ContainSongsFactory,
         textPopUpFactory: any TextPopUpFactory,
         thumbnailPopupFactory: any ThumbnailPopupFactory,
-        checkThumbnailFactory: any CheckThumbnailFactory
+        checkThumbnailFactory: any CheckThumbnailFactory,
+        defaultPlaylistImageFactory: any DefaultPlaylistImageFactory
     ) {
         self.multiPurposePopupFactory = multiPurposePopupFactory
         self.containSongsFactory = containSongsFactory
         self.textPopUpFactory = textPopUpFactory
         self.thumbnailPopupFactory = thumbnailPopupFactory
         self.checkThumbnailFactory = checkThumbnailFactory
+        self.defaultPlaylistImageFactory = defaultPlaylistImageFactory
 
         super.init(reactor: reactor)
     }
@@ -583,7 +587,11 @@ extension MyPlaylistDetailViewController: ThumbnailPopupDelegate {
     func didTap(_ index: Int, _ cost: Int) {
         if index == 0 {
             LogManager.analytics(PlaylistAnalyticsLog.clickPlaylistDefaultImageButton)
-            #warning("기본이미지 선택 옵션")
+            let vc =  defaultPlaylistImageFactory.makeView(self)
+            vc.modalPresentationStyle = .overFullScreen
+            
+            self.present(vc, animated: true)
+            
 
         } else {
             LogManager.analytics(
@@ -596,6 +604,13 @@ extension MyPlaylistDetailViewController: ThumbnailPopupDelegate {
 
 extension MyPlaylistDetailViewController: CheckThumbnailDelegate {
     func receive(_ imageData: Data) {
-        headerView.updateThumbnail(imageData)
+        headerView.updateThumbnailByAlbum(imageData)
     }
+}
+
+extension MyPlaylistDetailViewController: DefaultPlaylistImageDelegate {
+    func receive(_ name: String, _ url: String) {
+        headerView.updateThumbnailByDefault(url)
+    }
+    
 }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -32,7 +32,7 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
     private let thumbnailPopupFactory: any ThumbnailPopupFactory
 
     private let checkThumbnailFactory: any CheckThumbnailFactory
-    
+
     private let defaultPlaylistImageFactory: any DefaultPlaylistImageFactory
 
     private var wmNavigationbarView: WMNavigationBarView = WMNavigationBarView()
@@ -587,11 +587,10 @@ extension MyPlaylistDetailViewController: ThumbnailPopupDelegate {
     func didTap(_ index: Int, _ cost: Int) {
         if index == 0 {
             LogManager.analytics(PlaylistAnalyticsLog.clickPlaylistDefaultImageButton)
-            let vc =  defaultPlaylistImageFactory.makeView(self)
+            let vc = defaultPlaylistImageFactory.makeView(self)
             vc.modalPresentationStyle = .overFullScreen
-            
+
             self.present(vc, animated: true)
-            
 
         } else {
             LogManager.analytics(
@@ -612,5 +611,4 @@ extension MyPlaylistDetailViewController: DefaultPlaylistImageDelegate {
     func receive(_ name: String, _ url: String) {
         headerView.updateThumbnailByDefault(url)
     }
-    
 }

--- a/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
@@ -1,0 +1,58 @@
+import UIKit
+import DesignSystem
+import SnapKit
+import Then
+import Kingfisher
+
+final class DefaultThumbnailCell: UICollectionViewCell {
+
+    
+    override var isSelected: Bool {
+        
+        willSet(newValue) {
+            
+            
+        }
+        
+    }
+    
+    
+    private let imageView: UIImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.layer.cornerRadius = 6
+        $0.clipsToBounds = true
+        $0.layer.borderColor = UIColor.red.cgColor
+        $0.layer.borderWidth = 2
+    }
+
+    
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        addViews()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+extension DefaultThumbnailCell {
+    
+    private func addViews() {
+        self.contentView.addSubview(imageView)
+    }
+    
+    private func setLayout() {
+        imageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    public func configure(_ image: String) {
+        imageView.image = UIImage(named: image)
+    }
+    
+}

--- a/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
@@ -6,15 +6,18 @@ import UIKit
 
 final class DefaultThumbnailCell: UICollectionViewCell {
     override var isSelected: Bool {
-        willSet(newValue) {}
+        willSet(newValue) {
+            
+            imageView.layer.borderWidth = newValue ? 2 : 0
+            
+        }
     }
 
     private let imageView: UIImageView = UIImageView().then {
         $0.contentMode = .scaleAspectFill
         $0.layer.cornerRadius = 6
         $0.clipsToBounds = true
-        $0.layer.borderColor = UIColor.red.cgColor
-        $0.layer.borderWidth = 2
+        $0.layer.borderColor =  DesignSystemAsset.PrimaryColorV2.point.color.cgColor
     }
 
     override init(frame: CGRect) {
@@ -41,6 +44,10 @@ extension DefaultThumbnailCell {
     }
 
     public func configure(_ image: String) {
-        imageView.image = UIImage(named: image)
+       
+        let image = DesignSystemAsset.PlayListTheme.theme0.image
+        
+        
+        imageView.image = image
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
@@ -1,22 +1,14 @@
-import UIKit
 import DesignSystem
+import Kingfisher
 import SnapKit
 import Then
-import Kingfisher
+import UIKit
 
 final class DefaultThumbnailCell: UICollectionViewCell {
-
-    
     override var isSelected: Bool {
-        
-        willSet(newValue) {
-            
-            
-        }
-        
+        willSet(newValue) {}
     }
-    
-    
+
     private let imageView: UIImageView = UIImageView().then {
         $0.contentMode = .scaleAspectFill
         $0.layer.cornerRadius = 6
@@ -25,34 +17,30 @@ final class DefaultThumbnailCell: UICollectionViewCell {
         $0.layer.borderWidth = 2
     }
 
-    
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         addViews()
         setLayout()
     }
-    
+
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
 }
 
 extension DefaultThumbnailCell {
-    
     private func addViews() {
         self.contentView.addSubview(imageView)
     }
-    
+
     private func setLayout() {
         imageView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
     }
-    
+
     public func configure(_ image: String) {
         imageView.image = UIImage(named: image)
     }
-    
 }

--- a/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
@@ -7,9 +7,7 @@ import UIKit
 final class DefaultThumbnailCell: UICollectionViewCell {
     override var isSelected: Bool {
         willSet(newValue) {
-            
             imageView.layer.borderWidth = newValue ? 2 : 0
-            
         }
     }
 
@@ -17,7 +15,7 @@ final class DefaultThumbnailCell: UICollectionViewCell {
         $0.contentMode = .scaleAspectFill
         $0.layer.cornerRadius = 6
         $0.clipsToBounds = true
-        $0.layer.borderColor =  DesignSystemAsset.PrimaryColorV2.point.color.cgColor
+        $0.layer.borderColor = DesignSystemAsset.PrimaryColorV2.point.color.cgColor
     }
 
     override init(frame: CGRect) {
@@ -44,10 +42,8 @@ extension DefaultThumbnailCell {
     }
 
     public func configure(_ image: String) {
-       
         let image = DesignSystemAsset.PlayListTheme.theme0.image
-        
-        
+
         imageView.image = image
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Views/MyPlaylistHeaderView.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/MyPlaylistHeaderView.swift
@@ -147,7 +147,7 @@ extension MyPlaylistHeaderView: MyPlaylistHeaderStateProtocol {
     func updateThumbnailByAlbum(_ data: Data) {
         thumbnailImageView.image = UIImage(data: data)
     }
-    
+
     func updateThumbnailByDefault(_ url: String) {
         thumbnailImageView.kf.setImage(with: URL(string: url))
     }

--- a/Projects/Features/PlaylistFeature/Sources/Views/MyPlaylistHeaderView.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/MyPlaylistHeaderView.swift
@@ -9,7 +9,8 @@ import UIKit
 private protocol MyPlaylistHeaderStateProtocol {
     func updateEditState(_ isEditing: Bool)
     func updateData(_ model: PlaylistDetailHeaderModel)
-    func updateThumbnail(_ data: Data)
+    func updateThumbnailByAlbum(_ data: Data)
+    func updateThumbnailByDefault(_ url: String)
 }
 
 private protocol MyPlaylistHeaderActionProtocol {
@@ -143,8 +144,12 @@ extension MyPlaylistHeaderView: MyPlaylistHeaderStateProtocol {
         cameraContainerView.isHidden = !isEditing
     }
 
-    func updateThumbnail(_ data: Data) {
+    func updateThumbnailByAlbum(_ data: Data) {
         thumbnailImageView.image = UIImage(data: data)
+    }
+    
+    func updateThumbnailByDefault(_ url: String) {
+        thumbnailImageView.kf.setImage(with: URL(string: url))
     }
 }
 

--- a/Projects/Features/PlaylistFeature/Sources/Views/MyPlaylistHeaderView.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/MyPlaylistHeaderView.swift
@@ -11,6 +11,8 @@ private protocol MyPlaylistHeaderStateProtocol {
     func updateData(_ model: PlaylistDetailHeaderModel)
     func updateThumbnailByAlbum(_ data: Data)
     func updateThumbnailByDefault(_ url: String)
+    
+#warning("api 구현 후 함수명을 좀 더 명확하게 변경하기")
 }
 
 private protocol MyPlaylistHeaderActionProtocol {

--- a/Projects/Features/PlaylistFeature/Sources/Views/MyPlaylistHeaderView.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/MyPlaylistHeaderView.swift
@@ -11,8 +11,8 @@ private protocol MyPlaylistHeaderStateProtocol {
     func updateData(_ model: PlaylistDetailHeaderModel)
     func updateThumbnailByAlbum(_ data: Data)
     func updateThumbnailByDefault(_ url: String)
-    
-#warning("api 구현 후 함수명을 좀 더 명확하게 변경하기")
+
+    #warning("api 구현 후 함수명을 좀 더 명확하게 변경하기")
 }
 
 private protocol MyPlaylistHeaderActionProtocol {


### PR DESCRIPTION
## 💡 배경 및 개요

플레이리스트 썸네일 중 왁뮤에서 제공해주는 이미지를 선택해주는 팝업을 구현 합니다.

https://github.com/wakmusic/wakmusic-iOS/assets/48616183/a4c8b54a-5309-4754-b067-0a362642d92b




Resolves: #735

## 📃 작업내용

- 디폴트 이미지를 고를 수 있는 팝업 화면을 구현했습니다.
- 클릭 이벤트를 통해 선택 이미지를 트래킹 합니다.
- 확인 후 창이 닫히며 델리게이트로 선택한 정보를 전다라하고 카메라 딤 화면을 업데이트 합니다.

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
