### PR TITLE
🔀 :: (#807) 홈화면 음악 상세 연결

### DIFF
--- a/Projects/Features/HomeFeature/Resources/Home.storyboard
+++ b/Projects/Features/HomeFeature/Resources/Home.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -48,7 +48,7 @@
                                                                     <constraint firstAttribute="height" constant="24" id="p1R-BY-xby"/>
                                                                 </constraints>
                                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                                                <state key="normal" title="전체듣기">
+                                                                <state key="normal" title="전체보기">
                                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </state>
                                                             </button>
@@ -272,7 +272,7 @@
                                                             <constraint firstAttribute="height" constant="51" id="MMA-Gw-lIO"/>
                                                         </constraints>
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                                        <state key="normal" title="전체듣기"/>
+                                                        <state key="normal" title="전체보기"/>
                                                     </button>
                                                 </subviews>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -647,7 +647,7 @@
             <color red="0.89399999380111694" green="0.90600001811981201" blue="0.92500001192092896" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="gray900">
-            <color red="0.063000001013278961" green="0.093999996781349182" blue="0.15700000524520874" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.098039215686274508" green="0.10196078431372549" blue="0.10980392156862745" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/Projects/Features/HomeFeature/Sources/Analytics/HomeAnalyticsLog.swift
+++ b/Projects/Features/HomeFeature/Sources/Analytics/HomeAnalyticsLog.swift
@@ -3,7 +3,10 @@ import LogManager
 enum HomeAnalyticsLog: AnalyticsLogType {
     case clickChartTop100MusicsTitleButton
     case clickAllChartTop100MusicsButton
-    case clickMusicItem(location: MusicItemLocation)
+    case clickRecentMusicsTitleButton
+    case clickAllRecentMusicsButton
+    case clickMusicItem(location: MusicItemLocation, id: String)
+    case clickMusicItemPlayButton(location: MusicItemLocation, id: String)
 }
 
 enum MusicItemLocation: String, CustomStringConvertible {

--- a/Projects/Features/HomeFeature/Sources/ViewModels/HomeViewModel.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewModels/HomeViewModel.swift
@@ -36,7 +36,9 @@ public final class HomeViewModel: ViewModelType {
 
     public struct Input {
         let fetchHomeUseCase: PublishSubject<Void> = PublishSubject()
+        @available(*, deprecated, message: "스펙 변경에 따라 all listen 제거")
         let chartAllListenTapped: PublishSubject<Void> = PublishSubject()
+        @available(*, deprecated, message: "스펙 변경에 따라 all listen 제거")
         let newSongsAllListenTapped: PublishSubject<Void> = PublishSubject()
         let refreshPulled: PublishSubject<Void> = PublishSubject()
     }

--- a/Projects/Features/HomeFeature/Sources/Views/HomeNewSongCell.swift
+++ b/Projects/Features/HomeFeature/Sources/Views/HomeNewSongCell.swift
@@ -8,15 +8,26 @@
 
 import DesignSystem
 import Kingfisher
+import RxGesture
+import RxSwift
 import SongsDomainInterface
 import UIKit
 import Utility
 
-class HomeNewSongCell: UICollectionViewCell {
+protocol HomeNewSongCellDelegate: AnyObject {
+    func thumbnailDidTap(model: NewSongsEntity)
+    func playButtonDidTap(model: NewSongsEntity)
+}
+
+final class HomeNewSongCell: UICollectionViewCell {
     @IBOutlet weak var albumImageView: UIImageView!
     @IBOutlet weak var titleStringLabel: UILabel!
     @IBOutlet weak var artistLabel: UILabel!
     @IBOutlet weak var playImageView: UIImageView!
+
+    private var model: NewSongsEntity?
+    weak var delegate: (any HomeNewSongCellDelegate)?
+    private let disposeBag = DisposeBag()
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -28,11 +39,13 @@ class HomeNewSongCell: UICollectionViewCell {
         albumImageView.clipsToBounds = true
         albumImageView.contentMode = .scaleAspectFill
         playImageView.image = DesignSystemAsset.Home.playSmall.image
+        bind()
     }
 }
 
 extension HomeNewSongCell {
     func update(model: NewSongsEntity) {
+        self.model = model
         let titleAttributedString = NSMutableAttributedString(
             string: model.title,
             attributes: [
@@ -58,5 +71,25 @@ extension HomeNewSongCell {
             placeholder: DesignSystemAsset.Logo.placeHolderMedium.image,
             options: [.transition(.fade(0.2))]
         )
+    }
+}
+
+private extension HomeNewSongCell {
+    func bind() {
+        albumImageView.rx.tapGesture()
+            .when(.recognized)
+            .bind { [weak self] _ in
+                guard let newSongEntity = self?.model else { return }
+                self?.delegate?.thumbnailDidTap(model: newSongEntity)
+            }
+            .disposed(by: disposeBag)
+
+        playImageView.rx.tapGesture()
+            .when(.recognized)
+            .bind { [weak self] _ in
+                guard let newSongEntity = self?.model else { return }
+                self?.delegate?.playButtonDidTap(model: newSongEntity)
+            }
+            .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요
- 홈화면과 음악 상세 페이지를 연결해요

Resolves: #807

## 📃 작업내용
- 홈화면의 최신 음악 cell 영역의 행동과 상세 페이지를 연결

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
