### PR TITLE
🔀 :: (#742)  플레이리스트 기본 이미지를 불러오는 UseCase를 연결합니다.

### DIFF
--- a/Projects/App/Sources/Application/AppComponent+Playlist.swift
+++ b/Projects/App/Sources/Application/AppComponent+Playlist.swift
@@ -5,6 +5,8 @@ import PlaylistDomainInterface
 import PlaylistFeature
 import PlaylistFeatureInterface
 import StorageFeature
+import ImageDomainInterface
+import ImageDomain
 
 // MARK: 변수명 주의
 // AppComponent 내 변수 == Dependency 내 변수  이름 같아야함
@@ -121,6 +123,12 @@ public extension AppComponent {
     var checkSubscriptionUseCase: any CheckSubscriptionUseCase {
         shared {
             CheckSubscriptionUseCaseImpl(playlistRepository: playlistRepository)
+        }
+    }
+    
+    var fetchDefaultPlaylistImageUseCase: any FetchDefaultPlaylistImageUseCase {
+        shared {
+           FetchDefaultPlaylistImageUseCaseImpl(imageRepository: imageRepository)
         }
     }
 }

--- a/Projects/App/Sources/Application/AppComponent+Playlist.swift
+++ b/Projects/App/Sources/Application/AppComponent+Playlist.swift
@@ -1,12 +1,12 @@
 import BaseFeature
 import BaseFeatureInterface
+import ImageDomain
+import ImageDomainInterface
 import PlaylistDomain
 import PlaylistDomainInterface
 import PlaylistFeature
 import PlaylistFeatureInterface
 import StorageFeature
-import ImageDomainInterface
-import ImageDomain
 
 // MARK: 변수명 주의
 // AppComponent 내 변수 == Dependency 내 변수  이름 같아야함
@@ -125,10 +125,10 @@ public extension AppComponent {
             CheckSubscriptionUseCaseImpl(playlistRepository: playlistRepository)
         }
     }
-    
+
     var fetchDefaultPlaylistImageUseCase: any FetchDefaultPlaylistImageUseCase {
         shared {
-           FetchDefaultPlaylistImageUseCaseImpl(imageRepository: imageRepository)
+            FetchDefaultPlaylistImageUseCaseImpl(imageRepository: imageRepository)
         }
     }
 }

--- a/Projects/Domains/ImageDomain/Interface/DataSource/RemoteImageDataSource.swift
+++ b/Projects/Domains/ImageDomain/Interface/DataSource/RemoteImageDataSource.swift
@@ -4,4 +4,5 @@ import RxSwift
 public protocol RemoteImageDataSource {
     func fetchLyricDecoratingBackground() -> Single<[LyricDecoratingBackgroundEntity]>
     func fetchProfileList() -> Single<[ProfileListEntity]>
+    func fetchDefaultPlaylistImage() -> Single<[DefaultImageEntity]>
 }

--- a/Projects/Domains/ImageDomain/Interface/Entity/DefaultImageEntity.swift
+++ b/Projects/Domains/ImageDomain/Interface/Entity/DefaultImageEntity.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+
+public struct DefaultImageEntity :  Hashable, Equatable {
+    
+    public let name: String
+    public let url: String
+    
+    public init(name: String, url: String) {
+        self.name = name
+        self.url = url
+    }
+    
+}

--- a/Projects/Domains/ImageDomain/Interface/Entity/DefaultImageEntity.swift
+++ b/Projects/Domains/ImageDomain/Interface/Entity/DefaultImageEntity.swift
@@ -1,14 +1,11 @@
 import Foundation
 
