### PR TITLE
🔀 :: (#836) ContainSong에 제약 조건 및 에러 토스트 메시지 구현

### DIFF
--- a/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -129,7 +129,7 @@ extension ContainSongsViewController {
         closeButton.setImage(DesignSystemAsset.Navigation.close.image, for: .normal)
 
         titleLabel.font = DesignSystemFontFamily.Pretendard.medium.font(size: 16)
-        titleLabel.textColor = DesignSystemAsset.GrayColor.gray900.color
+        titleLabel.textColor = DesignSystemAsset.BlueGrayColor.gray900.color
         titleLabel.text = "리스트에 담기"
         titleLabel.setTextWithAttributes(kernValue: -0.5)
 

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -7,9 +7,6 @@ import RxSwift
 import UIKit
 import Utility
 
-public protocol ContainSongsViewDelegate: AnyObject {
-    func tokenExpired()
-}
 
 public final class ContainSongsViewController: BaseViewController, ViewControllerFromStoryBoard {
     @IBOutlet weak var closeButton: UIButton!
@@ -25,7 +22,6 @@ public final class ContainSongsViewController: BaseViewController, ViewControlle
     lazy var input = ContainSongsViewModel.Input()
     lazy var output = viewModel.transform(from: input)
     var disposeBag = DisposeBag()
-    public weak var delegate: ContainSongsViewDelegate?
 
     deinit { DEBUG_LOG("❌ \(Self.self) Deinit") }
 
@@ -119,9 +115,7 @@ extension ContainSongsViewController {
                 owner.showToast(text: error.localizedDescription, font: toastFont)
                 NotificationCenter.default.post(name: .movedTab, object: 4)
 
-                owner.dismiss(animated: true) {
-                    owner.delegate?.tokenExpired()
-                }
+                owner.dismiss(animated: true)
             }
             .disposed(by: disposeBag)
 
@@ -187,14 +181,3 @@ extension ContainSongsViewController: ContainPlayListHeaderViewDelegate {
     }
 }
 
-#warning("토근 만료 처리")
-// extension ContainSongsViewController: MultiPurposePopupViewDelegate {
-//    public func didTokenExpired() {
-//        self.dismiss(animated: true) { [weak self] in
-//
-//            guard let self else { return }
-//
-//            self.delegate?.tokenExpired()
-//        }
-//    }
-// }

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -6,6 +6,7 @@ import PlaylistDomainInterface
 import RxSwift
 import UIKit
 import Utility
+import UserDomainInterface
 
 
 public final class ContainSongsViewController: BaseViewController, ViewControllerFromStoryBoard {
@@ -85,10 +86,10 @@ extension ContainSongsViewController {
             .do(onNext: { [weak self] indexPath, _ in
                 self?.tableView.deselectRow(at: indexPath, animated: true)
             })
-            .map { indexPath, model -> String in
-                return model[indexPath.row].key
+            .map { indexPath, model -> PlaylistEntity in
+                return model[indexPath.row]
             }
-            .bind(to: input.containSongWithKey)
+            .bind(to: input.itemDidTap)
             .disposed(by: disposeBag)
 
         output.showToastMessage
@@ -102,7 +103,10 @@ extension ContainSongsViewController {
                 } else if result.status == 200 {
                     NotificationCenter.default.post(name: .playListRefresh, object: nil) // 플리목록창 이름 변경하기 위함
                     self.dismiss(animated: true)
-                } else {
+                } else if result.status == -1 {
+                    return 
+                }
+                else {
                     self.dismiss(animated: true)
                 }
 

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -5,9 +5,8 @@ import NVActivityIndicatorView
 import PlaylistDomainInterface
 import RxSwift
 import UIKit
-import Utility
 import UserDomainInterface
-
+import Utility
 
 public final class ContainSongsViewController: BaseViewController, ViewControllerFromStoryBoard {
     @IBOutlet weak var closeButton: UIButton!
@@ -104,9 +103,8 @@ extension ContainSongsViewController {
                     NotificationCenter.default.post(name: .playListRefresh, object: nil) // 플리목록창 이름 변경하기 위함
                     self.dismiss(animated: true)
                 } else if result.status == -1 {
-                    return 
-                }
-                else {
+                    return
+                } else {
                     self.dismiss(animated: true)
                 }
 
@@ -184,4 +182,3 @@ extension ContainSongsViewController: ContainPlayListHeaderViewDelegate {
         showBottomSheet(content: multiPurposePopVc, size: .fixed(296))
     }
 }
-

--- a/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
@@ -2,12 +2,12 @@ import AuthDomainInterface
 import BaseDomainInterface
 import ErrorModule
 import Foundation
+import Localization
 import PlaylistDomainInterface
 import RxRelay
 import RxSwift
 import UserDomainInterface
 import Utility
-import Localization
 
 #warning("커스텀 에러 리스폰스 후추..")
 public final class ContainSongsViewModel: ViewModelType {
@@ -94,17 +94,19 @@ public final class ContainSongsViewModel: ViewModelType {
                 guard let self = self else {
                     return Observable.empty()
                 }
-                
+
                 let count = model.songCount + self.songs.count
-                
-                guard count <= limit else  {
-                    output.showToastMessage.onNext(BaseEntity(
-                        status: -1,
-                        description: LocalizationStrings.overFlowAddPlaylistWarning( count - limit ))
+
+                guard count <= limit else {
+                    output.showToastMessage.onNext(
+                        BaseEntity(
+                            status: -1,
+                            description: LocalizationStrings.overFlowAddPlaylistWarning(count - limit)
+                        )
                     )
                     return .empty()
                 }
-                
+
                 return self.addSongIntoPlaylistUseCase
                     .execute(key: model.key, songs: self.songs)
                     .catch { (error: Error) in

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController+Delegate.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController+Delegate.swift
@@ -13,7 +13,7 @@ extension PlaylistViewController: SongCartViewDelegate {
             guard let viewController = containSongsFactory.makeView(songs: songs) as? ContainSongsViewController else {
                 return
             }
-            viewController.delegate = self
+       
             viewController.modalPresentationStyle = .overFullScreen
 
             self.present(viewController, animated: true) {
@@ -79,8 +79,3 @@ extension PlaylistViewController: PlaylistTableViewCellDelegate {
     }
 }
 
-extension PlaylistViewController: ContainSongsViewDelegate {
-    public func tokenExpired() {
-        self.dismiss(animated: true)
-    }
-}

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController+Delegate.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController+Delegate.swift
@@ -13,7 +13,7 @@ extension PlaylistViewController: SongCartViewDelegate {
             guard let viewController = containSongsFactory.makeView(songs: songs) as? ContainSongsViewController else {
                 return
             }
-       
+
             viewController.modalPresentationStyle = .overFullScreen
 
             self.present(viewController, animated: true) {
@@ -78,4 +78,3 @@ extension PlaylistViewController: PlaylistTableViewCellDelegate {
         tappedCellIndex.onNext(index)
     }
 }
-


### PR DESCRIPTION
## 💡 배경 및 개요

플레이리스트에 50곡 이상 담는 것을 방지합니다.

Resolves: #836

## 📃 작업내용

https://github.com/user-attachments/assets/64a80e1d-a536-4362-a41e-db800a726fab


불필요한 코드를 제거하고 제한사항 및 토스트 처리

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
