### PR TITLE
♻️ :: (#654) PlayState API 노출 및 playlist 캡슐화

### DIFF
--- a/Projects/App/Sources/Application/AppDelegate.swift
+++ b/Projects/App/Sources/Application/AppDelegate.swift
@@ -16,8 +16,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        // Override point for customization after application launch.
-
         // Use Firebase library to configure APIs
         FirebaseApp.configure()
         setAnalyticsDefaultParameters()
@@ -39,9 +37,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         naverInstance?.consumerKey = NAVER_CONSUMER_KEY() // 클라이언트 아이디
         naverInstance?.consumerSecret = NAVER_CONSUMER_SECRET() // 시크릿 아이디
         naverInstance?.appName = NAVER_APP_NAME() // 앱이름
-
-        // Realm register
-        RealmManager.shared.register()
 
         return true
     }

--- a/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlayState+Public.swift
+++ b/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlayState+Public.swift
@@ -22,18 +22,18 @@ public extension PlayState {
         // 3. 리스트 뒤에 곡들 추가
         // 4. currentPlayIndex 변경
         // 5. 주어진 첫번째 곡 재생
-        let existSongIndexs = songs.uniqueElements.compactMap { self.playList.uniqueIndex(of: PlaylistItem(item: $0)) }
-        self.playList.remove(indexs: existSongIndexs)
+        let existSongIndexs = songs.uniqueElements.compactMap { self.uniqueIndex(of: PlaylistItem(item: $0)) }
+        self.remove(indexs: existSongIndexs)
         let mappedSongs = songs.uniqueElements.map { PlaylistItem(item: $0) }
-        self.playList.append(mappedSongs)
+        self.append(contentsOf: mappedSongs)
     }
 
     /// 주어진 곡들을 재생목록에 추가합니다.
     /// - Parameter duplicateAllowed: 재생목록 추가 시 중복 허용 여부 (기본값: false)
     func appendSongsToPlaylist(_ songs: [SongsDomainInterface.SongEntity], duplicateAllowed: Bool = false) {
-        let existSongIndexs = songs.uniqueElements.compactMap { self.playList.uniqueIndex(of: PlaylistItem(item: $0)) }
-        self.playList.remove(indexs: existSongIndexs)
+        let existSongIndexs = songs.uniqueElements.compactMap { self.uniqueIndex(of: PlaylistItem(item: $0)) }
+        self.remove(indexs: existSongIndexs)
         let mappedSongs = songs.uniqueElements.map { PlaylistItem(item: $0) }
-        self.playList.append(mappedSongs)
+        self.append(contentsOf: mappedSongs)
     }
 }