-
-public struct DefaultImageEntity :  Hashable, Equatable {
-    
+public struct DefaultImageEntity: Hashable, Equatable {
     public let name: String
     public let url: String
-    
+
     public init(name: String, url: String) {
         self.name = name
         self.url = url
     }
-    
 }

--- a/Projects/Domains/ImageDomain/Interface/Repository/ImageRepository.swift
+++ b/Projects/Domains/ImageDomain/Interface/Repository/ImageRepository.swift
@@ -4,4 +4,5 @@ import RxSwift
 public protocol ImageRepository {
     func fetchLyricDecoratingBackground() -> Single<[LyricDecoratingBackgroundEntity]>
     func fetchProfileList() -> Single<[ProfileListEntity]>
+    func fetchDefaultPlaylistImage() -> Single<[DefaultImageEntity]>
 }

--- a/Projects/Domains/ImageDomain/Interface/UseCase/FetchDefaultPlaylistImageUseCase.swift
+++ b/Projects/Domains/ImageDomain/Interface/UseCase/FetchDefaultPlaylistImageUseCase.swift
@@ -1,0 +1,6 @@
+import Foundation
+import RxSwift
+
+public protocol FetchDefaultPlaylistImageUseCase {
+    func execute() -> Single<[DefaultImageEntity]>
+}

--- a/Projects/Domains/ImageDomain/Sources/API/ImageAPI.swift
+++ b/Projects/Domains/ImageDomain/Sources/API/ImageAPI.swift
@@ -28,14 +28,14 @@ extension ImageAPI: WMAPI {
 
     public var method: Moya.Method {
         switch self {
-        case .fetchLyricDecoratingBackground, .fetchDefaultPlaylistImage , .fetchProfileList:
+        case .fetchLyricDecoratingBackground, .fetchDefaultPlaylistImage, .fetchProfileList:
             return .get
         }
     }
 
     public var task: Moya.Task {
         switch self {
-        case .fetchLyricDecoratingBackground, .fetchProfileList , .fetchDefaultPlaylistImage:
+        case .fetchLyricDecoratingBackground, .fetchProfileList, .fetchDefaultPlaylistImage:
             return .requestPlain
         }
     }

--- a/Projects/Domains/ImageDomain/Sources/API/ImageAPI.swift
+++ b/Projects/Domains/ImageDomain/Sources/API/ImageAPI.swift
@@ -7,6 +7,7 @@ import Moya
 public enum ImageAPI {
     case fetchLyricDecoratingBackground
     case fetchProfileList
+    case fetchDefaultPlaylistImage
 }
 
 extension ImageAPI: WMAPI {
@@ -20,23 +21,21 @@ extension ImageAPI: WMAPI {
             return "/lyrics/backgrounds"
         case .fetchProfileList:
             return "/user/profiles"
+        case .fetchDefaultPlaylistImage:
+            return "/playlists"
         }
     }
 
     public var method: Moya.Method {
         switch self {
-        case .fetchLyricDecoratingBackground:
-            return .get
-        case .fetchProfileList:
+        case .fetchLyricDecoratingBackground, .fetchDefaultPlaylistImage , .fetchProfileList:
             return .get
         }
     }
 
     public var task: Moya.Task {
         switch self {
-        case .fetchLyricDecoratingBackground:
-            return .requestPlain
-        case .fetchProfileList:
+        case .fetchLyricDecoratingBackground, .fetchProfileList , .fetchDefaultPlaylistImage:
             return .requestPlain
         }
     }

--- a/Projects/Domains/ImageDomain/Sources/DataSource/RemoteImageDataSourceImpl.swift
+++ b/Projects/Domains/ImageDomain/Sources/DataSource/RemoteImageDataSourceImpl.swift
@@ -15,4 +15,10 @@ public final class RemoteImageDataSourceImpl: BaseRemoteDataSource<ImageAPI>, Re
             .map([FetchProfileListResponseDTO].self)
             .map { $0.map { $0.toDomain() } }
     }
+    
+    public func fetchDefaultPlaylistImage() -> Single<[DefaultImageEntity]> {
+        return request(.fetchDefaultPlaylistImage)
+            .map([FetchDefaultImageResponseDTO].self)
+            .map{ $0.map{$0.toDomain()} }
+    }
 }

--- a/Projects/Domains/ImageDomain/Sources/DataSource/RemoteImageDataSourceImpl.swift
+++ b/Projects/Domains/ImageDomain/Sources/DataSource/RemoteImageDataSourceImpl.swift
@@ -15,10 +15,10 @@ public final class RemoteImageDataSourceImpl: BaseRemoteDataSource<ImageAPI>, Re
             .map([FetchProfileListResponseDTO].self)
             .map { $0.map { $0.toDomain() } }
     }
