### PR TITLE
🔀 :: (#661) 검색 전 화면 로딩 중에 써치바 포커싱 시 앱 종료 버그를 해결합니다.

### DIFF
--- a/Projects/Features/SearchFeature/Sources/CompositionalLayout/Enum/DataSource/BeforeVcDataSoruce.swift
+++ b/Projects/Features/SearchFeature/Sources/CompositionalLayout/Enum/DataSource/BeforeVcDataSoruce.swift
@@ -8,7 +8,7 @@ enum BeforeVcDataSoruce: Hashable {
     case youtube(model: CurrentVideoEntity)
     case recommend(model: RecommendPlaylistEntity)
 //    case popularList(model: Model)
-#warning("추후 업데이트 시 사용")
+    #warning("추후 업데이트 시 사용")
     var title: String {
         switch self {
         case let .youtube(model):

--- a/Projects/Features/SearchFeature/Sources/CompositionalLayout/Enum/DataSource/BeforeVcDataSoruce.swift
+++ b/Projects/Features/SearchFeature/Sources/CompositionalLayout/Enum/DataSource/BeforeVcDataSoruce.swift
@@ -7,16 +7,16 @@ import PlaylistDomainInterface
 enum BeforeVcDataSoruce: Hashable {
     case youtube(model: CurrentVideoEntity)
     case recommend(model: RecommendPlaylistEntity)
-    case popularList(model: Model)
-
+//    case popularList(model: Model)
+#warning("추후 업데이트 시 사용")
     var title: String {
         switch self {
         case let .youtube(model):
             return ""
         case let .recommend(model):
             return model.title
-        case let .popularList(model):
-            return model.title
+//        case let .popularList(model):
+//            return model.title
         }
     }
 }

--- a/Projects/Features/SearchFeature/Sources/Reactors/SongSearchResultReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/Reactors/SongSearchResultReactor.swift
@@ -91,7 +91,7 @@ final class SongSearchResultReactor: Reactor {
 
         case let .updateScrollPage(page):
             newState.scrollPage = page
-            
+
         case let .showToast(message):
             newState.toastMessage = message
         }

--- a/Projects/Features/SearchFeature/Sources/Reactors/WakmusicRecommendReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/Reactors/WakmusicRecommendReactor.swift
@@ -41,7 +41,7 @@ final class WakmusicRecommendReactor: Reactor {
             newState.dataSource = dataSource
         case let .updateLodingState(isLoading):
             newState.isLoading = isLoading
-            
+
         case let .showToast(message):
             newState.toastMessage = message
         }

--- a/Projects/Features/SearchFeature/Sources/Reactors/WakmusicRecommendReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/Reactors/WakmusicRecommendReactor.swift
@@ -17,11 +17,13 @@ final class WakmusicRecommendReactor: Reactor {
     enum Mutation {
         case updateDataSource([RecommendPlaylistEntity])
         case updateLodingState(Bool)
+        case showToast(String)
     }
 
     struct State {
         var dataSource: [RecommendPlaylistEntity]
         var isLoading: Bool
+        @Pulse var toastMessage: String?
     }
 
     func mutate(action: Action) -> Observable<Mutation> {
@@ -39,6 +41,9 @@ final class WakmusicRecommendReactor: Reactor {
             newState.dataSource = dataSource
         case let .updateLodingState(isLoading):
             newState.isLoading = isLoading
+            
+        case let .showToast(message):
+            newState.toastMessage = message
         }
 
         return newState
@@ -65,7 +70,13 @@ extension WakmusicRecommendReactor {
             fetchRecommendPlaylistUseCase
                 .execute()
                 .asObservable()
-                .map { Mutation.updateDataSource($0) },
+                .map { Mutation.updateDataSource($0) }
+                .catch { error in
+                    let wmErorr = error.asWMError
+                    return Observable.just(
+                        Mutation.showToast(wmErorr.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")
+                    )
+                },
             .just(.updateLodingState(false))
         ])
     }

--- a/Projects/Features/SearchFeature/Sources/View/PopularPlayListCell.swift
+++ b/Projects/Features/SearchFeature/Sources/View/PopularPlayListCell.swift
@@ -42,10 +42,11 @@ final class PopularPlayListCell: UICollectionViewCell {
 }
 
 extension PopularPlayListCell {
-    public func update(_ model: Model) {
-        self.titleLabel.text = model.title
-        self.nickNameLabel.text = "Hamp"
-    }
+    #warning("추후 업데이트 시 사용")
+//    public func update(_ model: Model) {
+//        self.titleLabel.text = model.title
+//        self.nickNameLabel.text = "Hamp"
+//    }
 
     private func configureUI() {
         imageView.snp.makeConstraints {

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
@@ -126,7 +126,11 @@ final class BeforeSearchContentViewController: BaseReactorViewController<BeforeS
         // 최근 검색어 tableView 셋팅
         Utility.PreferenceManager.$recentRecords
             .compactMap { $0 ?? [] }
-            .bind(to: tableView.rx.items) { ( tableView: UITableView, index: Int, element: String) -> RecentRecordTableViewCell in
+            .bind(to: tableView.rx.items) { (
+                tableView: UITableView,
+                index: Int,
+                element: String
+            ) -> RecentRecordTableViewCell in
                 guard let cell = tableView.dequeueReusableCell(
                     withIdentifier: "RecentRecordTableViewCell",
                     for: IndexPath(row: index, section: 0)
@@ -143,14 +147,14 @@ final class BeforeSearchContentViewController: BaseReactorViewController<BeforeS
         sharedState.map(\.dataSource)
             .bind(with: self) { owner, dataSource in
 
-                var snapShot = NSDiffableDataSourceSnapshot<BeforeSearchSection,BeforeVcDataSoruce>()
+                var snapShot = NSDiffableDataSourceSnapshot<BeforeSearchSection, BeforeVcDataSoruce>()
                 snapShot.appendSections([.youtube, .recommend])
 
                 snapShot.appendItems([.youtube(model: dataSource.currentVideo)], toSection: .youtube)
                 snapShot.appendItems(dataSource.recommendPlayList.map { .recommend(model: $0) }, toSection: .recommend)
-                
+
                 #warning("추후 업데이트 시 사용")
-                //snapShot.appendItems(tmp.map { .popularList(model: $0) }, toSection: .popularList)
+                // snapShot.appendItems(tmp.map { .popularList(model: $0) }, toSection: .popularList)
 
                 owner.dataSource.apply(snapShot, animatingDifferences: false)
             }
@@ -252,8 +256,15 @@ extension BeforeSearchContentViewController {
                 supplementaryView.update(layoutKind.title, indexPath.section)
             }
 
-        let dataSource = UICollectionViewDiffableDataSource<BeforeSearchSection, BeforeVcDataSoruce>(collectionView: collectionView) {
-            ( collectionView: UICollectionView, indexPath: IndexPath,item: BeforeVcDataSoruce ) -> UICollectionViewCell? in
+        let dataSource = UICollectionViewDiffableDataSource<
+            BeforeSearchSection,
+            BeforeVcDataSoruce
+        >(collectionView: collectionView) {
+            (
+                collectionView: UICollectionView,
+                indexPath: IndexPath,
+                item: BeforeVcDataSoruce
+            ) -> UICollectionViewCell? in
 
             switch item {
             case let .youtube(model: model):
@@ -304,7 +315,7 @@ extension BeforeSearchContentViewController: UICollectionViewDelegate {
 
             navigatePlaylistDetail(key: model.key, kind: .wakmu)
 
-        #warning("추후 업데이트 시 사용")
+            #warning("추후 업데이트 시 사용")
 //        case let .popularList(model: model):
 //            LogManager.printDebug("popular \(model)")
         }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
@@ -99,9 +99,9 @@ final class BeforeSearchContentViewController: BaseReactorViewController<BeforeS
         super.bindState(reactor: reactor)
 
         let sharedState = reactor.state.share()
-        
+
         reactor.pulse(\.$toastMessage)
-            .compactMap{$0}
+            .compactMap { $0 }
             .bind(with: self) { owner, message in
                 owner.showToast(text: message, font: .setFont(.t6(weight: .light)))
             }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
@@ -99,6 +99,13 @@ final class BeforeSearchContentViewController: BaseReactorViewController<BeforeS
         super.bindState(reactor: reactor)
 
         let sharedState = reactor.state.share()
+        
+        reactor.pulse(\.$toastMessage)
+            .compactMap{$0}
+            .bind(with: self) { owner, message in
+                owner.showToast(text: message, font: .setFont(.t6(weight: .light)))
+            }
+            .disposed(by: disposeBag)
 
         sharedState.map(\.isLoading)
             .distinctUntilChanged()

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
@@ -13,10 +13,6 @@ import RxSwift
 import UIKit
 import Utility
 
-public struct Model: Hashable {
-    let title: String
-}
-
 final class BeforeSearchContentViewController: BaseReactorViewController<BeforeSearchReactor>, PlaylistDetailNavigator {
     private let wakmusicRecommendComponent: WakmusicRecommendComponent
     private let textPopUpFactory: TextPopUpFactory
@@ -130,11 +126,7 @@ final class BeforeSearchContentViewController: BaseReactorViewController<BeforeS
         // 최근 검색어 tableView 셋팅
         Utility.PreferenceManager.$recentRecords
             .compactMap { $0 ?? [] }
-            .bind(to: tableView.rx.items) { (
-                tableView: UITableView,
-                index: Int,
-                element: String
-            ) -> RecentRecordTableViewCell in
+            .bind(to: tableView.rx.items) { ( tableView: UITableView, index: Int, element: String) -> RecentRecordTableViewCell in
                 guard let cell = tableView.dequeueReusableCell(
                     withIdentifier: "RecentRecordTableViewCell",
                     for: IndexPath(row: index, section: 0)
@@ -149,16 +141,16 @@ final class BeforeSearchContentViewController: BaseReactorViewController<BeforeS
             }.disposed(by: disposeBag)
 
         sharedState.map(\.dataSource)
-            .distinctUntilChanged { $0.currentVideo == $1.currentVideo }
             .bind(with: self) { owner, dataSource in
-                let tmp: [Model] = [Model(title: "임시플리1"), Model(title: "임시플리2"), Model(title: "임시플리3")]
 
-                var snapShot = owner.dataSource.snapshot()
-                snapShot.appendSections([.youtube, .recommend, .popularList])
+                var snapShot = NSDiffableDataSourceSnapshot<BeforeSearchSection,BeforeVcDataSoruce>()
+                snapShot.appendSections([.youtube, .recommend])
 
                 snapShot.appendItems([.youtube(model: dataSource.currentVideo)], toSection: .youtube)
                 snapShot.appendItems(dataSource.recommendPlayList.map { .recommend(model: $0) }, toSection: .recommend)
-                snapShot.appendItems(tmp.map { .popularList(model: $0) }, toSection: .popularList)
+                
+                #warning("추후 업데이트 시 사용")
+                //snapShot.appendItems(tmp.map { .popularList(model: $0) }, toSection: .popularList)
 
                 owner.dataSource.apply(snapShot, animatingDifferences: false)
             }
@@ -240,11 +232,12 @@ extension BeforeSearchContentViewController {
             cell.update(model: itemIdentifier)
         }
 
-        let popularListCellRegistration = UICollectionView
-            .CellRegistration<PopularPlayListCell, Model> { cell, indexPath, item in
-
-                cell.update(item)
-            }
+        #warning("추후 업데이트 시 사용")
+//        let popularListCellRegistration = UICollectionView
+//            .CellRegistration<PopularPlayListCell, Model> { cell, indexPath, item in
+//
+//                cell.update(item)
+//            }
 
         // MARK: Header
 
@@ -259,15 +252,8 @@ extension BeforeSearchContentViewController {
                 supplementaryView.update(layoutKind.title, indexPath.section)
             }
 
-        let dataSource = UICollectionViewDiffableDataSource<
-            BeforeSearchSection,
-            BeforeVcDataSoruce
-        >(collectionView: collectionView) {
-            (
-                collectionView: UICollectionView,
-                indexPath: IndexPath,
-                item: BeforeVcDataSoruce
-            ) -> UICollectionViewCell? in
+        let dataSource = UICollectionViewDiffableDataSource<BeforeSearchSection, BeforeVcDataSoruce>(collectionView: collectionView) {
+            ( collectionView: UICollectionView, indexPath: IndexPath,item: BeforeVcDataSoruce ) -> UICollectionViewCell? in
 
             switch item {
             case let .youtube(model: model):
@@ -284,12 +270,14 @@ extension BeforeSearchContentViewController {
                         item: model
                     )
 
-            case let .popularList(model: model):
-                return collectionView.dequeueConfiguredReusableCell(
-                    using: popularListCellRegistration,
-                    for: indexPath,
-                    item: model
-                )
+//            case let .popularList(model: model):
+//                break
+                #warning("추후 업데이트 시 사용")
+//                return collectionView.dequeueConfiguredReusableCell(
+//                    using: popularListCellRegistration,
+//                    for: indexPath,
+//                    item: model
+//                )
             }
         }
 
@@ -301,7 +289,7 @@ extension BeforeSearchContentViewController {
     }
 }
 
-// MARK: CollectionView Deleagte
+// MARK: CollectionView Deleagate
 extension BeforeSearchContentViewController: UICollectionViewDelegate {
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let model = dataSource.itemIdentifier(for: indexPath) else {
@@ -316,8 +304,9 @@ extension BeforeSearchContentViewController: UICollectionViewDelegate {
 
             navigatePlaylistDetail(key: model.key, kind: .wakmu)
 
-        case let .popularList(model: model):
-            LogManager.printDebug("popular \(model)")
+        #warning("추후 업데이트 시 사용")
+//        case let .popularList(model: model):
+//            LogManager.printDebug("popular \(model)")
         }
     }
 }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -93,6 +93,13 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
         super.bindState(reactor: reactor)
 
         let sharedState = reactor.state.share()
+        
+        reactor.pulse(\.$toastMessage)
+            .compactMap{$0}
+            .bind(with: self) { owner, message in
+                owner.showToast(text: message, font: .setFont(.t6(weight: .light)))
+            }
+            .disposed(by: disposeBag)
 
         sharedState.map(\.sortType)
             .distinctUntilChanged()

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -93,9 +93,9 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
         super.bindState(reactor: reactor)
 
         let sharedState = reactor.state.share()
-        
+
         reactor.pulse(\.$toastMessage)
-            .compactMap{$0}
+            .compactMap { $0 }
             .bind(with: self) { owner, message in
                 owner.showToast(text: message, font: .setFont(.t6(weight: .light)))
             }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -93,6 +93,13 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
         super.bindState(reactor: reactor)
 
         let sharedState = reactor.state.share()
+        
+        reactor.pulse(\.$toastMessage)
+            .compactMap{$0}
+            .bind(with: self) { owner, message in
+                owner.showToast(text: message, font: .setFont(.t6(weight: .light)))
+            }
+            .disposed(by: disposeBag)
 
         sharedState.map(\.sortType)
             .distinctUntilChanged()

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -93,9 +93,9 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
         super.bindState(reactor: reactor)
 
         let sharedState = reactor.state.share()
-        
+
         reactor.pulse(\.$toastMessage)
-            .compactMap{$0}
+            .compactMap { $0 }
             .bind(with: self) { owner, message in
                 owner.showToast(text: message, font: .setFont(.t6(weight: .light)))
             }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/WakmusicRecommendViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/WakmusicRecommendViewController.swift
@@ -72,6 +72,13 @@ final class WakmusicRecommendViewController: BaseReactorViewController<WakmusicR
     override func bindState(reactor: WakmusicRecommendReactor) {
         super.bindState(reactor: reactor)
         let sharedState = reactor.state.share()
+        
+        reactor.pulse(\.$toastMessage)
+            .compactMap{$0}
+            .bind(with: self) { owner, message in
+                owner.showToast(text: message, font: .setFont(.t6(weight: .light)))
+            }
+            .disposed(by: disposeBag)
 
         sharedState.map(\.dataSource)
             .distinctUntilChanged()

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/WakmusicRecommendViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/WakmusicRecommendViewController.swift
@@ -72,9 +72,9 @@ final class WakmusicRecommendViewController: BaseReactorViewController<WakmusicR
     override func bindState(reactor: WakmusicRecommendReactor) {
         super.bindState(reactor: reactor)
         let sharedState = reactor.state.share()
-        
+
         reactor.pulse(\.$toastMessage)
-            .compactMap{$0}
+            .compactMap { $0 }
             .bind(with: self) { owner, message in
                 owner.showToast(text: message, font: .setFont(.t6(weight: .light)))
             }


### PR DESCRIPTION
## 💡 배경 및 개요

같은 데이터 소스의 스냅샷을 중복으로 추가하여 발생된느 버그를 해결합니다.

Resolves: #661

## 📃 작업내용

- 스냅샷을 데이터소스 올 때 마다 생성합니다.
- 추후 업데이트 내용인 인기 리스트를 주석 및 warning처리 
- 에러 처리 및 토스트 작업

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
