### PR TITLE
🔀 :: (#877) 아티스트:: 구독 상태 반영 오류 수정

### DIFF
--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistDetailViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistDetailViewController.swift
@@ -55,7 +55,8 @@ public final class ArtistDetailViewController: UIViewController, ViewControllerF
         configureUI()
         configureHeader()
         configureContent()
-        bind()
+        outputBind()
+        inputBind()
     }
 
     override public func viewDidAppear(_ animated: Bool) {
@@ -88,9 +89,13 @@ public final class ArtistDetailViewController: UIViewController, ViewControllerF
 }
 
 private extension ArtistDetailViewController {
-    func bind() {
+    func outputBind() {
         output.isSubscription
-            .bind(to: subscriptionButton.rx.isSelected)
+            .skip(1)
+            .bind { [subscriptionButton] isSubscription in
+                subscriptionButton?.isHidden = false
+                subscriptionButton?.isSelected = isSubscription
+            }
             .disposed(by: disposeBag)
 
         output.showLogin
@@ -113,14 +118,12 @@ private extension ArtistDetailViewController {
 
         output.showToast
             .bind(with: self) { owner, message in
-                owner.showToast(
-                    text: message,
-                    font: DesignSystemFontFamily.Pretendard.light.font(size: 14),
-                    verticalOffset: 56 + 10
-                )
+                owner.showToast(text: message, options: [.tabBar])
             }
             .disposed(by: disposeBag)
+    }
 
+    func inputBind() {
         input.fetchArtistSubscriptionStatus.onNext(())
 
         subscriptionButton.rx.tap
@@ -133,6 +136,7 @@ private extension ArtistDetailViewController {
         backButton.setImage(DesignSystemAsset.Navigation.back.image, for: .normal)
         subscriptionButton.setImage(DesignSystemAsset.Artist.subscriptionOff.image, for: .normal)
         subscriptionButton.setImage(DesignSystemAsset.Artist.subscriptionOn.image, for: .selected)
+        subscriptionButton.isHidden = true
 
         let model = viewModel.model
         let flatColor: String = model.personalColor

--- a/Projects/Features/ArtistFeature/Sources/ViewModels/ArtistDetailViewModel.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewModels/ArtistDetailViewModel.swift
@@ -65,20 +65,19 @@ public final class ArtistDetailViewModel: ViewModelType {
                 return true
             }
             .withLatestFrom(output.isSubscription)
-            .flatMap { [subscriptionArtistUseCase] status -> Observable<Void> in
+            .flatMap { [subscriptionArtistUseCase] status -> Observable<Bool> in
                 return subscriptionArtistUseCase.execute(id: id, on: !status)
-                    .andThen(Observable.just(()))
+                    .andThen(Observable.just(!status))
                     .catch { error in
                         output.showToast.onNext(error.asWMError.errorDescription ?? error.localizedDescription)
                         return Observable.empty()
                     }
             }
-            .subscribe(onNext: { _ in
-                let isSubscribe: Bool = !output.isSubscription.value
+            .subscribe(onNext: { isSubscribe in
                 output.isSubscription.accept(isSubscribe)
                 output.showToast.onNext(
                     isSubscribe ?
-                        "신곡 알림이 등록되었습니다." : "신곡 알림이 해제되었습니다"
+                        "신곡 알림이 등록되었습니다." : "신곡 알림이 해제되었습니다."
                 )
             })
             .disposed(by: disposeBag)

--- a/Projects/Features/ArtistFeature/Sources/ViewModels/ArtistDetailViewModel.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewModels/ArtistDetailViewModel.swift
@@ -76,8 +76,9 @@ public final class ArtistDetailViewModel: ViewModelType {
             .subscribe(onNext: { _ in
                 let isSubscribe: Bool = !output.isSubscription.value
                 output.isSubscription.accept(isSubscribe)
-                output.showToast.onNext(isSubscribe ?
-                    "신곡 알림이 등록되었습니다.": "신곡 알림이 해제되었습니다"
+                output.showToast.onNext(
+                    isSubscribe ?
+                        "신곡 알림이 등록되었습니다." : "신곡 알림이 해제되었습니다"
                 )
             })
             .disposed(by: disposeBag)

--- a/Projects/Features/ArtistFeature/Sources/ViewModels/ArtistDetailViewModel.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewModels/ArtistDetailViewModel.swift
@@ -38,11 +38,14 @@ public final class ArtistDetailViewModel: ViewModelType {
         let id = model.id
 
         input.fetchArtistSubscriptionStatus
-            .filter { PreferenceManager.userInfo != nil }
             .flatMap { [fetchArtistSubscriptionStatusUseCase] _ -> Observable<ArtistSubscriptionStatusEntity> in
-                fetchArtistSubscriptionStatusUseCase.execute(id: id)
-                    .asObservable()
-                    .catchAndReturn(.init(isSubscription: false))
+                if PreferenceManager.userInfo == nil {
+                    return Observable.just(ArtistSubscriptionStatusEntity(isSubscription: false))
+                } else {
+                    return fetchArtistSubscriptionStatusUseCase.execute(id: id)
+                        .asObservable()
+                        .catchAndReturn(.init(isSubscription: false))
+                }
             }
             .map { $0.isSubscription }
             .bind(to: output.isSubscription)
@@ -62,16 +65,20 @@ public final class ArtistDetailViewModel: ViewModelType {
                 return true
             }
             .withLatestFrom(output.isSubscription)
-            .flatMap { [subscriptionArtistUseCase] status -> Completable in
-                subscriptionArtistUseCase.execute(id: id, on: !status)
+            .flatMap { [subscriptionArtistUseCase] status -> Observable<Void> in
+                return subscriptionArtistUseCase.execute(id: id, on: !status)
+                    .andThen(Observable.just(()))
                     .catch { error in
                         output.showToast.onNext(error.asWMError.errorDescription ?? error.localizedDescription)
-                        return Completable.never()
+                        return Observable.empty()
                     }
             }
-            .debug()
-            .subscribe(onCompleted: {
-                output.isSubscription.accept(!output.isSubscription.value)
+            .subscribe(onNext: { _ in
+                let isSubscribe: Bool = !output.isSubscription.value
+                output.isSubscription.accept(isSubscribe)
+                output.showToast.onNext(isSubscribe ?
+                    "신곡 알림이 등록되었습니다.": "신곡 알림이 해제되었습니다"
+                )
             })
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 💡 배경 및 개요
- 아티스트 구독/구독취소 시 상태 값이 바로 반영 안되는 오류 수정

Resolves: #877 

## 📃 작업내용
- Completable.andThen() 처리

## 🙋‍♂️ 리뷰노트
x

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