-    
+
     public func fetchDefaultPlaylistImage() -> Single<[DefaultImageEntity]> {
         return request(.fetchDefaultPlaylistImage)
             .map([FetchDefaultImageResponseDTO].self)
-            .map{ $0.map{$0.toDomain()} }
+            .map { $0.map { $0.toDomain() } }
     }
 }

--- a/Projects/Domains/ImageDomain/Sources/Repository/ImageRepositoryImpl.swift
+++ b/Projects/Domains/ImageDomain/Sources/Repository/ImageRepositoryImpl.swift
@@ -18,7 +18,7 @@ public final class ImageRepositoryImpl: ImageRepository {
     public func fetchProfileList() -> Single<[ProfileListEntity]> {
         remoteImageDataSource.fetchProfileList()
     }
-    
+
     public func fetchDefaultPlaylistImage() -> Single<[DefaultImageEntity]> {
         remoteImageDataSource.fetchDefaultPlaylistImage()
     }

--- a/Projects/Domains/ImageDomain/Sources/Repository/ImageRepositoryImpl.swift
+++ b/Projects/Domains/ImageDomain/Sources/Repository/ImageRepositoryImpl.swift
@@ -18,4 +18,8 @@ public final class ImageRepositoryImpl: ImageRepository {
     public func fetchProfileList() -> Single<[ProfileListEntity]> {
         remoteImageDataSource.fetchProfileList()
     }
+    
+    public func fetchDefaultPlaylistImage() -> Single<[DefaultImageEntity]> {
+        remoteImageDataSource.fetchDefaultPlaylistImage()
+    }
 }

--- a/Projects/Domains/ImageDomain/Sources/ResponseDTO/FetchDefaultImageResponseDTO.swift
+++ b/Projects/Domains/ImageDomain/Sources/ResponseDTO/FetchDefaultImageResponseDTO.swift
@@ -15,4 +15,3 @@ public extension FetchDefaultImageResponseDTO {
         )
     }
 }
-

--- a/Projects/Domains/ImageDomain/Sources/ResponseDTO/FetchDefaultImageResponseDTO.swift
+++ b/Projects/Domains/ImageDomain/Sources/ResponseDTO/FetchDefaultImageResponseDTO.swift
@@ -1,18 +1,18 @@
 import Foundation
 import ImageDomainInterface
 
