### PR TITLE
🔀 :: (#775) 검샐 결과 화면에 songCart를 연결합니다. 

### DIFF
--- a/Projects/Domains/SearchDomain/Interface/Enum/Option.swift
+++ b/Projects/Domains/SearchDomain/Interface/Enum/Option.swift
@@ -25,9 +25,8 @@ public enum FilterType: String, Encodable, SearchOptionType {
 public enum SortType: String, Encodable, SearchOptionType {
     case latest
     case oldest
-    case likes
-    case views
     case alphabetical
+    case popular
 
     public var title: String {
         switch self {
@@ -35,12 +34,10 @@ public enum SortType: String, Encodable, SearchOptionType {
             "최신순"
         case .oldest:
             "과거순"
-        case .likes:
-            "좋아요순"
-        case .views:
-            "조회수순"
         case .alphabetical:
             "가나다순"
+        case .popular:
+            "인기순 (서버 개발 검토 중)"
         }
     }
 }

--- a/Projects/Domains/SongsDomain/Sources/ResponseDTO/SingleSongResponseDTO.swift
+++ b/Projects/Domains/SongsDomain/Sources/ResponseDTO/SingleSongResponseDTO.swift
@@ -40,7 +40,7 @@ public extension SingleSongResponseDTO {
             reaction: "",
             views: views,
             last: 0,
-            date: (Double(date) / 1000.0).unixTimeToDate.dateToString(format: "yyyy.MM.dd"),
+            date: date.changeDateFormat(origin: "yyMMdd", result: "yyyy.MM.dd"),
             likes: likes,
             karaokeNumber: .init(TJ: karaokeNumber.TJ, KY: karaokeNumber.KY)
         )

--- a/Projects/Features/SearchFeature/Sources/Components/SongSearchResultComponent.swift
+++ b/Projects/Features/SearchFeature/Sources/Components/SongSearchResultComponent.swift
@@ -9,6 +9,7 @@ import UIKit
 public protocol SongSearchResultDependency: Dependency {
     var fetchSearchSongsUseCase: any FetchSearchSongsUseCase { get }
     var searchSortOptionComponent: SearchSortOptionComponent { get }
+    var containSongsFactory: any ContainSongsFactory { get }
 }
 
 public final class SongSearchResultComponent: Component<SongSearchResultDependency>, SongSearchResultFactory {
@@ -18,7 +19,8 @@ public final class SongSearchResultComponent: Component<SongSearchResultDependen
                 text: text,
                 fetchSearchSongsUseCase: dependency.fetchSearchSongsUseCase
             ),
-            dependency.searchSortOptionComponent
+            searchSortOptionComponent: dependency.searchSortOptionComponent,
+            containSongsFactory: dependency.containSongsFactory
         )
     }
 }

--- a/Projects/Features/SearchFeature/Sources/CompositionalLayout/Layout/ListSearchResultCollectionViewLayout.swift
+++ b/Projects/Features/SearchFeature/Sources/CompositionalLayout/Layout/ListSearchResultCollectionViewLayout.swift
@@ -30,7 +30,7 @@ extension ListSearchResultCollectionViewLayout {
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
 
         let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = NSDirectionalEdgeInsets(top: .zero, leading: 20.0, bottom: 20.0, trailing: 20.0)
+        section.contentInsets = NSDirectionalEdgeInsets(top: .zero, leading: .zero, bottom: 56.0, trailing: .zero)
 
         return section
     }

--- a/Projects/Features/SearchFeature/Sources/CompositionalLayout/Layout/SongSearchResultCollectionViewLayout.swift
+++ b/Projects/Features/SearchFeature/Sources/CompositionalLayout/Layout/SongSearchResultCollectionViewLayout.swift
@@ -30,7 +30,7 @@ extension SongSearchResultCollectionViewLayout {
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
 
         let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = NSDirectionalEdgeInsets(top: .zero, leading: 20.0, bottom: 20.0, trailing: 20.0)
+        section.contentInsets = NSDirectionalEdgeInsets(top: .zero, leading: .zero, bottom: 56.0, trailing: .zero)
 
         return section
     }

--- a/Projects/Features/SearchFeature/Sources/Reactors/SongSearchResultReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/Reactors/SongSearchResultReactor.swift
@@ -92,7 +92,6 @@ final class SongSearchResultReactor: Reactor {
             newState.dataSource = dataSource
             newState.canLoad = canLoad
 
-
         case let .updateLoadingState(isLoading):
             newState.isLoading = isLoading
 
@@ -101,10 +100,9 @@ final class SongSearchResultReactor: Reactor {
 
         case let .showToast(message):
             newState.toastMessage = message
-            
+
         case let .updateSelectedCount(count):
             newState.selectedCount = count
-
 
         case let .updateSelectingStateByIndex(dataSource):
             newState.dataSource = dataSource
@@ -162,7 +160,7 @@ extension SongSearchResultReactor {
             .just(Mutation.updateLoadingState(false)) // 로딩 종료
         ])
     }
