### PR TITLE
🔀 :: (#868) 팀 소개:: 데이터 구조 변경

### DIFF
--- a/Projects/Domains/TeamDomain/Interface/Entity/TeamListEntity.swift
+++ b/Projects/Domains/TeamDomain/Interface/Entity/TeamListEntity.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public struct TeamListEntity {
     public let team: String
+    public let part: String
     public let name: String
     public let position: String
     public let profile: String
@@ -9,12 +10,14 @@ public struct TeamListEntity {
 
     public init(
         team: String,
+        part: String,
         name: String,
         position: String,
         profile: String,
         isLead: Bool
     ) {
         self.team = team
+        self.part = part
         self.name = name
         self.position = position
         self.profile = profile

--- a/Projects/Domains/TeamDomain/Sources/ResponseDTO/FetchTeamListResponseDTO.swift
+++ b/Projects/Domains/TeamDomain/Sources/ResponseDTO/FetchTeamListResponseDTO.swift
@@ -3,6 +3,7 @@ import TeamDomainInterface
 
 public struct FetchTeamListResponseDTO: Decodable {
     public let team: String
+    public let part: String
     public let name: String
     public let position: String
     public let profile: String
@@ -13,6 +14,7 @@ public extension FetchTeamListResponseDTO {
     func toDomain() -> TeamListEntity {
         return .init(
             team: team,
+            part: part,
             name: name,
             position: position,
             profile: profile,

--- a/Projects/Features/TeamFeature/Interface/TeamInfoType.swift
+++ b/Projects/Features/TeamFeature/Interface/TeamInfoType.swift
@@ -1,15 +1,7 @@
 import Foundation
 
-public enum TeamInfoType {
-    case develop
-    case weeklyWM
-
-    var title: String {
-        switch self {
-        case .develop:
-            return "개발팀"
-        case .weeklyWM:
-            return "주간 왁뮤팀"
-        }
-    }
+public enum TeamInfoType: String {
+    case develop = "개발팀"
+    case weeklyWM = "주간 왁뮤팀"
+    case unknown = ""
 }

--- a/Projects/Features/TeamFeature/Sources/ViewControllers/TeamInfoContentViewController.swift
+++ b/Projects/Features/TeamFeature/Sources/ViewControllers/TeamInfoContentViewController.swift
@@ -86,7 +86,7 @@ private extension TeamInfoContentViewController {
 
     func setLayout() {
         tableView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(output.type.value == .develop ? 104 : 100)
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(output.type.value == .weeklyWM ? 100 : 104)
             $0.horizontalEdges.bottom.equalToSuperview()
         }
 

--- a/Projects/Features/TeamFeature/Sources/ViewModels/TeamInfoContentViewModel.swift
+++ b/Projects/Features/TeamFeature/Sources/ViewModels/TeamInfoContentViewModel.swift
@@ -32,17 +32,17 @@ public final class TeamInfoContentViewModel: ViewModelType {
     public func transform(from input: Input) -> Output {
         let output = Output()
         let entities = self.entities
-        let teams = entities.map { $0.team }.uniqueElements
+        let parts = entities.map { $0.part }.uniqueElements
 
         output.type.accept(type)
 
         input.combineTeamList
             .map { _ -> [TeamInfoSectionModel] in
-                return teams.map { team -> TeamInfoSectionModel in
+                return parts.map { part -> TeamInfoSectionModel in
                     return TeamInfoSectionModel(
-                        title: team,
+                        title: part,
                         model: TeamInfoModel(
-                            members: entities.filter { $0.team == team },
+                            members: entities.filter { $0.part == part },
                             isOpen: true
                         )
                     )

--- a/Projects/Features/TeamFeature/Sources/ViewModels/TeamInfoViewModel.swift
+++ b/Projects/Features/TeamFeature/Sources/ViewModels/TeamInfoViewModel.swift
@@ -24,24 +24,25 @@ public final class TeamInfoViewModel: ViewModelType {
     }
 
     public struct Output {
-        let dataSource: BehaviorRelay<([TeamListEntity], [TeamListEntity])> = .init(value: ([], []))
+        let dataSource: BehaviorRelay<[TeamListEntity]> = .init(value: [])
+        let teams: BehaviorRelay<[String]> = .init(value: [])
+
     }
 
     public func transform(from input: Input) -> Output {
         let output = Output()
 
         input.fetchTeamList
-            .flatMap { [weak self] _ -> Observable<([TeamListEntity], [TeamListEntity])> in
+            .flatMap { [weak self] _ -> Observable<[TeamListEntity]> in
                 guard let self = self else { return .never() }
-                return Observable.zip(
-                    self.fetchTeamListUseCase.execute()
-                        .asObservable()
-                        .catchAndReturn(self.makeDummy1()),
-                    self.fetchTeamListUseCase.execute()
-                        .asObservable()
-                        .catchAndReturn(self.makeDummy2())
-                )
+                return self.fetchTeamListUseCase.execute()
+                    .asObservable()
+                    .catchAndReturn(self.makeDummy())
             }
+            .do(onNext: { source in
+                let teams: [String] = source.map { $0.team }.uniqueElements
+                output.teams.accept(teams)
+            })
             .bind(to: output.dataSource)
             .disposed(by: disposeBag)
 
@@ -50,48 +51,43 @@ public final class TeamInfoViewModel: ViewModelType {
 }
 
 private extension TeamInfoViewModel {
-    func makeDummy1() -> [TeamListEntity] {
+    func makeDummy() -> [TeamListEntity] {
         return [
-            .init(team: "기획 · 디자인", name: "샴퓨", position: "Product Designer", profile: "", isLead: true),
-            .init(team: "기획 · 디자인", name: "스타티스", position: "작가", profile: "", isLead: false),
-            .init(team: "기획 · 디자인", name: "Wacter", position: "영상", profile: "", isLead: false),
-            .init(team: "iOS 개발", name: "iOS Hamp", position: "개발자", profile: "", isLead: true),
-            .init(team: "iOS 개발", name: "구구", position: "개발자", profile: "", isLead: false),
-            .init(team: "iOS 개발", name: "baegteun", position: "개발자", profile: "", isLead: false),
-            .init(team: "iOS 개발", name: "케이", position: "개발자", profile: "", isLead: false),
-            .init(team: "iOS 개발", name: "김대희", position: "개발자", profile: "", isLead: false),
-            .init(team: "AOS 개발", name: "Hees", position: "개발자", profile: "", isLead: true),
-            .init(team: "AOS 개발", name: "깊은꿈속", position: "개발자", profile: "", isLead: false),
-            .init(team: "AOS 개발", name: "민감자", position: "개발자", profile: "", isLead: false),
-            .init(team: "AOS 개발", name: "다블람", position: "개발자", profile: "", isLead: false),
-            .init(team: "Back-End 개발", name: "코코아", position: "개발자", profile: "", isLead: true),
-            .init(team: "Web 개발", name: "니엔", position: "개발자", profile: "", isLead: true)
-        ]
-    }
-
-    func makeDummy2() -> [TeamListEntity] {
-        return [
-            .init(team: "영상", name: "미니박스", position: "영상 · 개발자", profile: "", isLead: true),
-            .init(team: "영상", name: "라스", position: "영상 · 시트 · TMI", profile: "", isLead: false),
-            .init(team: "영상", name: "하루", position: "영상", profile: "", isLead: false),
-            .init(team: "시트", name: "수학", position: "시트 · 썸네일 · TMI", profile: "", isLead: false),
-            .init(team: "녹화", name: "똘저놈", position: "개발자", profile: "", isLead: false),
-            .init(team: "녹화", name: "내이름은이든", position: "개발자", profile: "", isLead: false),
-            .init(team: "썸네일", name: "Mudori", position: "썸네일", profile: "", isLead: false),
-            .init(team: "TMI", name: "225", position: "TMI", profile: "", isLead: false),
-            .init(team: "TMI", name: "하늘참", position: "TMI", profile: "", isLead: false),
-            .init(team: "TMI", name: "찬란한빛", position: "TMI", profile: "", isLead: false),
-            .init(team: "TMI", name: "듀엘이에요", position: "TMI", profile: "", isLead: false),
-            .init(team: "TMI", name: "루엘", position: "TMI", profile: "", isLead: false),
-            .init(team: "TMI", name: "소프트피치", position: "TMI", profile: "", isLead: false),
-            .init(team: "연출", name: "찌랭이", position: "연출 기획", profile: "", isLead: false),
-            .init(team: "연출", name: "설가람", position: "연출 기획", profile: "", isLead: true),
-            .init(team: "연출", name: "공대문과생", position: "연출 기획", profile: "", isLead: false),
-            .init(team: "연출", name: "에이요", position: "연출 편집", profile: "", isLead: false),
-            .init(team: "연출", name: "LCM", position: "연출 편집", profile: "", isLead: false),
-            .init(team: "연출", name: "브푸", position: "연출 편집", profile: "", isLead: false),
-            .init(team: "연출", name: "DO_S", position: "연출 편집", profile: "", isLead: false),
-            .init(team: "연출", name: "티콘", position: "연출 SFX", profile: "", isLead: false)
+            .init(team: "개발팀", part: "기획 · 디자인", name: "샴퓨", position: "Product Designer", profile: "", isLead: true),
+            .init(team: "개발팀", part: "기획 · 디자인", name: "스타티스", position: "작가", profile: "", isLead: false),
+            .init(team: "개발팀", part: "기획 · 디자인", name: "Wacter", position: "영상", profile: "", isLead: false),
+            .init(team: "개발팀", part: "iOS 개발", name: "iOS Hamp", position: "개발자", profile: "", isLead: true),
+            .init(team: "개발팀", part: "iOS 개발", name: "구구", position: "개발자", profile: "", isLead: false),
+            .init(team: "개발팀", part: "iOS 개발", name: "baegteun", position: "개발자", profile: "", isLead: false),
+            .init(team: "개발팀", part: "iOS 개발", name: "케이", position: "개발자", profile: "", isLead: false),
+            .init(team: "개발팀", part: "iOS 개발", name: "김대희", position: "개발자", profile: "", isLead: false),
+            .init(team: "개발팀", part: "AOS 개발", name: "Hees", position: "개발자", profile: "", isLead: true),
+            .init(team: "개발팀", part: "AOS 개발", name: "깊은꿈속", position: "개발자", profile: "", isLead: false),
+            .init(team: "개발팀", part: "AOS 개발", name: "민감자", position: "개발자", profile: "", isLead: false),
+            .init(team: "개발팀", part: "AOS 개발", name: "다블람", position: "개발자", profile: "", isLead: false),
+            .init(team: "개발팀", part: "Back-End 개발", name: "코코아", position: "개발자", profile: "", isLead: true),
+            .init(team: "개발팀", part: "Web 개발", name: "니엔", position: "개발자", profile: "", isLead: true),
+            .init(team: "주간 왁뮤팀", part: "영상", name: "미니박스", position: "영상 · 개발자", profile: "", isLead: true),
+            .init(team: "주간 왁뮤팀", part: "영상", name: "라스", position: "영상 · 시트 · TMI", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "영상", name: "하루", position: "영상", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "시트", name: "수학", position: "시트 · 썸네일 · TMI", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "녹화", name: "똘저놈", position: "개발자", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "녹화", name: "내이름은이든", position: "개발자", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "썸네일", name: "Mudori", position: "썸네일", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "TMI", name: "225", position: "TMI", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "TMI", name: "하늘참", position: "TMI", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "TMI", name: "찬란한빛", position: "TMI", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "TMI", name: "듀엘이에요", position: "TMI", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "TMI", name: "루엘", position: "TMI", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "TMI", name: "소프트피치", position: "TMI", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "연출", name: "찌랭이", position: "연출 기획", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "연출", name: "설가람", position: "연출 기획", profile: "", isLead: true),
+            .init(team: "주간 왁뮤팀", part: "연출", name: "공대문과생", position: "연출 기획", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "연출", name: "에이요", position: "연출 편집", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "연출", name: "LCM", position: "연출 편집", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "연출", name: "브푸", position: "연출 편집", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "연출", name: "DO_S", position: "연출 편집", profile: "", isLead: false),
+            .init(team: "주간 왁뮤팀", part: "연출", name: "티콘", position: "연출 SFX", profile: "", isLead: false)
         ]
     }
 }

--- a/Projects/Features/TeamFeature/Sources/ViewModels/TeamInfoViewModel.swift
+++ b/Projects/Features/TeamFeature/Sources/ViewModels/TeamInfoViewModel.swift
@@ -26,7 +26,6 @@ public final class TeamInfoViewModel: ViewModelType {
     public struct Output {
         let dataSource: BehaviorRelay<[TeamListEntity]> = .init(value: [])
         let teams: BehaviorRelay<[String]> = .init(value: [])
-
     }
 
     public func transform(from input: Input) -> Output {


### PR DESCRIPTION
## 💡 배경 및 개요
- 하드코딩 해뒀던 2개의 팀을 > 팀 갯수에 맞게 확장되도록 변경

Resolves: #868 

## 📃 작업내용
- responseDTO, entity에 part 추가
- 유니크한 team 항목으로 탭 컨트롤러 셋팅

## 🙋‍♂️ 리뷰노트
이 또한 api 없이 상상코딩임.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
