### PR TITLE
🔀 :: (#757) 검색에서 스크롤 올릴 때 pinned Header 걸치기 

### DIFF
--- a/Projects/App/Sources/Application/AppComponent+Search.swift
+++ b/Projects/App/Sources/Application/AppComponent+Search.swift
@@ -5,14 +5,12 @@ import SearchFeature
 import SearchFeatureInterface
 
 extension AppComponent {
-    
     var searchGlobalScrollState: any SearchGlobalScrollPortocol {
         shared {
             SearchGlobalScrollState()
         }
     }
 
-    
     var searchFactory: any SearchFactory {
         SearchComponent(parent: self)
     }

--- a/Projects/App/Sources/Application/AppComponent+Search.swift
+++ b/Projects/App/Sources/Application/AppComponent+Search.swift
@@ -5,6 +5,14 @@ import SearchFeature
 import SearchFeatureInterface
 
 extension AppComponent {
+    
+    var searchGlobalScrollState: any SearchGlobalScrollPortocol {
+        shared {
+            SearchGlobalScrollState()
+        }
+    }
+
+    
     var searchFactory: any SearchFactory {
         SearchComponent(parent: self)
     }

--- a/Projects/App/Sources/Application/AppComponent+Search.swift
+++ b/Projects/App/Sources/Application/AppComponent+Search.swift
@@ -5,7 +5,7 @@ import SearchFeature
 import SearchFeatureInterface
 
 extension AppComponent {
-    var searchGlobalScrollState: any SearchGlobalScrollPortocol {
+    var searchGlobalScrollState: any SearchGlobalScrollProtocol {
         shared {
             SearchGlobalScrollState()
         }

--- a/Projects/Features/SearchFeature/Resources/Search.storyboard
+++ b/Projects/Features/SearchFeature/Resources/Search.storyboard
@@ -20,13 +20,14 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e54-rK-aGI">
                                 <rect key="frame" x="0.0" y="59" width="393" height="16"/>
+                                <color key="backgroundColor" name="blueGray800"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="16" id="nJ5-2M-ZsW"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5nx-1t-MMz">
                                 <rect key="frame" x="0.0" y="75" width="393" height="36"/>
-                                <color key="backgroundColor" name="gray100"/>
+                                <color key="backgroundColor" name="blueGray800"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="36" id="ykE-p1-BQh"/>
                                 </constraints>
@@ -73,7 +74,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nj5-Rh-R0O">
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="115"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yLy-ME-gxl" userLabel="SearchHeaderView" customClass="SearchHeaderView">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yLy-ME-gxl" userLabel="SearchHeaderView">
                                         <rect key="frame" x="0.0" y="59" width="393" height="56"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="DMe-Vm-2cg">
@@ -148,7 +149,9 @@
                         <outlet property="cancelButton" destination="pwf-8T-rR0" id="ydM-fP-bdc"/>
                         <outlet property="contentView" destination="jLC-fz-G5h" id="v7E-Mr-1a8"/>
                         <outlet property="contentViewBottomConstraint" destination="znF-Ya-K6h" id="gP4-l4-S2x"/>
+                        <outlet property="searchHeaderContentView" destination="yLy-ME-gxl" id="CqP-Pw-x7T"/>
                         <outlet property="searchHeaderView" destination="nj5-Rh-R0O" id="evQ-ZJ-eOe"/>
+                        <outlet property="searchHeaderViewTopConstraint" destination="2dP-Eo-Ia3" id="SKg-lp-3WO"/>
                         <outlet property="searchImageView" destination="DMe-Vm-2cg" id="oFs-eJ-DKi"/>
                         <outlet property="searchTextFiled" destination="VJU-GJ-8b6" id="qs0-yr-rIP"/>
                     </connections>
@@ -159,6 +162,9 @@
         </scene>
     </scenes>
     <resources>
+        <namedColor name="blueGray800">
+            <color red="0.11372549019607843" green="0.16078431372549021" blue="0.22352941176470589" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <namedColor name="gray100">
             <color red="0.94900000095367432" green="0.9570000171661377" blue="0.96899998188018799" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Projects/Features/SearchFeature/Resources/Search.storyboard
+++ b/Projects/Features/SearchFeature/Resources/Search.storyboard
@@ -20,14 +20,14 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e54-rK-aGI">
                                 <rect key="frame" x="0.0" y="59" width="393" height="16"/>
-                                <color key="backgroundColor" name="blueGray800"/>
+                                <color key="backgroundColor" name="blueGray100"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="16" id="nJ5-2M-ZsW"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5nx-1t-MMz">
                                 <rect key="frame" x="0.0" y="75" width="393" height="36"/>
-                                <color key="backgroundColor" name="blueGray800"/>
+                                <color key="backgroundColor" name="blueGray100"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="36" id="ykE-p1-BQh"/>
                                 </constraints>
@@ -162,8 +162,8 @@
         </scene>
     </scenes>
     <resources>
-        <namedColor name="blueGray800">
-            <color red="0.11372549019607843" green="0.16078431372549021" blue="0.22352941176470589" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <namedColor name="blueGray100">
+            <color red="0.94900000095367432" green="0.9570000171661377" blue="0.96899998188018799" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="gray100">
             <color red="0.94900000095367432" green="0.9570000171661377" blue="0.96899998188018799" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Projects/Features/SearchFeature/Sources/Components/AfterSearchComponent.swift
+++ b/Projects/Features/SearchFeature/Sources/Components/AfterSearchComponent.swift
@@ -8,6 +8,7 @@ import SongsDomainInterface
 public protocol AfterSearchDependency: Dependency {
     var songSearchResultFactory: any SongSearchResultFactory { get }
     var listSearchResultFactory: any ListSearchResultFactory { get }
+    var searchGlobalScrollState: any SearchGlobalScrollPortocol { get }
 }
 
 public final class AfterSearchComponent: Component<AfterSearchDependency> {
@@ -15,6 +16,7 @@ public final class AfterSearchComponent: Component<AfterSearchDependency> {
         return AfterSearchViewController.viewController(
             songSearchResultFactory: dependency.songSearchResultFactory,
             listSearchResultFactory: dependency.listSearchResultFactory,
+            searchGlobalScrollState: dependency.searchGlobalScrollState,
             reactor: .init(text: text)
         )
     }

--- a/Projects/Features/SearchFeature/Sources/Components/AfterSearchComponent.swift
+++ b/Projects/Features/SearchFeature/Sources/Components/AfterSearchComponent.swift
@@ -8,7 +8,7 @@ import SongsDomainInterface
 public protocol AfterSearchDependency: Dependency {
     var songSearchResultFactory: any SongSearchResultFactory { get }
     var listSearchResultFactory: any ListSearchResultFactory { get }
-    var searchGlobalScrollState: any SearchGlobalScrollPortocol { get }
+    var searchGlobalScrollState: any SearchGlobalScrollProtocol { get }
 }
 
 public final class AfterSearchComponent: Component<AfterSearchDependency> {

--- a/Projects/Features/SearchFeature/Sources/Components/ListSearchResultComponent.swift
+++ b/Projects/Features/SearchFeature/Sources/Components/ListSearchResultComponent.swift
@@ -11,7 +11,7 @@ public protocol ListSearchResultDependency: Dependency {
     var fetchSearchPlaylistsUseCase: any FetchSearchPlaylistsUseCase { get }
     var searchSortOptionComponent: SearchSortOptionComponent { get }
     var playlistDetailFactory: any PlaylistDetailFactory { get }
-    var searchGlobalScrollState: any SearchGlobalScrollPortocol { get }
+    var searchGlobalScrollState: any SearchGlobalScrollProtocol { get }
 }
 
 public final class ListSearchResultComponent: Component<ListSearchResultDependency>, ListSearchResultFactory {

--- a/Projects/Features/SearchFeature/Sources/Components/ListSearchResultComponent.swift
+++ b/Projects/Features/SearchFeature/Sources/Components/ListSearchResultComponent.swift
@@ -11,6 +11,7 @@ public protocol ListSearchResultDependency: Dependency {
     var fetchSearchPlaylistsUseCase: any FetchSearchPlaylistsUseCase { get }
     var searchSortOptionComponent: SearchSortOptionComponent { get }
     var playlistDetailFactory: any PlaylistDetailFactory { get }
+    var searchGlobalScrollState: any SearchGlobalScrollPortocol { get }
 }
 
 public final class ListSearchResultComponent: Component<ListSearchResultDependency>, ListSearchResultFactory {
@@ -21,7 +22,8 @@ public final class ListSearchResultComponent: Component<ListSearchResultDependen
                 fetchSearchPlaylistsUseCase: dependency.fetchSearchPlaylistsUseCase
             ),
             searchSortOptionComponent: dependency.searchSortOptionComponent,
-            playlistDetailFactory: dependency.playlistDetailFactory
+            playlistDetailFactory: dependency.playlistDetailFactory,
+            searchGlobalScrollState: dependency.searchGlobalScrollState
         )
     }
 }

--- a/Projects/Features/SearchFeature/Sources/Components/SearchComponent.swift
+++ b/Projects/Features/SearchFeature/Sources/Components/SearchComponent.swift
@@ -8,7 +8,7 @@ public protocol SearchDependency: Dependency {
     var beforeSearchComponent: BeforeSearchComponent { get }
     var afterSearchComponent: AfterSearchComponent { get }
     var textPopUpFactory: any TextPopUpFactory { get }
-    var searchGlobalScrollState: any SearchGlobalScrollPortocol { get }
+    var searchGlobalScrollState: any SearchGlobalScrollProtocol { get }
 }
 
 public final class SearchComponent: Component<SearchDependency>, SearchFactory {

--- a/Projects/Features/SearchFeature/Sources/Components/SearchComponent.swift
+++ b/Projects/Features/SearchFeature/Sources/Components/SearchComponent.swift
@@ -8,6 +8,7 @@ public protocol SearchDependency: Dependency {
     var beforeSearchComponent: BeforeSearchComponent { get }
     var afterSearchComponent: AfterSearchComponent { get }
     var textPopUpFactory: any TextPopUpFactory { get }
+    var searchGlobalScrollState: any SearchGlobalScrollPortocol { get }
 }
 
 public final class SearchComponent: Component<SearchDependency>, SearchFactory {
@@ -16,7 +17,8 @@ public final class SearchComponent: Component<SearchDependency>, SearchFactory {
             reactor: SearchReactor(),
             beforeSearchComponent: self.dependency.beforeSearchComponent,
             afterSearchComponent: self.dependency.afterSearchComponent,
-            textPopUpFactory: dependency.textPopUpFactory
+            textPopUpFactory: dependency.textPopUpFactory,
+            searchGlobalScrollState: dependency.searchGlobalScrollState
         )
     }
 }

--- a/Projects/Features/SearchFeature/Sources/Components/SongSearchResultComponent.swift
+++ b/Projects/Features/SearchFeature/Sources/Components/SongSearchResultComponent.swift
@@ -10,6 +10,7 @@ public protocol SongSearchResultDependency: Dependency {
     var fetchSearchSongsUseCase: any FetchSearchSongsUseCase { get }
     var searchSortOptionComponent: SearchSortOptionComponent { get }
     var containSongsFactory: any ContainSongsFactory { get }
+    var searchGlobalScrollState: any SearchGlobalScrollPortocol { get }
 }
 
 public final class SongSearchResultComponent: Component<SongSearchResultDependency>, SongSearchResultFactory {
@@ -20,7 +21,8 @@ public final class SongSearchResultComponent: Component<SongSearchResultDependen
                 fetchSearchSongsUseCase: dependency.fetchSearchSongsUseCase
             ),
             searchSortOptionComponent: dependency.searchSortOptionComponent,
-            containSongsFactory: dependency.containSongsFactory
+            containSongsFactory: dependency.containSongsFactory,
+            searchGlobalScrollState: dependency.searchGlobalScrollState
         )
     }
 }

--- a/Projects/Features/SearchFeature/Sources/Components/SongSearchResultComponent.swift
+++ b/Projects/Features/SearchFeature/Sources/Components/SongSearchResultComponent.swift
@@ -10,7 +10,7 @@ public protocol SongSearchResultDependency: Dependency {
     var fetchSearchSongsUseCase: any FetchSearchSongsUseCase { get }
     var searchSortOptionComponent: SearchSortOptionComponent { get }
     var containSongsFactory: any ContainSongsFactory { get }
-    var searchGlobalScrollState: any SearchGlobalScrollPortocol { get }
+    var searchGlobalScrollState: any SearchGlobalScrollProtocol { get }
 }
 
 public final class SongSearchResultComponent: Component<SongSearchResultDependency>, SongSearchResultFactory {

--- a/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
+++ b/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
@@ -9,7 +9,7 @@ public enum SearchResultPage {
 public protocol SearchGlobalScrollPortocol {
     var scrollAmountObservable: Observable<(CGFloat, CGFloat)> { get }
     var expandSearchHeaderObservable: Observable<Void> { get }
-    
+
     var songResultScrollToTopObservable: Observable<Void> { get }
     var listResultScrollToTopObservable: Observable<Void> { get }
 
@@ -19,7 +19,6 @@ public protocol SearchGlobalScrollPortocol {
 }
 
 public final class SearchGlobalScrollState: SearchGlobalScrollPortocol {
-    
     private let scrollAmountSubject = PublishSubject<(CGFloat, CGFloat)>()
     private let expandSearchHeaderSubject = PublishSubject<Void>()
     private let songResultScrollToTopSubject = PublishSubject<Void>()
@@ -42,23 +41,21 @@ public final class SearchGlobalScrollState: SearchGlobalScrollPortocol {
     public func expand() {
         expandSearchHeaderSubject.onNext(())
     }
-    
+
     public var songResultScrollToTopObservable: Observable<Void> {
         songResultScrollToTopSubject
     }
-    
+
     public var listResultScrollToTopObservable: Observable<Void> {
         listResultScrollToTopSubject
     }
-    
+
     public func scrollToTop(page: SearchResultPage) {
-        
         switch page {
         case .song:
             songResultScrollToTopSubject.onNext(())
         case .list:
             listResultScrollToTopSubject.onNext(())
         }
-        
     }
 }

--- a/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
+++ b/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
@@ -7,14 +7,12 @@ public protocol SearchGlobalScrollPortocol {
 
     func scrollTo(amount: CGFloat)
     func expand()
-
 }
 
 public final class SearchGlobalScrollState: SearchGlobalScrollPortocol {
-
     private let scrollAmountSubject = PublishSubject<CGFloat>()
     private let expandSearchHeaderSubject = PublishSubject<Void>()
-    
+
     public init() {}
 
     public var scrollAmountObservable: Observable<CGFloat> {
@@ -24,14 +22,12 @@ public final class SearchGlobalScrollState: SearchGlobalScrollPortocol {
     public func scrollTo(amount: CGFloat) {
         scrollAmountSubject.onNext(amount)
     }
-    
+
     public var expandSearchHeaderObservable: Observable<Void> {
         expandSearchHeaderSubject
     }
-    
+
     public func expand() {
         expandSearchHeaderSubject.onNext(())
     }
-    
-
 }

--- a/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
+++ b/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
@@ -6,7 +6,7 @@ public enum SearchResultPage {
     case list
 }
 
-public protocol SearchGlobalScrollPortocol {
+public protocol SearchGlobalScrollProtocol {
     var scrollAmountObservable: Observable<(CGFloat, CGFloat)> { get }
     var expandSearchHeaderObservable: Observable<Void> { get }
 
@@ -18,7 +18,7 @@ public protocol SearchGlobalScrollPortocol {
     func scrollToTop(page: SearchResultPage)
 }
 
-public final class SearchGlobalScrollState: SearchGlobalScrollPortocol {
+public final class SearchGlobalScrollState: SearchGlobalScrollProtocol {
     private let scrollAmountSubject = PublishSubject<(CGFloat, CGFloat)>()
     private let expandSearchHeaderSubject = PublishSubject<Void>()
     private let songResultScrollToTopSubject = PublishSubject<Void>()

--- a/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
+++ b/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
@@ -1,17 +1,29 @@
 import Foundation
 import RxSwift
 
+public enum SearchResultPage {
+    case song
+    case list
+}
+
 public protocol SearchGlobalScrollPortocol {
     var scrollAmountObservable: Observable<(CGFloat, CGFloat)> { get }
     var expandSearchHeaderObservable: Observable<Void> { get }
+    
+    var songResultScrollToTopObservable: Observable<Void> { get }
+    var listResultScrollToTopObservable: Observable<Void> { get }
 
     func scrollTo(source: (CGFloat, CGFloat))
     func expand()
+    func scrollToTop(page: SearchResultPage)
 }
 
 public final class SearchGlobalScrollState: SearchGlobalScrollPortocol {
+    
     private let scrollAmountSubject = PublishSubject<(CGFloat, CGFloat)>()
     private let expandSearchHeaderSubject = PublishSubject<Void>()
+    private let songResultScrollToTopSubject = PublishSubject<Void>()
+    private let listResultScrollToTopSubject = PublishSubject<Void>()
 
     public init() {}
 
@@ -29,5 +41,24 @@ public final class SearchGlobalScrollState: SearchGlobalScrollPortocol {
 
     public func expand() {
         expandSearchHeaderSubject.onNext(())
+    }
+    
+    public var songResultScrollToTopObservable: Observable<Void> {
+        songResultScrollToTopSubject
+    }
+    
+    public var listResultScrollToTopObservable: Observable<Void> {
+        listResultScrollToTopSubject
+    }
+    
+    public func scrollToTop(page: SearchResultPage) {
+        
+        switch page {
+        case .song:
+            songResultScrollToTopSubject.onNext(())
+        case .list:
+            listResultScrollToTopSubject.onNext(())
+        }
+        
     }
 }

--- a/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
+++ b/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
@@ -3,15 +3,17 @@ import RxSwift
 
 public protocol SearchGlobalScrollPortocol {
     var scrollAmountObservable: Observable<CGFloat> { get }
+    var expandSearchHeaderObservable: Observable<Void> { get }
 
     func scrollTo(amount: CGFloat)
+    func expand()
 
 }
 
 public final class SearchGlobalScrollState: SearchGlobalScrollPortocol {
-    
-    private let scrollAmountSubject = PublishSubject<CGFloat>()
 
+    private let scrollAmountSubject = PublishSubject<CGFloat>()
+    private let expandSearchHeaderSubject = PublishSubject<Void>()
     
     public init() {}
 
@@ -21,6 +23,14 @@ public final class SearchGlobalScrollState: SearchGlobalScrollPortocol {
 
     public func scrollTo(amount: CGFloat) {
         scrollAmountSubject.onNext(amount)
+    }
+    
+    public var expandSearchHeaderObservable: Observable<Void> {
+        expandSearchHeaderSubject
+    }
+    
+    public func expand() {
+        expandSearchHeaderSubject.onNext(())
     }
     
 

--- a/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
+++ b/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
@@ -2,25 +2,25 @@ import Foundation
 import RxSwift
 
 public protocol SearchGlobalScrollPortocol {
-    var scrollAmountObservable: Observable<CGFloat> { get }
+    var scrollAmountObservable: Observable<(CGFloat, CGFloat)> { get }
     var expandSearchHeaderObservable: Observable<Void> { get }
 
-    func scrollTo(amount: CGFloat)
+    func scrollTo(source: (CGFloat, CGFloat))
     func expand()
 }
 
 public final class SearchGlobalScrollState: SearchGlobalScrollPortocol {
-    private let scrollAmountSubject = PublishSubject<CGFloat>()
+    private let scrollAmountSubject = PublishSubject<(CGFloat, CGFloat)>()
     private let expandSearchHeaderSubject = PublishSubject<Void>()
 
     public init() {}
 
-    public var scrollAmountObservable: Observable<CGFloat> {
+    public var scrollAmountObservable: Observable<(CGFloat, CGFloat)> {
         scrollAmountSubject
     }
 
-    public func scrollTo(amount: CGFloat) {
-        scrollAmountSubject.onNext(amount)
+    public func scrollTo(source: (CGFloat, CGFloat)) {
+        scrollAmountSubject.onNext(source)
     }
 
     public var expandSearchHeaderObservable: Observable<Void> {

--- a/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
+++ b/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
@@ -1,0 +1,26 @@
+import RxSwift
+import Foundation
+
+public protocol SearchGlobalScrollPortocol {
+    var scrollAmountObservable: Observable<CGFloat> { get }
+    
+    func scrollTo(_ amount: CGFloat) 
+}
+
+
+public final class SearchGlobalScrollState: SearchGlobalScrollPortocol {
+    
+    private let scrollAmountSubject = PublishSubject<CGFloat>()
+    
+    public init() {}
+    
+    public var scrollAmountObservable: Observable<CGFloat> {
+        scrollAmountSubject
+    }
+    
+    public func scrollTo(_ amount: CGFloat) {
+        scrollAmountSubject.onNext(amount)
+    }
+    
+    
+}

--- a/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
+++ b/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
@@ -1,26 +1,22 @@
-import RxSwift
 import Foundation
+import RxSwift
 
 public protocol SearchGlobalScrollPortocol {
     var scrollAmountObservable: Observable<CGFloat> { get }
-    
-    func scrollTo(_ amount: CGFloat) 
+
+    func scrollTo(_ amount: CGFloat)
 }
 
-
 public final class SearchGlobalScrollState: SearchGlobalScrollPortocol {
-    
     private let scrollAmountSubject = PublishSubject<CGFloat>()
-    
+
     public init() {}
-    
+
     public var scrollAmountObservable: Observable<CGFloat> {
         scrollAmountSubject
     }
-    
+
     public func scrollTo(_ amount: CGFloat) {
         scrollAmountSubject.onNext(amount)
     }
-    
-    
 }

--- a/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
+++ b/Projects/Features/SearchFeature/Sources/Service/SearchGlobalScrollState.swift
@@ -4,19 +4,24 @@ import RxSwift
 public protocol SearchGlobalScrollPortocol {
     var scrollAmountObservable: Observable<CGFloat> { get }
 
-    func scrollTo(_ amount: CGFloat)
+    func scrollTo(amount: CGFloat)
+
 }
 
 public final class SearchGlobalScrollState: SearchGlobalScrollPortocol {
+    
     private let scrollAmountSubject = PublishSubject<CGFloat>()
 
+    
     public init() {}
 
     public var scrollAmountObservable: Observable<CGFloat> {
         scrollAmountSubject
     }
 
-    public func scrollTo(_ amount: CGFloat) {
+    public func scrollTo(amount: CGFloat) {
         scrollAmountSubject.onNext(amount)
     }
+    
+
 }

--- a/Projects/Features/SearchFeature/Sources/View/ListResultCell.swift
+++ b/Projects/Features/SearchFeature/Sources/View/ListResultCell.swift
@@ -34,11 +34,11 @@ final class ListResultCell: UICollectionViewCell {
         $0.numberOfLines = 1
     }
 
-    private let dateLabel = WMLabel(
+    private let sharedCountLabel = WMLabel(
         text: "",
         textColor: DesignSystemAsset.NewGrayColor.gray900.color,
         font: .sc7(weight: .score3Light),
-        alignment: .left,
+        alignment: .right,
         lineHeight: UIFont.WMFontSystem.t7().lineHeight,
         kernValue: -0.5
     ).then {
@@ -59,7 +59,7 @@ final class ListResultCell: UICollectionViewCell {
 
 extension ListResultCell {
     private func addSubview() {
-        self.contentView.addSubviews(thumbnailView, titleLabel, creatorLabel, dateLabel)
+        self.contentView.addSubviews(thumbnailView, titleLabel, creatorLabel, sharedCountLabel)
     }
 
     private func setLayout() {
@@ -82,8 +82,8 @@ extension ListResultCell {
             $0.bottom.equalTo(thumbnailView.snp.bottom)
         }
 
-        dateLabel.snp.makeConstraints {
-            $0.width.equalTo(70)
+        sharedCountLabel.snp.makeConstraints {
+            $0.width.lessThanOrEqualTo(66)
             $0.centerY.equalTo(thumbnailView.snp.centerY)
             $0.trailing.equalToSuperview().inset(20)
             $0.leading.equalTo(titleLabel.snp.trailing).offset(8)
@@ -93,7 +93,7 @@ extension ListResultCell {
     public func update(_ model: SearchPlaylistEntity) {
         titleLabel.text = model.title
         creatorLabel.text = model.userName
-        dateLabel.text = model.date
+        sharedCountLabel.text = model.date
         thumbnailView.kf.setImage(with: URL(string: model.image), placeholder: nil, options: [.transition(.fade(0.2))])
     }
 }

--- a/Projects/Features/SearchFeature/Sources/View/SongResultCell.swift
+++ b/Projects/Features/SearchFeature/Sources/View/SongResultCell.swift
@@ -38,7 +38,7 @@ final class SongResultCell: UICollectionViewCell {
         text: "",
         textColor: DesignSystemAsset.NewGrayColor.gray900.color,
         font: .sc7(weight: .score3Light),
-        alignment: .left,
+        alignment: .right,
         lineHeight: UIFont.WMFontSystem.t7().lineHeight,
         kernValue: -0.5
     ).then {
@@ -83,7 +83,7 @@ extension SongResultCell {
         }
 
         dateLabel.snp.makeConstraints {
-            $0.width.equalTo(70)
+            $0.width.lessThanOrEqualTo(66)
             $0.centerY.equalTo(thumbnailView.snp.centerY)
             $0.trailing.equalToSuperview().inset(20)
             $0.leading.equalTo(titleLabel.snp.trailing).offset(8)

--- a/Projects/Features/SearchFeature/Sources/View/SongResultCell.swift
+++ b/Projects/Features/SearchFeature/Sources/View/SongResultCell.swift
@@ -17,7 +17,7 @@ final class SongResultCell: UICollectionViewCell {
         textColor: DesignSystemAsset.NewGrayColor.gray900.color,
         font: .t6(weight: .medium),
         alignment: .left,
-        lineHeight: UIFont.WMFontSystem.t6().lineHeight,
+        lineHeight: UIFont.WMFontSystem.t6(weight: .medium).lineHeight,
         kernValue: -0.5
     ).then {
         $0.numberOfLines = 1

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
@@ -45,14 +45,14 @@ public final class AfterSearchViewController: TabmanViewController, ViewControll
         viewController.reactor = reactor
         return viewController
     }
-    
+
     override public func pageboyViewController(
-            _ pageboyViewController: PageboyViewController,
-            didScrollToPageAt index: TabmanViewController.PageIndex,
-            direction: PageboyViewController.NavigationDirection,
-            animated: Bool
-        ) {
-            searchGlobalScrollState.expand()
+        _ pageboyViewController: PageboyViewController,
+        didScrollToPageAt index: TabmanViewController.PageIndex,
+        direction: PageboyViewController.NavigationDirection,
+        animated: Bool
+    ) {
+        searchGlobalScrollState.expand()
     }
 
     deinit {
@@ -130,8 +130,7 @@ extension AfterSearchViewController: PageboyViewControllerDataSource, TMBarDataS
         for pageboyViewController: Pageboy.PageboyViewController,
         at index: Pageboy.PageboyViewController.PageIndex
     ) -> UIViewController? {
-        
-         viewControllers[index]
+        viewControllers[index]
     }
 
     public func defaultPage(for pageboyViewController: Pageboy.PageboyViewController) -> Pageboy.PageboyViewController

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
@@ -74,7 +74,7 @@ extension AfterSearchViewController {
     func bindAction(reactor: AfterSearchReactor) {}
 
     private func configureUI() {
-        self.fakeView.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
+    //    self.fakeView.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
         self.indicator.type = .circleStrokeSpin
         self.indicator.color = DesignSystemAsset.PrimaryColorV2.point.color
         self.dataSource = self // dateSource

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
@@ -19,6 +19,7 @@ public final class AfterSearchViewController: TabmanViewController, ViewControll
 
     private var songSearchResultFactory: SongSearchResultFactory!
     private var listSearchResultFactory: ListSearchResultFactory!
+    private var searchGlobalScrollState: SearchGlobalScrollPortocol!
     public var disposeBag = DisposeBag()
 
     private var viewControllers: [UIViewController] = [
@@ -34,11 +35,13 @@ public final class AfterSearchViewController: TabmanViewController, ViewControll
     public static func viewController(
         songSearchResultFactory: SongSearchResultFactory,
         listSearchResultFactory: ListSearchResultFactory,
+        searchGlobalScrollState: any SearchGlobalScrollPortocol,
         reactor: AfterSearchReactor
     ) -> AfterSearchViewController {
         let viewController = AfterSearchViewController.viewController(storyBoardName: "Search", bundle: Bundle.module)
         viewController.songSearchResultFactory = songSearchResultFactory
         viewController.listSearchResultFactory = listSearchResultFactory
+        viewController.searchGlobalScrollState = searchGlobalScrollState
         viewController.reactor = reactor
         return viewController
     }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
@@ -45,6 +45,8 @@ public final class AfterSearchViewController: TabmanViewController, ViewControll
         viewController.reactor = reactor
         return viewController
     }
+    
+
 
     deinit {
         DEBUG_LOG("❌ \(Self.self)")
@@ -59,7 +61,7 @@ public final class AfterSearchViewController: TabmanViewController, ViewControll
 extension AfterSearchViewController {
     func bindState(reacotr: AfterSearchReactor) {
         let currentState = reacotr.state.share()
-        #warning("첫 진입 시 text가 안내려옴 바인딩이 안되서")
+       
         currentState.map(\.text)
             .filter { !$0.isEmpty }
             .distinctUntilChanged()
@@ -144,10 +146,10 @@ extension AfterSearchViewController: PageboyViewControllerDataSource, TMBarDataS
 
 extension AfterSearchViewController {
     func scrollToTop() {
-        #warning("구현이 끝난 후 연결")
-//        let current: Int = self.currentIndex ?? 0
-//        let searchContent = self.viewControllers.compactMap { $0 as? AfterSearchContentViewController }
-//        guard searchContent.count > current else { return }
-//        searchContent[current].scrollToTop()
+
+        let current: Int = self.currentIndex ?? 0
+        
+        searchGlobalScrollState.scrollToTop(page: current == 0 ? .song : .list)
+        
     }
 }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
@@ -45,8 +45,6 @@ public final class AfterSearchViewController: TabmanViewController, ViewControll
         viewController.reactor = reactor
         return viewController
     }
-    
-
 
     deinit {
         DEBUG_LOG("❌ \(Self.self)")
@@ -61,7 +59,7 @@ public final class AfterSearchViewController: TabmanViewController, ViewControll
 extension AfterSearchViewController {
     func bindState(reacotr: AfterSearchReactor) {
         let currentState = reacotr.state.share()
-       
+
         currentState.map(\.text)
             .filter { !$0.isEmpty }
             .distinctUntilChanged()
@@ -146,10 +144,8 @@ extension AfterSearchViewController: PageboyViewControllerDataSource, TMBarDataS
 
 extension AfterSearchViewController {
     func scrollToTop() {
-
         let current: Int = self.currentIndex ?? 0
-        
+
         searchGlobalScrollState.scrollToTop(page: current == 0 ? .song : .list)
-        
     }
 }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
@@ -74,7 +74,7 @@ extension AfterSearchViewController {
     func bindAction(reactor: AfterSearchReactor) {}
 
     private func configureUI() {
-    //    self.fakeView.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
+        self.fakeView.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
         self.indicator.type = .circleStrokeSpin
         self.indicator.color = DesignSystemAsset.PrimaryColorV2.point.color
         self.dataSource = self // dateSource

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
@@ -121,7 +121,9 @@ extension AfterSearchViewController: PageboyViewControllerDataSource, TMBarDataS
         for pageboyViewController: Pageboy.PageboyViewController,
         at index: Pageboy.PageboyViewController.PageIndex
     ) -> UIViewController? {
-        viewControllers[index]
+        
+        searchGlobalScrollState.expand()
+        return viewControllers[index]
     }
 
     public func defaultPage(for pageboyViewController: Pageboy.PageboyViewController) -> Pageboy.PageboyViewController

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
@@ -19,7 +19,7 @@ public final class AfterSearchViewController: TabmanViewController, ViewControll
 
     private var songSearchResultFactory: SongSearchResultFactory!
     private var listSearchResultFactory: ListSearchResultFactory!
-    private var searchGlobalScrollState: SearchGlobalScrollPortocol!
+    private var searchGlobalScrollState: SearchGlobalScrollProtocol!
     public var disposeBag = DisposeBag()
 
     private var viewControllers: [UIViewController] = [
@@ -35,7 +35,7 @@ public final class AfterSearchViewController: TabmanViewController, ViewControll
     public static func viewController(
         songSearchResultFactory: SongSearchResultFactory,
         listSearchResultFactory: ListSearchResultFactory,
-        searchGlobalScrollState: any SearchGlobalScrollPortocol,
+        searchGlobalScrollState: any SearchGlobalScrollProtocol,
         reactor: AfterSearchReactor
     ) -> AfterSearchViewController {
         let viewController = AfterSearchViewController.viewController(storyBoardName: "Search", bundle: Bundle.module)

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/AfterSearchViewController.swift
@@ -45,6 +45,15 @@ public final class AfterSearchViewController: TabmanViewController, ViewControll
         viewController.reactor = reactor
         return viewController
     }
+    
+    override public func pageboyViewController(
+            _ pageboyViewController: PageboyViewController,
+            didScrollToPageAt index: TabmanViewController.PageIndex,
+            direction: PageboyViewController.NavigationDirection,
+            animated: Bool
+        ) {
+            searchGlobalScrollState.expand()
+    }
 
     deinit {
         DEBUG_LOG("❌ \(Self.self)")
@@ -122,8 +131,7 @@ extension AfterSearchViewController: PageboyViewControllerDataSource, TMBarDataS
         at index: Pageboy.PageboyViewController.PageIndex
     ) -> UIViewController? {
         
-        searchGlobalScrollState.expand()
-        return viewControllers[index]
+         viewControllers[index]
     }
 
     public func defaultPage(for pageboyViewController: Pageboy.PageboyViewController) -> Pageboy.PageboyViewController

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -20,7 +20,7 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
     private let searchSortOptionComponent: SearchSortOptionComponent
     private (set) var playlistDetailFactory: any PlaylistDetailFactory
 
-    private let searchGlobalScrollState: any SearchGlobalScrollPortocol
+    private let searchGlobalScrollState: any SearchGlobalScrollProtocol
 
     private lazy var collectionView: UICollectionView = createCollectionView().then {
         $0.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
@@ -37,7 +37,7 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
         _ reactor: ListSearchResultReactor,
         searchSortOptionComponent: SearchSortOptionComponent,
         playlistDetailFactory: any PlaylistDetailFactory,
-        searchGlobalScrollState: any SearchGlobalScrollPortocol
+        searchGlobalScrollState: any SearchGlobalScrollProtocol
     ) {
         self.searchSortOptionComponent = searchSortOptionComponent
         self.playlistDetailFactory = playlistDetailFactory

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -54,6 +54,7 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
         super.viewDidAppear(animated)
 
         searchGlobalScrollState.expand()
+        collectionView.setContentOffset(.zero, animated: false) // 이게 들어가야 맞는지 잘 모르겠지만 일단 넣음
     }
 
     override func bind(reactor: ListSearchResultReactor) {
@@ -235,8 +236,12 @@ extension ListSearchResultViewController: UICollectionViewDelegate {
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        if collectionView.isVerticallyScrollable {
-            searchGlobalScrollState.scrollTo(amount: scrollView.contentOffset.y)
-        }
+        guard collectionView.isVerticallyScrollable else { return }
+        searchGlobalScrollState.scrollTo(
+            source: (
+                scrollView.contentOffset.y,
+                scrollView.contentSize.height - scrollView.frame.size.height
+            )
+        )
     }
 }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -49,15 +49,13 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
         super.viewDidLoad()
         reactor?.action.onNext(.viewDidLoad)
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
-        searchGlobalScrollState.expand()
-        
 
+        searchGlobalScrollState.expand()
     }
-    
+
     override func bind(reactor: ListSearchResultReactor) {
         super.bind(reactor: reactor)
         collectionView.rx
@@ -148,7 +146,6 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
                     } else {
                         owner.collectionView.restore()
                     }
-                    
                 }
             }
             .disposed(by: disposeBag)
@@ -236,13 +233,10 @@ extension ListSearchResultViewController: UICollectionViewDelegate {
 
         navigatePlaylistDetail(key: model.key, kind: isMine ? .my : .unknown)
     }
-    
+
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        
         if collectionView.isVerticallyScrollable {
             searchGlobalScrollState.scrollTo(amount: scrollView.contentOffset.y)
         }
-        
-        
     }
 }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -50,6 +50,14 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
         reactor?.action.onNext(.viewDidLoad)
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        searchGlobalScrollState.expand()
+        
+
+    }
+    
     override func bind(reactor: ListSearchResultReactor) {
         super.bind(reactor: reactor)
         collectionView.rx
@@ -129,7 +137,7 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
                     snapshot.appendSections([.list])
 
                     snapshot.appendItems(dataSource, toSection: .list)
-                    owner.dataSource.apply(snapshot, animatingDifferences: true)
+                    owner.dataSource.apply(snapshot, animatingDifferences: false)
 
                     let warningView = WMWarningView(
                         text: "검색결과가 없습니다."
@@ -230,6 +238,11 @@ extension ListSearchResultViewController: UICollectionViewDelegate {
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        searchGlobalScrollState.scrollTo(amount: scrollView.contentOffset.y)
+        
+        if collectionView.isVerticallyScrollable {
+            searchGlobalScrollState.scrollTo(amount: scrollView.contentOffset.y)
+        }
+        
+        
     }
 }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -50,12 +50,6 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
         reactor?.action.onNext(.viewDidLoad)
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        searchGlobalScrollState.expand()
-    }
-
     override func bind(reactor: ListSearchResultReactor) {
         super.bind(reactor: reactor)
         collectionView.rx

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -61,16 +61,14 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
         collectionView.rx
             .setDelegate(self)
             .disposed(by: disposeBag)
-        
+
         searchGlobalScrollState.listResultScrollToTopObservable
             .observe(on: MainScheduler.asyncInstance)
             .bind(with: self) { owner, _ in
                 owner.collectionView.setContentOffset(.zero, animated: true)
-
             }
             .disposed(by: disposeBag)
     }
-    
 
     override func bindAction(reactor: ListSearchResultReactor) {
         super.bindAction(reactor: reactor)

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -52,9 +52,8 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
+        
         searchGlobalScrollState.expand()
-        collectionView.setContentOffset(.zero, animated: false) // 이게 들어가야 맞는지 잘 모르겠지만 일단 넣음
     }
 
     override func bind(reactor: ListSearchResultReactor) {

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -52,7 +52,7 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         searchGlobalScrollState.expand()
     }
 

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -19,6 +19,8 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
 
     private let searchSortOptionComponent: SearchSortOptionComponent
     private (set) var playlistDetailFactory: any PlaylistDetailFactory
+    
+    private let searchGlobalScrollState: any SearchGlobalScrollPortocol
 
     private lazy var collectionView: UICollectionView = createCollectionView().then {
         $0.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
@@ -34,10 +36,12 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
     init(
         _ reactor: ListSearchResultReactor,
         searchSortOptionComponent: SearchSortOptionComponent,
-        playlistDetailFactory: any PlaylistDetailFactory
+        playlistDetailFactory: any PlaylistDetailFactory,
+        searchGlobalScrollState: any SearchGlobalScrollPortocol
     ) {
         self.searchSortOptionComponent = searchSortOptionComponent
         self.playlistDetailFactory = playlistDetailFactory
+        self.searchGlobalScrollState = searchGlobalScrollState
         super.init(reactor: reactor)
     }
 

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -19,7 +19,7 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
 
     private let searchSortOptionComponent: SearchSortOptionComponent
     private (set) var playlistDetailFactory: any PlaylistDetailFactory
-    
+
     private let searchGlobalScrollState: any SearchGlobalScrollPortocol
 
     private lazy var collectionView: UICollectionView = createCollectionView().then {

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -61,7 +61,16 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
         collectionView.rx
             .setDelegate(self)
             .disposed(by: disposeBag)
+        
+        searchGlobalScrollState.listResultScrollToTopObservable
+            .observe(on: MainScheduler.asyncInstance)
+            .bind(with: self) { owner, _ in
+                owner.collectionView.setContentOffset(.zero, animated: true)
+
+            }
+            .disposed(by: disposeBag)
     }
+    
 
     override func bindAction(reactor: ListSearchResultReactor) {
         super.bindAction(reactor: reactor)

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/ListSearchResultViewController.swift
@@ -49,10 +49,12 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
         super.viewDidLoad()
         reactor?.action.onNext(.viewDidLoad)
     }
-
+    
     override func bind(reactor: ListSearchResultReactor) {
         super.bind(reactor: reactor)
-        collectionView.delegate = self
+        collectionView.rx
+            .setDelegate(self)
+            .disposed(by: disposeBag)
     }
 
     override func bindAction(reactor: ListSearchResultReactor) {
@@ -138,6 +140,7 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
                     } else {
                         owner.collectionView.restore()
                     }
+                    
                 }
             }
             .disposed(by: disposeBag)
@@ -223,9 +226,10 @@ extension ListSearchResultViewController: UICollectionViewDelegate {
         let id = PreferenceManager.userInfo?.decryptedID ?? ""
         let isMine = model.ownerId == id
 
-        navigatePlaylistDetail(
-            key: model.key,
-            kind: isMine ? .my : .unknown
-        )
+        navigatePlaylistDetail(key: model.key, kind: isMine ? .my : .unknown)
+    }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        searchGlobalScrollState.scrollTo(amount: scrollView.contentOffset.y)
     }
 }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
@@ -93,7 +93,6 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
     override public func bind(reactor: SearchReactor) {
         super.bind(reactor: reactor)
 
-        
         searchGlobalScrollState.scrollAmountObservable
             .observe(on: MainScheduler.asyncInstance)
             .bind(with: self, onNext: { owner, amount in

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
@@ -97,21 +97,42 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
             .observe(on: MainScheduler.asyncInstance)
             .bind(with: self, onNext: { owner, amount in
                 
-
+                DEBUG_LOG(amount)
+                let constraint = owner.searchHeaderViewTopConstraint.constant
                 
-                if amount > 0 {
+                // constraint == 0 평상 시
+                // constraint < 0 위로 올라가는 중
+                // constraint == -56 최종 끝 도달
+                
+                if 0 < amount  && amount <= 56.0   {
                     owner.searchHeaderViewTopConstraint.constant = max(-(56), -amount)
 
                     owner.searchHeaderView.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
                     owner.searchHeaderContentView.isHidden = true
                     
-                } else if amount < 0     {
-                    owner.searchHeaderContentView.isHidden = false
+                } else if amount <= 0  {
+                    
                     owner.searchHeaderViewTopConstraint.constant = min(0, -amount)
+                    owner.searchHeaderContentView.isHidden = false
                     owner.searchHeaderView.backgroundColor = .white
                 }
             })
             .disposed(by: disposeBag)
+        
+        searchGlobalScrollState.expandSearchHeaderObservable
+            .asDriver(onErrorJustReturn: ())
+            .drive(with: self, onNext: { owner, _ in
+                
+                UIView.animate(withDuration: 0.1) {
+                    owner.searchHeaderViewTopConstraint.constant = 0
+                    owner.searchHeaderContentView.isHidden = false
+                    owner.searchHeaderView.backgroundColor = .white
+                    owner.searchHeaderView.layoutIfNeeded()
+                }
+                
+            })
+            .disposed(by: disposeBag)
+            
         
     }
 

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
@@ -97,7 +97,6 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
             .observe(on: MainScheduler.asyncInstance)
             .bind(with: self, onNext: { owner, amount in
 
-            
                 let constraint = owner.searchHeaderViewTopConstraint.constant
 
                 // constraint == 0 평상 시

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
@@ -38,7 +38,7 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
     private var afterVC: AfterSearchViewController?
 
     private var searchGlobalScrollState: SearchGlobalScrollPortocol!
-    
+
     override public func viewDidLoad() {
         super.viewDidLoad()
     }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
@@ -11,8 +11,7 @@ import SnapKit
 import UIKit
 import Utility
 
-#warning("비어있을 때 검색 방지")
-internal final class SearchViewController: BaseStoryboardReactorViewController<SearchReactor>, ContainerViewType,
+final class SearchViewController: BaseStoryboardReactorViewController<SearchReactor>, ContainerViewType,
     EqualHandleTappedType {
     private enum Font {
         static let headerFontSize: CGFloat = 16
@@ -30,14 +29,16 @@ internal final class SearchViewController: BaseStoryboardReactorViewController<S
     @IBOutlet public weak var contentView: UIView!
     @IBOutlet weak var contentViewBottomConstraint: NSLayoutConstraint!
 
-    var beforeSearchComponent: BeforeSearchComponent!
-    var afterSearchComponent: AfterSearchComponent!
-    var textPopUpFactory: TextPopUpFactory!
+    private var beforeSearchComponent: BeforeSearchComponent!
+    private var afterSearchComponent: AfterSearchComponent!
+    private var textPopUpFactory: TextPopUpFactory!
 
     private lazy var beforeVC = beforeSearchComponent.makeView()
 
     private var afterVC: AfterSearchViewController?
 
+    private var searchGlobalScrollState: SearchGlobalScrollPortocol!
+    
     override public func viewDidLoad() {
         super.viewDidLoad()
     }
@@ -50,7 +51,8 @@ internal final class SearchViewController: BaseStoryboardReactorViewController<S
         reactor: SearchReactor,
         beforeSearchComponent: BeforeSearchComponent,
         afterSearchComponent: AfterSearchComponent,
-        textPopUpFactory: TextPopUpFactory
+        textPopUpFactory: TextPopUpFactory,
+        searchGlobalScrollState: any SearchGlobalScrollPortocol
     ) -> SearchViewController {
         let viewController = SearchViewController.viewController(storyBoardName: "Search", bundle: Bundle.module)
 
@@ -58,6 +60,7 @@ internal final class SearchViewController: BaseStoryboardReactorViewController<S
         viewController.beforeSearchComponent = beforeSearchComponent
         viewController.afterSearchComponent = afterSearchComponent
         viewController.textPopUpFactory = textPopUpFactory
+        viewController.searchGlobalScrollState = searchGlobalScrollState
         return viewController
     }
 

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
@@ -100,24 +100,24 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
             .observe(on: MainScheduler.asyncInstance)
             .bind(with: self, onNext: { owner, source in
                 /* 이전 코드
-                let constraint = owner.searchHeaderViewTopConstraint.constant
+                                 let constraint = owner.searchHeaderViewTopConstraint.constant
 
-//                 constraint == 0 평상 시
-//                 constraint < 0 위로 올라가는 중
-//                 constraint == -56 최종 끝 도달
+                 //                 constraint == 0 평상 시
+                 //                 constraint < 0 위로 올라가는 중
+                 //                 constraint == -56 최종 끝 도달
 
-                if 0 < amount && amount <= 56.0 {
-                    owner.searchHeaderViewTopConstraint.constant = max(-56, -amount)
+                                 if 0 < amount && amount <= 56.0 {
+                                     owner.searchHeaderViewTopConstraint.constant = max(-56, -amount)
 
-                    owner.searchHeaderView.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
-                    owner.searchHeaderContentView.isHidden = true
+                                     owner.searchHeaderView.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
+                                     owner.searchHeaderContentView.isHidden = true
 
-                } else if amount <= 0 {
-                    owner.searchHeaderViewTopConstraint.constant = min(0, -amount)
-                    owner.searchHeaderContentView.isHidden = false
-                    owner.searchHeaderView.backgroundColor = .white
-                }
-                */
+                                 } else if amount <= 0 {
+                                     owner.searchHeaderViewTopConstraint.constant = min(0, -amount)
+                                     owner.searchHeaderContentView.isHidden = false
+                                     owner.searchHeaderView.backgroundColor = .white
+                                 }
+                                 */
                 let offsetY: CGFloat = source.0
                 let scrollDiff = offsetY - owner.previousScrollOffset
                 let absoluteTop: CGFloat = 0
@@ -166,7 +166,7 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
         let percentage = openAmount / abs(self.maxHeight)
         self.searchHeaderContentView.alpha = percentage
         self.searchHeaderView.backgroundColor = percentage == 0 ?
-        DesignSystemAsset.BlueGrayColor.gray100.color : .white
+            DesignSystemAsset.BlueGrayColor.gray100.color : .white
     }
 
     override public func bindState(reactor: SearchReactor) {

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
@@ -39,7 +39,7 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
 
     private var afterVC: AfterSearchViewController?
 
-    private var searchGlobalScrollState: SearchGlobalScrollPortocol!
+    private var searchGlobalScrollState: SearchGlobalScrollProtocol!
 
     private let maxHeight: CGFloat = -56
     private var previousScrollOffset: CGFloat = 0
@@ -57,7 +57,7 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
         beforeSearchComponent: BeforeSearchComponent,
         afterSearchComponent: AfterSearchComponent,
         textPopUpFactory: TextPopUpFactory,
-        searchGlobalScrollState: any SearchGlobalScrollPortocol
+        searchGlobalScrollState: any SearchGlobalScrollProtocol
     ) -> SearchViewController {
         let viewController = SearchViewController.viewController(storyBoardName: "Search", bundle: Bundle.module)
 

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
@@ -92,48 +92,45 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
 
     override public func bind(reactor: SearchReactor) {
         super.bind(reactor: reactor)
-        
+
         searchGlobalScrollState.scrollAmountObservable
             .observe(on: MainScheduler.asyncInstance)
             .bind(with: self, onNext: { owner, amount in
-                
+
                 DEBUG_LOG(amount)
                 let constraint = owner.searchHeaderViewTopConstraint.constant
-                
+
                 // constraint == 0 평상 시
                 // constraint < 0 위로 올라가는 중
                 // constraint == -56 최종 끝 도달
-                
-                if 0 < amount  && amount <= 56.0   {
-                    owner.searchHeaderViewTopConstraint.constant = max(-(56), -amount)
+
+                if 0 < amount && amount <= 56.0 {
+                    owner.searchHeaderViewTopConstraint.constant = max(-56, -amount)
 
                     owner.searchHeaderView.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
                     owner.searchHeaderContentView.isHidden = true
-                    
-                } else if amount <= 0  {
-                    
+
+                } else if amount <= 0 {
                     owner.searchHeaderViewTopConstraint.constant = min(0, -amount)
                     owner.searchHeaderContentView.isHidden = false
                     owner.searchHeaderView.backgroundColor = .white
                 }
             })
             .disposed(by: disposeBag)
-        
+
         searchGlobalScrollState.expandSearchHeaderObservable
             .asDriver(onErrorJustReturn: ())
             .drive(with: self, onNext: { owner, _ in
-                
+
                 UIView.animate(withDuration: 0.1) {
                     owner.searchHeaderViewTopConstraint.constant = 0
                     owner.searchHeaderContentView.isHidden = false
                     owner.searchHeaderView.backgroundColor = .white
                     owner.searchHeaderView.layoutIfNeeded()
                 }
-                
+
             })
             .disposed(by: disposeBag)
-            
-        
     }
 
     override public func bindState(reactor: SearchReactor) {

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
@@ -29,6 +29,8 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
     @IBOutlet public weak var contentView: UIView!
     @IBOutlet weak var contentViewBottomConstraint: NSLayoutConstraint!
 
+    @IBOutlet weak var searchHeaderViewTopConstraint: NSLayoutConstraint!
+    @IBOutlet weak var searchHeaderContentView: UIView!
     private var beforeSearchComponent: BeforeSearchComponent!
     private var afterSearchComponent: AfterSearchComponent!
     private var textPopUpFactory: TextPopUpFactory!
@@ -90,6 +92,27 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
 
     override public func bind(reactor: SearchReactor) {
         super.bind(reactor: reactor)
+        
+        searchGlobalScrollState.scrollAmountObservable
+            .observe(on: MainScheduler.asyncInstance)
+            .bind(with: self, onNext: { owner, amount in
+                
+
+                
+                if amount > 0 {
+                    owner.searchHeaderViewTopConstraint.constant = max(-(56), -amount)
+
+                    owner.searchHeaderView.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
+                    owner.searchHeaderContentView.isHidden = true
+                    
+                } else if amount < 0     {
+                    owner.searchHeaderContentView.isHidden = false
+                    owner.searchHeaderViewTopConstraint.constant = min(0, -amount)
+                    owner.searchHeaderView.backgroundColor = .white
+                }
+            })
+            .disposed(by: disposeBag)
+        
     }
 
     override public func bindState(reactor: SearchReactor) {

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
@@ -97,7 +97,7 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
             .observe(on: MainScheduler.asyncInstance)
             .bind(with: self, onNext: { owner, amount in
 
-                DEBUG_LOG(amount)
+            
                 let constraint = owner.searchHeaderViewTopConstraint.constant
 
                 // constraint == 0 평상 시

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
@@ -99,25 +99,7 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
         searchGlobalScrollState.scrollAmountObservable
             .observe(on: MainScheduler.asyncInstance)
             .bind(with: self, onNext: { owner, source in
-                /* 이전 코드
-                                 let constraint = owner.searchHeaderViewTopConstraint.constant
 
-                 //                 constraint == 0 평상 시
-                 //                 constraint < 0 위로 올라가는 중
-                 //                 constraint == -56 최종 끝 도달
-
-                                 if 0 < amount && amount <= 56.0 {
-                                     owner.searchHeaderViewTopConstraint.constant = max(-56, -amount)
-
-                                     owner.searchHeaderView.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
-                                     owner.searchHeaderContentView.isHidden = true
-
-                                 } else if amount <= 0 {
-                                     owner.searchHeaderViewTopConstraint.constant = min(0, -amount)
-                                     owner.searchHeaderContentView.isHidden = false
-                                     owner.searchHeaderView.backgroundColor = .white
-                                 }
-                                 */
                 let offsetY: CGFloat = source.0
                 let scrollDiff = offsetY - owner.previousScrollOffset
                 let absoluteTop: CGFloat = 0
@@ -137,8 +119,8 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
                 }
 
                 if newHeight != owner.searchHeaderViewTopConstraint.constant {
-                    self.searchHeaderViewTopConstraint.constant = newHeight
-                    self.updateHeader()
+                    owner.searchHeaderViewTopConstraint.constant = newHeight
+                    owner.updateHeader()
                 }
                 owner.view.layoutIfNeeded()
                 owner.previousScrollOffset = offsetY

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SearchViewController.swift
@@ -93,6 +93,7 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
     override public func bind(reactor: SearchReactor) {
         super.bind(reactor: reactor)
 
+        
         searchGlobalScrollState.scrollAmountObservable
             .observe(on: MainScheduler.asyncInstance)
             .bind(with: self, onNext: { owner, amount in

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -21,6 +21,8 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
 
     private let searchSortOptionComponent: SearchSortOptionComponent
 
+    private let searchGlobalScrollState: any SearchGlobalScrollPortocol
+    
     private lazy var collectionView: UICollectionView = createCollectionView().then {
         $0.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
     }
@@ -35,10 +37,12 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
     init(
         _ reactor: SongSearchResultReactor,
         searchSortOptionComponent: SearchSortOptionComponent,
-        containSongsFactory: any ContainSongsFactory
+        containSongsFactory: any ContainSongsFactory,
+        searchGlobalScrollState: any SearchGlobalScrollPortocol
     ) {
         self.searchSortOptionComponent = searchSortOptionComponent
         self.containSongsFactory = containSongsFactory
+        self.searchGlobalScrollState = searchGlobalScrollState
         super.init(reactor: reactor)
     }
 

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -60,7 +60,6 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
         super.viewDidAppear(animated)
 
         searchGlobalScrollState.expand()
-        collectionView.setContentOffset(.zero, animated: false) // 이게 들어가야 맞는지 잘 모르겠지만 일단 넣음
     }
 
     override func bind(reactor: SongSearchResultReactor) {

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -56,7 +56,6 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
         reactor?.action.onNext(.deselectAll)
     }
 
-
     override func bind(reactor: SongSearchResultReactor) {
         super.bind(reactor: reactor)
         collectionView.rx

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -55,20 +55,18 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
         super.viewDidDisappear(animated)
         reactor?.action.onNext(.deselectAll)
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
-        searchGlobalScrollState.expand()
 
+        searchGlobalScrollState.expand()
     }
-    
+
     override func bind(reactor: SongSearchResultReactor) {
         super.bind(reactor: reactor)
         collectionView.rx
             .setDelegate(self)
             .disposed(by: disposeBag)
-        
     }
 
     override func bindAction(reactor: SongSearchResultReactor) {
@@ -136,9 +134,9 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
             .disposed(by: disposeBag)
 
         sharedState.map { ($0.isLoading, $0.dataSource) }
-            .bind(with: self) { owner, info  in
+            .bind(with: self) { owner, info in
 
-                let ( isLoading, dataSource ) = (info.0, info.1)
+                let (isLoading, dataSource) = (info.0, info.1)
 
                 if isLoading {
                     owner.indicator.startAnimating()
@@ -160,7 +158,6 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
                     } else {
                         owner.collectionView.restore()
                     }
-                    
                 }
             }
             .disposed(by: disposeBag)
@@ -256,13 +253,12 @@ extension SongSearchResultViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         reactor?.action.onNext(.itemDidTap(indexPath.row))
     }
-    
+
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if collectionView.isVerticallyScrollable {
             searchGlobalScrollState.scrollTo(amount: scrollView.contentOffset.y)
         }
     }
-    
 }
 
 extension SongSearchResultViewController: SearchSortOptionDelegate {

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -20,7 +20,7 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
 
     private let searchSortOptionComponent: SearchSortOptionComponent
 
-    private let searchGlobalScrollState: any SearchGlobalScrollPortocol
+    private let searchGlobalScrollState: any SearchGlobalScrollProtocol
 
     private lazy var collectionView: UICollectionView = createCollectionView().then {
         $0.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
@@ -37,7 +37,7 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
         _ reactor: SongSearchResultReactor,
         searchSortOptionComponent: SearchSortOptionComponent,
         containSongsFactory: any ContainSongsFactory,
-        searchGlobalScrollState: any SearchGlobalScrollPortocol
+        searchGlobalScrollState: any SearchGlobalScrollProtocol
     ) {
         self.searchSortOptionComponent = searchSortOptionComponent
         self.containSongsFactory = containSongsFactory

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -61,11 +61,20 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
 
         searchGlobalScrollState.expand()
     }
+    
 
     override func bind(reactor: SongSearchResultReactor) {
         super.bind(reactor: reactor)
         collectionView.rx
             .setDelegate(self)
+            .disposed(by: disposeBag)
+        
+        searchGlobalScrollState.songResultScrollToTopObservable
+            .observe(on: MainScheduler.asyncInstance)
+            .bind(with: self) { owner, _ in
+                owner.collectionView.setContentOffset(.zero, animated: true)
+
+            }
             .disposed(by: disposeBag)
     }
 

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -60,6 +60,7 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
         super.viewDidAppear(animated)
 
         searchGlobalScrollState.expand()
+        collectionView.setContentOffset(.zero, animated: false) // 이게 들어가야 맞는지 잘 모르겠지만 일단 넣음
     }
 
     override func bind(reactor: SongSearchResultReactor) {
@@ -255,9 +256,13 @@ extension SongSearchResultViewController: UICollectionViewDelegate {
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        if collectionView.isVerticallyScrollable {
-            searchGlobalScrollState.scrollTo(amount: scrollView.contentOffset.y)
-        }
+        guard collectionView.isVerticallyScrollable else { return }
+        searchGlobalScrollState.scrollTo(
+            source: (
+                scrollView.contentOffset.y,
+                scrollView.contentSize.height - scrollView.frame.size.height
+            )
+        )
     }
 }
 

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -56,6 +56,13 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
         reactor?.action.onNext(.deselectAll)
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        searchGlobalScrollState.expand()
+
+    }
+    
     override func bind(reactor: SongSearchResultReactor) {
         super.bind(reactor: reactor)
         collectionView.rx
@@ -251,7 +258,9 @@ extension SongSearchResultViewController: UICollectionViewDelegate {
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        searchGlobalScrollState.scrollTo(amount: scrollView.contentOffset.y)
+        if collectionView.isVerticallyScrollable {
+            searchGlobalScrollState.scrollTo(amount: scrollView.contentOffset.y)
+        }
     }
     
 }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -22,7 +22,7 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
     private let searchSortOptionComponent: SearchSortOptionComponent
 
     private let searchGlobalScrollState: any SearchGlobalScrollPortocol
-    
+
     private lazy var collectionView: UICollectionView = createCollectionView().then {
         $0.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
     }

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -11,7 +11,6 @@ import Then
 import UIKit
 import Utility
 
-#warning("오버 스크롤 처리")
 final class SongSearchResultViewController: BaseReactorViewController<SongSearchResultReactor>, SongCartViewType {
     var songCartView: SongCartView!
 
@@ -56,12 +55,13 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
         super.viewDidDisappear(animated)
         reactor?.action.onNext(.deselectAll)
     }
-
+    
     override func bind(reactor: SongSearchResultReactor) {
         super.bind(reactor: reactor)
         collectionView.rx
             .setDelegate(self)
             .disposed(by: disposeBag)
+        
     }
 
     override func bindAction(reactor: SongSearchResultReactor) {
@@ -129,9 +129,9 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
             .disposed(by: disposeBag)
 
         sharedState.map { ($0.isLoading, $0.dataSource) }
-            .bind(with: self) { owner, info in
+            .bind(with: self) { owner, info  in
 
-                let (isLoading, dataSource) = (info.0, info.1)
+                let ( isLoading, dataSource ) = (info.0, info.1)
 
                 if isLoading {
                     owner.indicator.startAnimating()
@@ -153,6 +153,7 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
                     } else {
                         owner.collectionView.restore()
                     }
+                    
                 }
             }
             .disposed(by: disposeBag)
@@ -239,13 +240,20 @@ extension SongSearchResultViewController {
         return dataSource
     }
 
-    public func scrollToTop() {}
+    public func scrollToTop() {
+        collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
+    }
 }
 
 extension SongSearchResultViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         reactor?.action.onNext(.itemDidTap(indexPath.row))
     }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        searchGlobalScrollState.scrollTo(amount: scrollView.contentOffset.y)
+    }
+    
 }
 
 extension SongSearchResultViewController: SearchSortOptionDelegate {

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -56,11 +56,6 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
         reactor?.action.onNext(.deselectAll)
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        searchGlobalScrollState.expand()
-    }
 
     override func bind(reactor: SongSearchResultReactor) {
         super.bind(reactor: reactor)

--- a/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/ViewControllers/SongSearchResultViewController.swift
@@ -61,19 +61,17 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
 
         searchGlobalScrollState.expand()
     }
-    
 
     override func bind(reactor: SongSearchResultReactor) {
         super.bind(reactor: reactor)
         collectionView.rx
             .setDelegate(self)
             .disposed(by: disposeBag)
-        
+
         searchGlobalScrollState.songResultScrollToTopObservable
             .observe(on: MainScheduler.asyncInstance)
             .bind(with: self) { owner, _ in
                 owner.collectionView.setContentOffset(.zero, animated: true)
-
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UICollectionView.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UICollectionView.swift
@@ -21,7 +21,6 @@ public extension UICollectionView {
     
     var isVerticallyScrollable: Bool {
         // 콘텐츠 크기가 컬렉션 뷰의 크기보다 큰지 비교
-        print(contentSize.height, bounds.height)
         return contentSize.height > bounds.height
     }
 

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UICollectionView.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UICollectionView.swift
@@ -18,4 +18,11 @@ public extension UICollectionView {
     func restore() {
         self.backgroundView = nil
     }
+    
+    var isVerticallyScrollable: Bool {
+        // 콘텐츠 크기가 컬렉션 뷰의 크기보다 큰지 비교
+        print(contentSize.height, bounds.height)
+        return contentSize.height > bounds.height
+    }
+
 }

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UICollectionView.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UICollectionView.swift
@@ -18,10 +18,9 @@ public extension UICollectionView {
     func restore() {
         self.backgroundView = nil
     }
-    
+
     var isVerticallyScrollable: Bool {
         // 콘텐츠 크기가 컬렉션 뷰의 크기보다 큰지 비교
         return contentSize.height > bounds.height
     }
-
 }

--- a/Projects/UsertInterfaces/DesignSystem/Sources/WMFontSystem.swift
+++ b/Projects/UsertInterfaces/DesignSystem/Sources/WMFontSystem.swift
@@ -25,7 +25,7 @@ public extension UIFont {
         case t4(weight: WMFontWeight = .medium)
         /// size: 16 height: 24
         case t5(weight: WMFontWeight = .medium)
-        /// size: 14 height: 24
+        /// size: 14 height: 22
         case t6(weight: WMFontWeight = .medium)
         /// size: 14 height: 20
         case t6_1(weight: WMFontWeight = .medium)
@@ -98,7 +98,7 @@ private extension UIFont.WMFontSystem {
         case .t3: return 32
         case .t4: return 28
         case .t5: return 24
-        case .t6: return 20
+        case .t6: return 22
         case .t6_1: return 20
         case .t7, .sc7: return 18
         case .t7_1: return 14


### PR DESCRIPTION
## 💡 배경 및 개요

검색 결과를 확장하여 보기 위해 검색 바를 불필요할 때 위로 밀어버립니다.


Resolves: #757 #650

## 📃 작업내용
https://github.com/wakmusic/wakmusic-iOS/assets/48616183/6dc3f5a2-72c7-4c93-97ec-643059ed086d

- searchGlobalScrollState을 구현하여 화면을 뛰어넘은 이벤트 전달을 연결했했습니다.
- 하위 스크롤 정보를 상단에 전달합니다.
- 하단 탭바에서 검색을 두번 클릭 시 현재 검색화면의 결과를 상단으로 끌어 올립니다.

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
