### PR TITLE
🔀 :: (#799)  containSong  터짐 해결

### DIFF
--- a/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
@@ -8,7 +8,6 @@ import RxSwift
 import UserDomainInterface
 import Utility
 
-
 #warning("커스텀 에러 ")
 public final class ContainSongsViewModel: ViewModelType {
     private let fetchPlayListUseCase: any FetchPlaylistUseCase

--- a/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
@@ -8,6 +8,8 @@ import RxSwift
 import UserDomainInterface
 import Utility
 
+
+#warning("커스텀 에러 ")
 public final class ContainSongsViewModel: ViewModelType {
     private let fetchPlayListUseCase: any FetchPlaylistUseCase
     private let addSongIntoPlaylistUseCase: any AddSongIntoPlaylistUseCase
@@ -59,29 +61,25 @@ public final class ContainSongsViewModel: ViewModelType {
                 }
                 return self.fetchPlayListUseCase.execute()
                     .asObservable()
-                    .catch { [logoutUseCase] (error: Error) in
+                    .catch { (error: Error) in
                         let wmError = error.asWMError
                         if wmError == .tokenExpired {
                             logoutRelay.accept(wmError)
-                            return logoutUseCase.execute()
-                                .asObservable()
-                                .catch { error in
-                                    let description = error.asWMError.errorDescription ?? ""
-                                    output.showToastMessage.onNext(BaseEntity(status: 0, description: description))
-                                    return Observable.never()
-                                }
-                                .flatMap { _ in
-                                    Observable.never()
-                                }
+                            return self.logoutUseCase.execute()
+                                .andThen(Observable.error(wmError))
                         } else {
                             return Observable.error(wmError)
                         }
                     }
             }
-            .do(onError: { error in
-                let wmError: WMError = error.asWMError
-                output.showToastMessage.onNext(BaseEntity(status: 400, description: wmError.errorDescription!))
+            .do(onError: { (error: Error) in
+                let wmError = error.asWMError
+                output.showToastMessage.onNext(BaseEntity(
+                    status: 401,
+                    description: wmError.errorDescription ?? "알 수 없는 오류가 발생하였습니다."
+                ))
             })
+            .catchAndReturn([])
             .withLatestFrom(PreferenceManager.$userInfo) { ($0, $1) }
             .map { playlist, userInfo in
 


### PR DESCRIPTION
## 💡 배경 및 개요

로그인 없이 팝업 될 때 앱이 터집니다.


Resolves: #799

## 📃 작업내용

에러 발생 시 do{onError:}  에서 토스트 메시지를 보내고
catchAndReturn으로 빈 배열을 바인딩한 후 , dismiss 시킵니다.

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