--- a/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlaylistItem.swift
+++ b/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlaylistItem.swift
@@ -1,0 +1,24 @@
+import Foundation
+import SongsDomainInterface
+
+public struct PlaylistItem: Equatable {
+    public let id: String
+    public let title: String
+    public let artist: String
+
+    public init(
+        id: String,
+        title: String,
+        artist: String
+    ) {
+        self.id = id
+        self.title = title
+        self.artist = artist
+    }
+
+    public init(item: SongEntity) {
+        self.id = item.id
+        self.title = item.title
+        self.artist = item.artist
+    }
+}

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -358,17 +358,26 @@ extension MyPlaylistDetailViewController {
             MyPlaylistDetailDataSource(
                 reactor: reactor!,
                 tableView: tableView
-            ) { [weak self] tableView, indexPath, itemIdentifier in
-
-                guard let self, let cell = tableView.dequeueReusableCell(
-                    withIdentifier: PlaylistTableViewCell.identifier,
-                    for: indexPath
-                ) as? PlaylistTableViewCell else {
+            ) {
+                [weak self] tableView,
+                indexPath,
+                itemIdentifier in
+                
+                guard let self,
+                      let cell = tableView.dequeueReusableCell(
+                        withIdentifier: PlaylistTableViewCell.identifier,
+                        for: indexPath
+                      ) as? PlaylistTableViewCell else {
                     return UITableViewCell()
                 }
-
+                
                 cell.delegate = self
-                cell.setContent(model: itemIdentifier, index: indexPath.row, isEditing: tableView.isEditing)
+                cell.setContent(
+                    model: itemIdentifier,
+                    index: indexPath.row,
+                    isEditing: tableView.isEditing,
+                    isSelected: itemIdentifier.isSelected
+                )
                 cell.selectionStyle = .none
 
                 return cell

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -360,17 +360,17 @@ extension MyPlaylistDetailViewController {
                 tableView: tableView
             ) {
                 [weak self] tableView,
-                indexPath,
-                itemIdentifier in
-                
+                    indexPath,
+                    itemIdentifier in
+
                 guard let self,
                       let cell = tableView.dequeueReusableCell(
-                        withIdentifier: PlaylistTableViewCell.identifier,
-                        for: indexPath
+                          withIdentifier: PlaylistTableViewCell.identifier,
+                          for: indexPath
                       ) as? PlaylistTableViewCell else {
                     return UITableViewCell()
                 }
-                
+
                 cell.delegate = self
                 cell.setContent(
                     model: itemIdentifier,

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController+Delegate.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController+Delegate.swift
@@ -62,16 +62,6 @@ extension PlaylistViewController: UITableViewDelegate {
 
     public func tableView(
         _ tableView: UITableView,
-        moveRowAt sourceIndexPath: IndexPath,
-        to destinationIndexPath: IndexPath
-    ) {
-        // 이동할 데이터를 가져와서 새로운 위치에 삽입합니다.
-        playState.playList.reorderPlaylist(from: sourceIndexPath.row, to: destinationIndexPath.row)
-        HapticManager.shared.impact(style: .light)
-    }
-
-    public func tableView(
-        _ tableView: UITableView,
         targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath,
         toProposedIndexPath proposedDestinationIndexPath: IndexPath
     ) -> IndexPath {

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController.swift
@@ -177,7 +177,7 @@ private extension PlaylistViewController {
             }.disposed(by: disposeBag)
 
         output.playlists
-            .map {  $0.isEmpty }
+            .map { $0.isEmpty }
             .bind(to: playlistView.editButton.rx.isHidden)
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/PlaylistFeature/Sources/ViewModels/PlayListViewModel.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewModels/PlayListViewModel.swift
@@ -189,7 +189,12 @@ final class PlaylistViewModel: ViewModelType {
 private extension [BaseFeature.PlaylistItem] {
     func toModel(selectedIds: Set<String>) -> [PlaylistItemModel] {
         self.map { item in
-            PlaylistItemModel(id: item.id, title: item.title, artist: item.artist, isSelected: selectedIds.contains(item.id))
+            PlaylistItemModel(
+                id: item.id,
+                title: item.title,
+                artist: item.artist,
+                isSelected: selectedIds.contains(item.id)
+            )
         }
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Views/PlaylistTableViewCell.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/PlaylistTableViewCell.swift
@@ -120,7 +120,8 @@ extension PlaylistTableViewCell {
     internal func setContent(
         model: PlaylistItemModel,
         index: Int,
-        isEditing: Bool
+        isEditing: Bool,
+        isSelected: Bool
     ) {
         self.thumbnailImageView.kf.setImage(
             with: URL(string: Utility.WMImageAPI.fetchYoutubeThumbnail(id: model.id).toString),
@@ -131,7 +132,7 @@ extension PlaylistTableViewCell {
         self.titleLabel.text = model.title
         self.artistLabel.text = model.artist
         self.model = (index, model)
-        self.backgroundColor = model.isSelected ? DesignSystemAsset.BlueGrayColor.gray200.color : UIColor.clear
+        self.backgroundColor = isSelected ? DesignSystemAsset.BlueGrayColor.gray200.color : UIColor.clear
 
         self.updateButtonHidden(isEditing: isEditing)
         self.updateConstraintPlayImageView(isEditing: isEditing)

--- a/Projects/Modules/Utility/Sources/Realm/RealmManager.swift
+++ b/Projects/Modules/Utility/Sources/Realm/RealmManager.swift
@@ -16,12 +16,6 @@ public class RealmManager: NSObject {
     private var realm: Realm!
 
     override init() {
-        super.init()
-        DEBUG_LOG("✅ \(Self.self) init")
-    }
-
-    public func register() {
-        // Realm DataBase Migration 하려면 아래의 schemaVersion을 +1 해줘야 합니다.
         let config = Realm.Configuration(
             schemaVersion: 2,
             migrationBlock: { database, oldSchemaVersion in
@@ -33,13 +27,16 @@ public class RealmManager: NSObject {
         )
         Realm.Configuration.defaultConfiguration = config
 
-        // init
         do {
             realm = try Realm()
         } catch {
             LogManager.printError(error.localizedDescription)
+            fatalError()
         }
         LogManager.printDebug(Realm.Configuration.defaultConfiguration.fileURL ?? "")
+
+        super.init()
+        DEBUG_LOG("✅ \(Self.self) init")
     }
 }
 


### PR DESCRIPTION
## 💡 배경 및 개요
- 재생목록에 노래를 추가할 역할을 가진 PlayState의 함수 인터페이스를 뚫어놓았어요.

Resolves: #654 

## 📃 작업내용
- 재생목록에 노래를 추가할 역할을 가진 PlayState의 함수 인터페이스를 뚫어놓았어요.
  - 추상화는 안되어있고 구체타입에 요청 보내시면 돼요

## 🙋‍♂️ 리뷰노트
- 노래 눌렀을 때 재생목록에 추가해야하는 분들 요기에다가 PlayState.shared.append 해주시면 돼용

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
