### PR TITLE
🔀 :: (#431) 액세스 토큰 자동 재발급 로직 추가

### DIFF
--- a/Projects/Domains/BaseDomain/Sources/DataSource/BaseRemoteDataSource.swift
+++ b/Projects/Domains/BaseDomain/Sources/DataSource/BaseRemoteDataSource.swift
@@ -69,7 +69,7 @@ private extension BaseRemoteDataSource {
                 return Single.error(api.errorMap[errorCode] ?? error)
             }
     }
-    
+
     func authorizedRequest(_ api: API) -> Single<Response> {
         if checkAccessTokenIsValid() {
             return defaultRequest(api)

--- a/Projects/Domains/BaseDomain/Sources/DataSource/BaseRemoteDataSource.swift
+++ b/Projects/Domains/BaseDomain/Sources/DataSource/BaseRemoteDataSource.swift
@@ -15,6 +15,7 @@ import RxSwift
 open class BaseRemoteDataSource<API: WMAPI> {
     private let keychain: any Keychain
     private let provider: MoyaProvider<API>
+    private var refreshProvider: MoyaProvider<TokenRefreshAPI>?
     private let decoder = JSONDecoder()
     private let maxRetryCount = 2
 
@@ -34,12 +35,21 @@ open class BaseRemoteDataSource<API: WMAPI> {
     public func request(_ api: API) -> Single<Response> {
         return Single<Response>.create { single in
             var disposabels = [Disposable]()
-            disposabels.append(
-                self.defaultRequest(api).subscribe(
-                    onSuccess: { single(.success($0)) },
-                    onFailure: { single(.failure($0)) }
+            if self.checkIsApiNeedsAuthorization(api) {
+                disposabels.append(
+                    self.authorizedRequest(api).subscribe(
+                        onSuccess: { single(.success($0)) },
+                        onFailure: { single(.failure($0)) }
+                    )
                 )
-            )
+            } else {
+                disposabels.append(
+                    self.defaultRequest(api).subscribe(
+                        onSuccess: { single(.success($0)) },
+                        onFailure: { single(.failure($0)) }
+                    )
+                )
+            }
             return Disposables.create(disposabels)
         }
     }
@@ -59,8 +69,34 @@ private extension BaseRemoteDataSource {
                 return Single.error(api.errorMap[errorCode] ?? error)
             }
     }
+    
+    func authorizedRequest(_ api: API) -> Single<Response> {
+        if checkAccessTokenIsValid() {
+            return defaultRequest(api)
+        } else {
+            return reissueToken()
+                .andThen(defaultRequest(api))
+                .retry(maxRetryCount)
+        }
+    }
 
     func checkIsApiNeedsAuthorization(_ api: API) -> Bool {
         api.jwtTokenType == .accessToken
+    }
+
+    func checkAccessTokenIsValid() -> Bool {
+        let accessToken = keychain.load(type: .accessToken)
+        return !accessToken.isEmpty
+    }
+
+    func reissueToken() -> Completable {
+        let refreshAPI = TokenRefreshAPI.refresh
+        let provider = refreshProvider ?? MoyaProvider(plugins: [JwtPlugin(keychain: keychain), CustomLoggingPlugin()])
+        if refreshProvider == nil {
+            refreshProvider = provider
+        }
+
+        return provider.rx.request(.refresh)
+            .asCompletable()
     }
 }

--- a/Projects/Domains/BaseDomain/Sources/DataSource/TokenRefreshAPI.swift
+++ b/Projects/Domains/BaseDomain/Sources/DataSource/TokenRefreshAPI.swift
@@ -16,7 +16,7 @@ extension TokenRefreshAPI: WMAPI {
 
     var jwtTokenType: JwtTokenType { .refreshToken }
 
-    var errorMap: [Int : WMError] {
+    var errorMap: [Int: WMError] {
         [
             400: .badRequest,
             401: .tokenExpired,

--- a/Projects/Domains/BaseDomain/Sources/DataSource/TokenRefreshAPI.swift
+++ b/Projects/Domains/BaseDomain/Sources/DataSource/TokenRefreshAPI.swift
@@ -1,0 +1,28 @@
+import ErrorModule
+import Moya
+
+enum TokenRefreshAPI {
+    case refresh
+}
+
+extension TokenRefreshAPI: WMAPI {
+    var domain: WMDomain { .auth }
+
+    var urlPath: String { "/token" }
+
+    var method: Moya.Method { .post }
+
+    var task: Moya.Task { .requestPlain }
+
+    var jwtTokenType: JwtTokenType { .refreshToken }
+
+    var errorMap: [Int : WMError] {
+        [
+            400: .badRequest,
+            401: .tokenExpired,
+            404: .notFound,
+            429: .tooManyRequest,
+            500: .internalServerError
+        ]
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요
액세스 토큰이 만료되었을 때 Refresh 토큰을 사용해서 재발급하는 로직을 추가했어요.

Resolves: #431 

## 📃 작업내용
- BaseRemoteDataSource를 상속하는 곳이라면 액세스 토큰이 만료되었을 때 자동으로 갱신해요

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