-public struct FetchProfileListResponseDTO: Decodable, Equatable {
+public struct FetchDefaultImageResponseDTO: Decodable, Equatable {
     public let type: String
     public let name: String
     public let url: String
 }
 
-public extension FetchProfileListResponseDTO {
-    func toDomain() -> ProfileListEntity {
-        ProfileListEntity(
+public extension FetchDefaultImageResponseDTO {
+    func toDomain() -> DefaultImageEntity {
+        DefaultImageEntity(
             name: name,
             url: url
         )
-        
     }
 }
+

--- a/Projects/Domains/ImageDomain/Sources/ResponseDTO/FetchProfileListResponseDTO.swift
+++ b/Projects/Domains/ImageDomain/Sources/ResponseDTO/FetchProfileListResponseDTO.swift
@@ -13,6 +13,5 @@ public extension FetchProfileListResponseDTO {
             name: name,
             url: url
         )
-        
     }
 }

--- a/Projects/Domains/ImageDomain/Sources/UseCase/FetchDefaultPlaylistImageUseCaseImpl.swift
+++ b/Projects/Domains/ImageDomain/Sources/UseCase/FetchDefaultPlaylistImageUseCaseImpl.swift
@@ -3,7 +3,6 @@ import ImageDomainInterface
 import RxSwift
 
 public struct FetchDefaultPlaylistImageUseCaseImpl: FetchDefaultPlaylistImageUseCase {
-    
     private let imageRepository: any ImageRepository
 
     public init(

--- a/Projects/Domains/ImageDomain/Sources/UseCase/FetchDefaultPlaylistImageUseCaseImpl.swift
+++ b/Projects/Domains/ImageDomain/Sources/UseCase/FetchDefaultPlaylistImageUseCaseImpl.swift
@@ -1,0 +1,18 @@
+import Foundation
+import ImageDomainInterface
+import RxSwift
+
+public struct FetchDefaultPlaylistImageUseCaseImpl: FetchDefaultPlaylistImageUseCase {
+    
+    private let imageRepository: any ImageRepository
+
+    public init(
+        imageRepository: ImageRepository
+    ) {
+        self.imageRepository = imageRepository
+    }
+
+    public func execute() -> Single<[DefaultImageEntity]> {
+        imageRepository.fetchDefaultPlaylistImage()
+    }
+}

--- a/Projects/Features/PlaylistFeature/Project.swift
+++ b/Projects/Features/PlaylistFeature/Project.swift
@@ -6,14 +6,16 @@ let project = Project.module(
     name: ModulePaths.Feature.PlaylistFeature.rawValue,
     targets: [
         .interface(module: .feature(.PlaylistFeature), dependencies: [
-            .feature(target: .BaseFeature, type: .interface)
+            .feature(target: .BaseFeature, type: .interface),
+            
         ]),
         .implements(
             module: .feature(.PlaylistFeature), dependencies: [
                 .feature(target: .BaseFeature),
                 .feature(target: .PlaylistFeature, type: .interface),
                 .domain(target: .AuthDomain, type: .interface),
-                .domain(target: .PlaylistDomain, type: .interface)
+                .domain(target: .PlaylistDomain, type: .interface),
+                .domain(target: .ImageDomain, type: .interface)
             ]
         ),
         .testing(module: .feature(.PlaylistFeature), dependencies: [

--- a/Projects/Features/PlaylistFeature/Project.swift
+++ b/Projects/Features/PlaylistFeature/Project.swift
@@ -6,7 +6,7 @@ let project = Project.module(
     name: ModulePaths.Feature.PlaylistFeature.rawValue,
     targets: [
         .interface(module: .feature(.PlaylistFeature), dependencies: [
-            .feature(target: .BaseFeature, type: .interface),
+            .feature(target: .BaseFeature, type: .interface)
 
         ]),
         .implements(

--- a/Projects/Features/PlaylistFeature/Project.swift
+++ b/Projects/Features/PlaylistFeature/Project.swift
@@ -7,7 +7,7 @@ let project = Project.module(
     targets: [
         .interface(module: .feature(.PlaylistFeature), dependencies: [
             .feature(target: .BaseFeature, type: .interface),
-            
+
         ]),
         .implements(
             module: .feature(.PlaylistFeature), dependencies: [

--- a/Projects/Features/PlaylistFeature/Sources/Components/DefaultPlaylistImageComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/DefaultPlaylistImageComponent.swift
@@ -2,16 +2,19 @@ import BaseFeature
 import BaseFeatureInterface
 import NeedleFoundation
 import PlaylistFeatureInterface
+import ImageDomainInterface
 import UIKit
 
 public protocol DefaultPlaylistImageDependency: Dependency {
-    #warning("usecase 주입")
-    //
+    var fetchDefaultPlaylistImageUseCase: any FetchDefaultPlaylistImageUseCase { get }
 }
 
 public final class DefaultPlaylistImageComponent: Component<DefaultPlaylistImageDependency>,
     DefaultPlaylistImageFactory {
     public func makeView(_ delegate: any DefaultPlaylistImageDelegate) -> UIViewController {
-        DefaultPlaylistImageViewController(delegate: delegate, reactor: DefaultPlaylistImageReactor())
+        DefaultPlaylistImageViewController(delegate: delegate, reactor: DefaultPlaylistImageReactor(
+            fetchDefaultPlaylistImageUseCase: dependency.fetchDefaultPlaylistImageUseCase
+
+        ))
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Components/DefaultPlaylistImageComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/DefaultPlaylistImageComponent.swift
@@ -1,8 +1,8 @@
 import BaseFeature
 import BaseFeatureInterface
+import ImageDomainInterface
 import NeedleFoundation
 import PlaylistFeatureInterface
-import ImageDomainInterface
 import UIKit
 
 public protocol DefaultPlaylistImageDependency: Dependency {

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/DefaultPlaylistImageReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/DefaultPlaylistImageReactor.swift
@@ -1,7 +1,7 @@
 import DesignSystem
 import Foundation
-import ReactorKit
 import ImageDomainInterface
+import ReactorKit
 import RxSwift
 
 final class DefaultPlaylistImageReactor: Reactor {
@@ -31,7 +31,7 @@ final class DefaultPlaylistImageReactor: Reactor {
             selectedIndex: 0,
             isLoading: true
         )
-        
+
         self.fetchDefaultPlaylistImageUseCase = fetchDefaultPlaylistImageUseCase
     }
 
@@ -73,7 +73,7 @@ extension DefaultPlaylistImageReactor {
             .just(.updateLoadingState(true)),
             fetchDefaultPlaylistImageUseCase.execute()
                 .asObservable()
-                .flatMap{ data -> Observable<Mutation>  in
+                .flatMap { data -> Observable<Mutation> in
                     return Observable.just(.updateDataSource(data))
                 },
             .just(.updateLoadingState(false))

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
@@ -168,7 +168,7 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
             .bind(with: self) { owner, flag in
 
                 if flag {
-                    owner.indicator.stopAnimating()
+                    owner.indicator.startAnimating()
                 } else {
                     owner.indicator.stopAnimating()
                     owner.collectionView.selectItem(

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
@@ -151,6 +151,7 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
 
         sharedState.map(\.dataSource)
             .distinctUntilChanged()
+            .filter{!$0.isEmpty}
             .bind(with: self) { owner, dataSource in
 
                 var snapShot = NSDiffableDataSourceSnapshot<Int, DefaultImageEntity>()
@@ -159,7 +160,13 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
 
                 snapShot.appendItems(dataSource)
 
-                owner.thumbnailDiffableDataSource.apply(snapShot)
+                owner.thumbnailDiffableDataSource.apply(snapShot) {
+                    owner.collectionView.selectItem(
+                        at: IndexPath(row: 0, section: 0),
+                        animated: false,
+                        scrollPosition: .top
+                    )
+                }
             }
             .disposed(by: disposeBag)
 
@@ -171,11 +178,6 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
                     owner.indicator.startAnimating()
                 } else {
                     owner.indicator.stopAnimating()
-                    owner.collectionView.selectItem(
-                        at: IndexPath(row: 0, section: 0),
-                        animated: false,
-                        scrollPosition: .top
-                    )
                 }
             }
             .disposed(by: disposeBag)

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
@@ -151,7 +151,7 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
 
         sharedState.map(\.dataSource)
             .distinctUntilChanged()
-            .filter{!$0.isEmpty}
+            .filter { !$0.isEmpty }
             .bind(with: self) { owner, dataSource in
 
                 var snapShot = NSDiffableDataSourceSnapshot<Int, DefaultImageEntity>()

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
@@ -1,10 +1,10 @@
 import BaseFeature
 import DesignSystem
+import ImageDomainInterface
 import PlaylistFeatureInterface
 import SnapKit
 import Then
 import UIKit
-import ImageDomainInterface
 
 final class DefaultPlaylistImageViewController: BaseReactorViewController<DefaultPlaylistImageReactor> {
     weak var delegate: DefaultPlaylistImageDelegate?
@@ -166,14 +166,17 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
         sharedState.map(\.isLoading)
             .distinctUntilChanged()
             .bind(with: self) { owner, flag in
-                
+
                 if flag {
                     owner.indicator.stopAnimating()
                 } else {
                     owner.indicator.stopAnimating()
-                    owner.collectionView.selectItem(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .top)
+                    owner.collectionView.selectItem(
+                        at: IndexPath(row: 0, section: 0),
+                        animated: false,
+                        scrollPosition: .top
+                    )
                 }
-                
             }
             .disposed(by: disposeBag)
 

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/DefaultPlaylistImageViewController.swift
@@ -4,6 +4,7 @@ import PlaylistFeatureInterface
 import SnapKit
 import Then
 import UIKit
+import ImageDomainInterface
 
 final class DefaultPlaylistImageViewController: BaseReactorViewController<DefaultPlaylistImageReactor> {
     weak var delegate: DefaultPlaylistImageDelegate?
@@ -39,12 +40,12 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
     private lazy var collectionView: UICollectionView = createCollectionView()
 
     private let thumbnailCellRegistration = UICollectionView.CellRegistration<
-        DefaultThumbnailCell, String
+        DefaultThumbnailCell, DefaultImageEntity
     > { cell, _, itemIdentifier in
         cell.configure(itemIdentifier)
     }
 
-    private lazy var thumbnailDiffableDataSource = UICollectionViewDiffableDataSource<Int, String>(
+    private lazy var thumbnailDiffableDataSource = UICollectionViewDiffableDataSource<Int, DefaultImageEntity>(
         collectionView: collectionView
     ) { [thumbnailCellRegistration] collectionView, indexPath, itemIdentifier in
         let cell = collectionView.dequeueConfiguredReusableCell(
@@ -64,8 +65,6 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
         super.viewDidLoad()
         self.view.backgroundColor = .white
         reactor?.action.onNext(.viewDidload)
-
-        collectionView.selectItem(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .top)
     }
 
     override func addView() {
@@ -138,7 +137,7 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
 
                 let (dataSource, index) = (info.0, info.1)
 
-                let (name, url) = ("임시 명", dataSource[index])
+                let (name, url) = (dataSource[index].name, dataSource[index].url)
 
                 owner.dismiss(animated: true) {
                     owner.delegate?.receive(name, url)
@@ -154,7 +153,7 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
             .distinctUntilChanged()
             .bind(with: self) { owner, dataSource in
 
-                var snapShot = NSDiffableDataSourceSnapshot<Int, String>()
+                var snapShot = NSDiffableDataSourceSnapshot<Int, DefaultImageEntity>()
 
                 snapShot.appendSections([0])
 
@@ -167,7 +166,14 @@ final class DefaultPlaylistImageViewController: BaseReactorViewController<Defaul
         sharedState.map(\.isLoading)
             .distinctUntilChanged()
             .bind(with: self) { owner, flag in
-                flag == true ? owner.indicator.stopAnimating() : owner.indicator.stopAnimating()
+                
+                if flag {
+                    owner.indicator.stopAnimating()
+                } else {
+                    owner.indicator.stopAnimating()
+                    owner.collectionView.selectItem(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .top)
+                }
+                
             }
             .disposed(by: disposeBag)
 

--- a/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
@@ -44,5 +44,5 @@ extension DefaultThumbnailCell {
 
     public func configure(_ model: DefaultImageEntity) {
         imageView.kf.setImage(with: URL(string: model.url), options: [.transition(.fade(0.2))])
-        }
+    }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
@@ -44,5 +44,5 @@ extension DefaultThumbnailCell {
 
     public func configure(_ model: DefaultImageEntity) {
         imageView.kf.setImage(with: URL(string: model.url), options: [.transition(.fade(0.2))])
-    }
+        }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
@@ -3,6 +3,8 @@ import Kingfisher
 import SnapKit
 import Then
 import UIKit
+import ImageDomainInterface
+
 
 final class DefaultThumbnailCell: UICollectionViewCell {
     override var isSelected: Bool {
@@ -41,9 +43,8 @@ extension DefaultThumbnailCell {
         }
     }
 
-    public func configure(_ image: String) {
-        let image = DesignSystemAsset.PlayListTheme.theme0.image
-
-        imageView.image = image
+    public func configure(_ model: DefaultImageEntity) {
+    
+        imageView.kf.setImage(with: URL(string: model.url), options: [.transition(.fade(0.2))])
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/DefaultThumbnailCell.swift
@@ -1,10 +1,9 @@
 import DesignSystem
+import ImageDomainInterface
 import Kingfisher
 import SnapKit
 import Then
 import UIKit
-import ImageDomainInterface
-
 
 final class DefaultThumbnailCell: UICollectionViewCell {
     override var isSelected: Bool {
@@ -44,7 +43,6 @@ extension DefaultThumbnailCell {
     }
 
     public func configure(_ model: DefaultImageEntity) {
-    
         imageView.kf.setImage(with: URL(string: model.url), options: [.transition(.fade(0.2))])
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요

실제 서버에 있는 이미지를 불러옵니다.

Resolves: #742

## 📃 작업내용

- imageDomain에  기본 playlist 이미지 불러오는 api 경로를 추가 합니다.
- usecase를 구현 후 연결합니다.

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
