### PR TITLE
🔀 :: (#758) 비로그인 상태로 열매 뽑기 화면 진입 시 크래쉬

### DIFF
--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -19,6 +19,7 @@ final class MyInfoReactor: Reactor {
         case settingNavigationDidTap
         case changedUserInfo(UserInfo?)
         case changedReadNoticeIDs([Int])
+        case requiredLogin
     }
 
     enum Mutation {
@@ -40,6 +41,7 @@ final class MyInfoReactor: Reactor {
         case mail
         case team
         case setting
+        case login
     }
 
     struct State {
@@ -101,6 +103,8 @@ final class MyInfoReactor: Reactor {
             )
         case let .changedReadNoticeIDs(readIDs):
             return updateIsAllNoticesRead(readIDs)
+        case .requiredLogin:
+            return navigateLogin()
         }
     }
 
@@ -218,5 +222,9 @@ private extension MyInfoReactor {
 
     func settingNavigationDidTap() -> Observable<Mutation> {
         return .just(.navigate(.setting))
+    }
+
+    func navigateLogin() -> Observable<Mutation> {
+        return .just(.navigate(.login))
     }
 }

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -140,40 +140,14 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
                         viewController.modalPresentationStyle = .fullScreen
                         owner.present(viewController, animated: true)
                     } else {
-                        let vc = owner.textPopUpFactory.makeView(
-                            text: "로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?",
-                            cancelButtonIsHidden: false,
-                            confirmButtonText: nil,
-                            cancelButtonText: nil,
-                            completion: {
-                                let loginVC = owner.signInFactory.makeView()
-                                loginVC.modalPresentationStyle = .fullScreen
-                                owner.present(loginVC, animated: true)
-                            },
-                            cancelCompletion: {}
-                        )
-                        owner.showBottomSheet(content: vc)
+                        reactor.action.onNext(.requiredLogin)
                     }
                 case .fruit:
                     if reactor.currentState.isLoggedIn {
                         let viewController = owner.fruitStorageFactory.makeView()
                         owner.navigationController?.pushViewController(viewController, animated: true)
                     } else {
-                        guard let vc = owner.textPopUpFactory.makeView(
-                            text: "로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?",
-                            cancelButtonIsHidden: false,
-                            confirmButtonText: nil,
-                            cancelButtonText: nil,
-                            completion: {
-                                let loginVC = owner.signInFactory.makeView()
-                                loginVC.modalPresentationStyle = .fullScreen
-                                owner.present(loginVC, animated: true)
-                            },
-                            cancelCompletion: {}
-                        ) as? TextPopupViewController else {
-                            return
-                        }
-                        owner.showBottomSheet(content: vc)
+                        reactor.action.onNext(.requiredLogin)
                     }
                 case .faq:
                     let vc = owner.faqFactory.makeView()
@@ -191,6 +165,20 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
                 case .setting:
                     let vc = owner.settingFactory.makeView()
                     owner.navigationController?.pushViewController(vc, animated: true)
+                case .login:
+                    let vc = owner.textPopUpFactory.makeView(
+                        text: "로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?",
+                        cancelButtonIsHidden: false,
+                        confirmButtonText: nil,
+                        cancelButtonText: nil,
+                        completion: {
+                            let loginVC = owner.signInFactory.makeView()
+                            loginVC.modalPresentationStyle = .fullScreen
+                            owner.present(loginVC, animated: true)
+                        },
+                        cancelCompletion: {}
+                    )
+                    owner.showBottomSheet(content: vc)
                 }
             }
             .disposed(by: disposeBag)

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -135,9 +135,25 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
             .bind(with: self) { owner, navigate in
                 switch navigate {
                 case .draw:
-                    let viewController = owner.fruitDrawFactory.makeView(delegate: owner)
-                    viewController.modalPresentationStyle = .fullScreen
-                    owner.present(viewController, animated: true)
+                    if reactor.currentState.isLoggedIn {
+                        let viewController = owner.fruitDrawFactory.makeView(delegate: owner)
+                        viewController.modalPresentationStyle = .fullScreen
+                        owner.present(viewController, animated: true)
+                    } else {
+                        let vc = owner.textPopUpFactory.makeView(
+                            text: "로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?",
+                            cancelButtonIsHidden: false,
+                            confirmButtonText: nil,
+                            cancelButtonText: nil,
+                            completion: {
+                                let loginVC = owner.signInFactory.makeView()
+                                loginVC.modalPresentationStyle = .fullScreen
+                                owner.present(loginVC, animated: true)
+                            },
+                            cancelCompletion: {}
+                        )
+                        owner.showBottomSheet(content: vc)
+                    }
                 case .fruit:
                     if reactor.currentState.isLoggedIn {
                         let viewController = owner.fruitStorageFactory.makeView()


### PR DESCRIPTION
## 💡 배경 및 개요
- 로그인 필수 화면에 비로그인으로 접근하여 앱 종료 됨

Resolves: #758 

## 📃 작업내용
- 로그인 체크 조건 추가
- 로그인 코드 중복으로 인해 reactor action으로 보냄

## 🙋‍♂️ 리뷰노트
x

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