-    
+
     func updateItemSelected(_ index: Int) -> Observable<Mutation> {
         let state = currentState
         var count = state.selectedCount

--- a/Projects/Features/SearchFeature/Sources/View/ListResultCell.swift
+++ b/Projects/Features/SearchFeature/Sources/View/ListResultCell.swift
@@ -67,7 +67,7 @@ extension ListResultCell {
             $0.width.equalTo(40)
             $0.height.equalTo(40)
             $0.top.bottom.equalToSuperview().inset(10)
-            $0.leading.equalToSuperview()
+            $0.leading.equalToSuperview().inset(20)
         }
 
         titleLabel.snp.makeConstraints {
@@ -85,7 +85,7 @@ extension ListResultCell {
         dateLabel.snp.makeConstraints {
             $0.width.equalTo(70)
             $0.centerY.equalTo(thumbnailView.snp.centerY)
-            $0.trailing.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(20)
             $0.leading.equalTo(titleLabel.snp.trailing).offset(8)
         }
     }

--- a/Projects/Features/SearchFeature/Sources/View/SearchOptionHeaderView.swift
+++ b/Projects/Features/SearchFeature/Sources/View/SearchOptionHeaderView.swift
@@ -47,6 +47,7 @@ final class SearchOptionHeaderView: UIView {
         collectionViewLayout: SearchFilterOptionCollectionViewLayout()
     ).then {
         $0.backgroundColor = .clear
+        $0.bounces = false
     }
 
     private let dimView = UIView()

--- a/Projects/Features/SearchFeature/Sources/View/SearchOptionHeaderView.swift
+++ b/Projects/Features/SearchFeature/Sources/View/SearchOptionHeaderView.swift
@@ -15,8 +15,7 @@ private protocol SearchOptionHeaderActionProtocol {
     var didTapSortButton: Observable<Void> { get }
 }
 
-final class SearchOptionHeaderView:
-    UIView {
+final class SearchOptionHeaderView: UIView {
     private let searchFilterCellRegistration = UICollectionView.CellRegistration<
         SearchFilterCell, FilterType
     > { cell, indexPath, itemIdentifier in

--- a/Projects/Features/SearchFeature/Sources/View/SearchSortOptionCell.swift
+++ b/Projects/Features/SearchFeature/Sources/View/SearchSortOptionCell.swift
@@ -49,10 +49,16 @@ extension SearchSortOptionCell {
 
     public func update(_ model: SortType, _ selectedModel: SortType) {
         self.label.text = model.title
+        
         if model == selectedModel {
             label.font = .setFont(.t4(weight: .medium))
         } else {
             label.font = .setFont(.t4(weight: .light))
+        }
+        
+        #warning("인기 순은 delegate 안 보냄 추후 업데이트 이후 해제 ")
+        if model == .popular {
+            label.textColor = DesignSystemAsset.BlueGrayColor.gray400.color
         }
 
         checkImageView.isHidden = model != selectedModel

--- a/Projects/Features/SearchFeature/Sources/View/SearchSortOptionCell.swift
+++ b/Projects/Features/SearchFeature/Sources/View/SearchSortOptionCell.swift
@@ -49,13 +49,13 @@ extension SearchSortOptionCell {
 
     public func update(_ model: SortType, _ selectedModel: SortType) {
         self.label.text = model.title
-        
+
         if model == selectedModel {
             label.font = .setFont(.t4(weight: .medium))
         } else {
             label.font = .setFont(.t4(weight: .light))
         }
-        
+
         #warning("인기 순은 delegate 안 보냄 추후 업데이트 이후 해제 ")
         if model == .popular {
             label.textColor = DesignSystemAsset.BlueGrayColor.gray400.color

--- a/Projects/Features/SearchFeature/Sources/View/SongResultCell.swift
+++ b/Projects/Features/SearchFeature/Sources/View/SongResultCell.swift
@@ -99,5 +99,6 @@ extension SongResultCell {
         titleLabel.text = model.title
         artistLabel.text = model.artist
         dateLabel.text = model.date
+        self.contentView.backgroundColor = model.isSelected ? DesignSystemAsset.BlueGrayColor.gray200.color : .clear
     }
 }

--- a/Projects/Features/SearchFeature/Sources/View/SongResultCell.swift
+++ b/Projects/Features/SearchFeature/Sources/View/SongResultCell.swift
@@ -67,7 +67,7 @@ extension SongResultCell {
             $0.width.equalTo(72)
             $0.height.equalTo(40)
             $0.top.bottom.equalToSuperview().inset(10)
-            $0.leading.equalToSuperview()
+            $0.leading.equalToSuperview().inset(20)
         }
 
         titleLabel.snp.makeConstraints {
@@ -85,7 +85,7 @@ extension SongResultCell {
         dateLabel.snp.makeConstraints {
             $0.width.equalTo(70)
             $0.centerY.equalTo(thumbnailView.snp.centerY)
-            $0.trailing.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(20)
             $0.leading.equalTo(titleLabel.snp.trailing).offset(8)
         }
     }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
@@ -339,7 +339,7 @@ extension BeforeSearchContentViewController: BeforeSearchSectionHeaderViewDelega
             case .recommend:
                 self.navigationController?.pushViewController(wakmusicRecommendComponent.makeView(), animated: true)
             case .popularList:
-#warning("추후 업데이트 시 사용")
+                #warning("추후 업데이트 시 사용")
                 break
             }
         }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/BeforeSearchContentViewController.swift
@@ -333,13 +333,13 @@ extension BeforeSearchContentViewController: UICollectionViewDelegate {
 extension BeforeSearchContentViewController: BeforeSearchSectionHeaderViewDelegate {
     func tap(_ section: Int?) {
         if let section = section, let layoutKind = BeforeSearchSection(rawValue: section) {
-            #warning("네비게이션 연결")
             switch layoutKind {
             case .youtube:
                 break
             case .recommend:
                 self.navigationController?.pushViewController(wakmusicRecommendComponent.makeView(), animated: true)
             case .popularList:
+#warning("추후 업데이트 시 사용")
                 break
             }
         }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -183,11 +183,7 @@ extension ListSearchResultViewController {
         let dataSource = UICollectionViewDiffableDataSource<
             ListSearchResultSection,
             SearchPlaylistEntity
-        >(collectionView: collectionView) { (
-            collectionView: UICollectionView,
-            indexPath: IndexPath,
-            item: SearchPlaylistEntity
-        ) -> UICollectionViewCell? in
+        >(collectionView: collectionView) { ( collectionView: UICollectionView, indexPath: IndexPath, item: SearchPlaylistEntity ) -> UICollectionViewCell? in
 
             return collectionView.dequeueConfiguredReusableCell(
                 using: cellRegistration,

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -183,7 +183,11 @@ extension ListSearchResultViewController {
         let dataSource = UICollectionViewDiffableDataSource<
             ListSearchResultSection,
             SearchPlaylistEntity
-        >(collectionView: collectionView) { ( collectionView: UICollectionView, indexPath: IndexPath, item: SearchPlaylistEntity ) -> UICollectionViewCell? in
+        >(collectionView: collectionView) { (
+            collectionView: UICollectionView,
+            indexPath: IndexPath,
+            item: SearchPlaylistEntity
+        ) -> UICollectionViewCell? in
 
             return collectionView.dequeueConfiguredReusableCell(
                 using: cellRegistration,

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -150,11 +150,11 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
         headerView.snp.makeConstraints {
             $0.height.equalTo(30)
             $0.top.equalToSuperview().offset(72) // 56 + 16
-            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview()
         }
 
         collectionView.snp.makeConstraints {
-            $0.top.equalTo(headerView.snp.bottom)
+            $0.top.equalTo(headerView.snp.bottom).offset(8)
             $0.bottom.horizontalEdges.equalToSuperview()
         }
     }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchSortOptionViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchSortOptionViewController.swift
@@ -100,12 +100,11 @@ extension SearchSortOptionViewController {
             .map(\.row)
             .bind(with: self) { owner, index in
 
-                    owner.dismiss(animated: true) {
-                        #warning("인기 순은 delegate 안 보냄 추후 업데이트 이후 해제 ")
-                        if index == 3 { return }
-                        owner.delegate?.updateSortType(owner.options[index])
-                    }
-                
+                owner.dismiss(animated: true) {
+                    #warning("인기 순은 delegate 안 보냄 추후 업데이트 이후 해제 ")
+                    if index == 3 { return }
+                    owner.delegate?.updateSortType(owner.options[index])
+                }
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchSortOptionViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchSortOptionViewController.swift
@@ -16,7 +16,7 @@ final class SearchSortOptionViewController: BaseViewController {
 
     private var disposeBag = DisposeBag()
 
-    private let options: [SortType] = [.latest, .oldest, .alphabetical]
+    private let options: [SortType] = [.latest, .oldest, .alphabetical, .popular]
 
     private var selectedModel: SortType
 
@@ -100,8 +100,12 @@ extension SearchSortOptionViewController {
             .map(\.row)
             .bind(with: self) { owner, index in
 
-                owner.delegate?.updateSortType(owner.options[index])
-                owner.dismiss(animated: true)
+                    owner.dismiss(animated: true) {
+                        #warning("인기 순은 delegate 안 보냄 추후 업데이트 이후 해제 ")
+                        if index == 3 { return }
+                        owner.delegate?.updateSortType(owner.options[index])
+                    }
+                
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -191,7 +191,7 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
         }
 
         collectionView.snp.makeConstraints {
-            $0.top.equalTo(headerView.snp.bottom).offset(16)
+            $0.top.equalTo(headerView.snp.bottom).offset(8)
             $0.bottom.horizontalEdges.equalToSuperview()
         }
     }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -1,4 +1,5 @@
 import BaseFeature
+import BaseFeatureInterface
 import DesignSystem
 import LogManager
 import RxCocoa
@@ -9,7 +10,6 @@ import SongsDomainInterface
 import Then
 import UIKit
 import Utility
-import BaseFeatureInterface
 
 #warning("오버 스크롤 처리")
 final class SongSearchResultViewController: BaseReactorViewController<SongSearchResultReactor>, SongCartViewType {
@@ -18,7 +18,7 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
     var bottomSheetView: BottomSheetView!
 
     private let containSongsFactory: any ContainSongsFactory
-    
+
     private let searchSortOptionComponent: SearchSortOptionComponent
 
     private lazy var collectionView: UICollectionView = createCollectionView().then {
@@ -32,7 +32,11 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
         SongEntity
     > = createDataSource()
 
-    init(_ reactor: SongSearchResultReactor,searchSortOptionComponent: SearchSortOptionComponent, containSongsFactory: any ContainSongsFactory) {
+    init(
+        _ reactor: SongSearchResultReactor,
+        searchSortOptionComponent: SearchSortOptionComponent,
+        containSongsFactory: any ContainSongsFactory
+    ) {
         self.searchSortOptionComponent = searchSortOptionComponent
         self.containSongsFactory = containSongsFactory
         super.init(reactor: reactor)
@@ -43,7 +47,7 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
         self.view.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
         reactor?.action.onNext(.viewDidLoad)
     }
-    
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         reactor?.action.onNext(.deselectAll)
@@ -148,12 +152,12 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
                 }
             }
             .disposed(by: disposeBag)
-        
+
         sharedState.map(\.selectedCount)
             .distinctUntilChanged()
-            .withLatestFrom(sharedState.map(\.dataSource)){($0,$1)}
+            .withLatestFrom(sharedState.map(\.dataSource)) { ($0, $1) }
             .bind(with: self) { owner, info in
-                
+
                 let (count, limit) = (info.0, info.1.count)
 
                 if count == .zero {
@@ -170,7 +174,6 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
                 }
             }
             .disposed(by: disposeBag)
-        
     }
 
     override func addView() {
@@ -227,7 +230,6 @@ extension SongSearchResultViewController {
                 for: indexPath,
                 item: item
             )
-            
         }
 
         return dataSource
@@ -252,13 +254,12 @@ extension SongSearchResultViewController: SearchSortOptionDelegate {
 
 extension SongSearchResultViewController: SongCartViewDelegate {
     func buttonTapped(type: SongCartSelectType) {
-        
         guard let reactor = reactor else {
             return
         }
 
         let currentState = reactor.currentState
-         
+
         switch type {
         case let .allSelect(flag: flag):
             break
@@ -266,7 +267,7 @@ extension SongSearchResultViewController: SongCartViewDelegate {
             let vc = containSongsFactory.makeView(songs: currentState.dataSource.filter { $0.isSelected }.map { $0.id })
             vc.modalPresentationStyle = .overFullScreen
             self.present(vc, animated: true)
-        
+
         case .addPlayList:
             #warning("재생목록 관련 구현체 구현 시 추가")
             break
@@ -276,8 +277,7 @@ extension SongSearchResultViewController: SongCartViewDelegate {
         case .remove:
             break
         }
-        
+
         reactor.action.onNext(.deselectAll)
     }
-    
 }


### PR DESCRIPTION
## 💡 배경 및 개요

곡 검색 결과 화면 songCart를 연결합니다.

Resolves: #755 

## 📃 작업내용

- songCart 연결하고 동작을 확인합니다.
- 검색 결과 화면 클릭 범위가 양쪽 20씩 빠져있는걸 해결했습니다.

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
