### PR TITLE
🔀 :: (#751) 프리퍼런스 접근 개선

### DIFF
--- a/Projects/App/Sources/Application/AppDelegate.swift
+++ b/Projects/App/Sources/Application/AppDelegate.swift
@@ -22,7 +22,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         FirebaseApp.configure()
         setAnalyticsDefaultParameters()
         if let userInfo = PreferenceManager.userInfo {
-            LogManager.setUserID(userID: userInfo.decryptID)
+            LogManager.setUserID(userID: userInfo.decryptedID)
         } else {
             LogManager.setUserID(userID: nil)
         }

--- a/Projects/App/Sources/Application/AppDelegate.swift
+++ b/Projects/App/Sources/Application/AppDelegate.swift
@@ -21,8 +21,8 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use Firebase library to configure APIs
         FirebaseApp.configure()
         setAnalyticsDefaultParameters()
-        if let userID = PreferenceManager.userInfo?.ID {
-            LogManager.setUserID(userID: AES256.decrypt(encoded: userID))
+        if let userInfo = PreferenceManager.userInfo {
+            LogManager.setUserID(userID: userInfo.decryptID)
         } else {
             LogManager.setUserID(userID: nil)
         }

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -175,9 +175,8 @@ private extension MyInfoReactor {
     }
 
     func updateNickname(_ userInfo: UserInfo?) -> Observable<Mutation> {
-        guard let nickname = userInfo?.name else { return .empty() }
-        let decrypt = AES256.decrypt(encoded: nickname)
-        return .just(.updateNickname(decrypt))
+        guard let userInfo = userInfo else { return .empty() }
+        return .just(.updateNickname(userInfo.decryptName))
     }
 
     func updatePlatform(_ userInfo: UserInfo?) -> Observable<Mutation> {

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -176,7 +176,7 @@ private extension MyInfoReactor {
 
     func updateNickname(_ userInfo: UserInfo?) -> Observable<Mutation> {
         guard let userInfo = userInfo else { return .empty() }
-        return .just(.updateNickname(userInfo.decryptName))
+        return .just(.updateNickname(userInfo.decryptedName))
     }
 
     func updatePlatform(_ userInfo: UserInfo?) -> Observable<Mutation> {

--- a/Projects/Features/MyInfoFeature/Sources/ViewModels/QuestionViewModel.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewModels/QuestionViewModel.swift
@@ -132,7 +132,7 @@ extension InquiryType {
                 * 자동으로 작성된 시스템 정보입니다. 원활한 문의를 위해서 삭제하지 말아 주세요.\n
                 \(APP_NAME()) v\(APP_VERSION())
                 \(Device().modelName) / \(OS_NAME()) \(OS_VERSION())
-                닉네임: \(Utility.PreferenceManager.userInfo?.decryptName ?? ""))
+                닉네임: \(Utility.PreferenceManager.userInfo?.decryptedName ?? ""))
             """
         }
     }

--- a/Projects/Features/MyInfoFeature/Sources/ViewModels/QuestionViewModel.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewModels/QuestionViewModel.swift
@@ -132,7 +132,7 @@ extension InquiryType {
                 * 자동으로 작성된 시스템 정보입니다. 원활한 문의를 위해서 삭제하지 말아 주세요.\n
                 \(APP_NAME()) v\(APP_VERSION())
                 \(Device().modelName) / \(OS_NAME()) \(OS_VERSION())
-                닉네임: \(AES256.decrypt(encoded: Utility.PreferenceManager.userInfo?.name ?? ""))
+                닉네임: \(Utility.PreferenceManager.userInfo?.decryptName ?? ""))
             """
         }
     }

--- a/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
@@ -89,10 +89,10 @@ private extension LoginViewModel {
             .subscribe(onNext: { [input, output] entity in
                 LogManager.setUserID(userID: entity.id)
                 PreferenceManager.shared.setUserInfo(
-                    ID: AES256.encrypt(string: entity.id),
+                    ID: entity.id,
                     platform: entity.platform,
                     profile: entity.profile,
-                    name: AES256.encrypt(string: entity.name),
+                    name: entity.name,
                     itemCount: entity.itemCount
                 )
                 output.dismissLoginScene.accept(input.arrivedTokenFromThirdParty.value.0)

--- a/Projects/Features/StorageFeature/Sources/ViewModels/AfterLoginStorageViewModel.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewModels/AfterLoginStorageViewModel.swift
@@ -55,10 +55,10 @@ public final class AfterLoginViewModel: ViewModelType {
             }
             .subscribe(onNext: {
                 PreferenceManager.shared.setUserInfo(
-                    ID: AES256.encrypt(string: $0.id),
+                    ID: $0.id,
                     platform: $0.platform,
                     profile: $0.profile,
-                    name: AES256.encrypt(string: $0.name),
+                    name: $0.name,
                     itemCount: $0.itemCount
                 )
             }).disposed(by: disposeBag)

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+PreferenceManager.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+PreferenceManager.swift
@@ -54,10 +54,10 @@ public extension PreferenceManager {
         itemCount: Int
     ) {
         let userInfo = UserInfo(
-            ID: ID,
+            ID: AES256.encrypt(string: ID),
             platform: platform,
             profile: profile,
-            name: name,
+            name: AES256.encrypt(string: name),
             itemCount: itemCount
         )
         Utility.PreferenceManager.userInfo = userInfo

--- a/Projects/Modules/Utility/Sources/Manager/UserInfoManager.swift
+++ b/Projects/Modules/Utility/Sources/Manager/UserInfoManager.swift
@@ -15,6 +15,14 @@ public struct UserInfo: Codable, Equatable {
     public let name: String
     public let itemCount: Int
 
+    public var decryptID: String {
+        return AES256.decrypt(encoded: ID)
+    }
+
+    public var decryptName: String {
+        return AES256.decrypt(encoded: name)
+    }
+
     public static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.ID == rhs.ID
     }
@@ -26,7 +34,7 @@ public extension UserInfo {
             ID: self.ID,
             platform: self.platform,
             profile: self.profile,
-            name: name,
+            name: AES256.encrypt(string: name),
             itemCount: self.itemCount
         )
     }

--- a/Projects/Modules/Utility/Sources/Manager/UserInfoManager.swift
+++ b/Projects/Modules/Utility/Sources/Manager/UserInfoManager.swift
@@ -15,11 +15,11 @@ public struct UserInfo: Codable, Equatable {
     public let name: String
     public let itemCount: Int
 
-    public var decryptID: String {
+    public var decryptedID: String {
         return AES256.decrypt(encoded: ID)
     }
 
-    public var decryptName: String {
+    public var decryptedName: String {
         return AES256.decrypt(encoded: name)
     }
 

--- a/Projects/Modules/Utility/Sources/Utils/AES256.swift
+++ b/Projects/Modules/Utility/Sources/Utils/AES256.swift
@@ -13,8 +13,10 @@ public enum AES256 {
     /// 키값 32바이트: AES256(24bytes: AES192, 16bytes: AES128)
     private static let SECRET_KEY = "01234567890123450123456789012345"
     private static let IV = "0123456789012345"
+}
 
-    public static func encrypt(string: String) -> String {
+public extension AES256 {
+    static func encrypt(string: String) -> String {
         guard !string.isEmpty else { return "" }
         guard let result = try? getAESObject()?.encrypt(string.bytes).toBase64() else {
             return ""
@@ -22,7 +24,7 @@ public enum AES256 {
         return result
     }
 
-    public static func decrypt(encoded: String) -> String {
+    static func decrypt(encoded: String) -> String {
         guard !encoded.isEmpty else {
             return ""
         }
@@ -35,8 +37,10 @@ public enum AES256 {
         }
         return String(bytes: decode, encoding: .utf8) ?? ""
     }
+}
 
-    private static func getAESObject() -> AES? {
+private extension AES256 {
+    static func getAESObject() -> AES? {
         let keyDecodes: [UInt8] = Array(SECRET_KEY.utf8)
         let ivDecodes: [UInt8] = Array(IV.utf8)
         let aesObject = try? AES(key: keyDecodes, blockMode: CBC(iv: ivDecodes), padding: .pkcs5)


### PR DESCRIPTION
## 💡 배경 및 개요
- UserInfo에 값을 저장할때 ID, name은 암호화를 해서 저장하고, 복호화를 하여 사용하는 방식이었음.

Resolves: #751 

## 📃 작업내용
- UserInfo entity를 직접 암호화 시켜 저장하던 방식에서 setUserInfo 함수 내로 밀어넣음
- 복호화된 ID, name을 가져오는 프로퍼티 추가
`as-is
 AES256.decrypt(encoded: PrefernceManager.userInfo?.ID ?? ""
 to-be
 PrefernceManager.userInfo.decryptID ?? ""
`
- 결론: AES관련 메소드가 뷰컨이나 뷰모델에서 더 이상 사용되지않음.

## 🙋‍♂️ 리뷰노트
- 더 좋은 방법이? 일단 이렇게 밖에 생각안나요. 어디부터 고쳐야할지,

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
