### PR TITLE
🔀 :: (#887) 앱 접속 시 유저 정보 셋팅

### DIFF
--- a/Projects/Features/RootFeature/Sources/ViewModels/IntroViewModel.swift
+++ b/Projects/Features/RootFeature/Sources/ViewModels/IntroViewModel.swift
@@ -150,8 +150,9 @@ public final class IntroViewModel: ViewModelType {
                             .disposed(by: disposeBag)
                     }
                     output.userInfoResult.onNext(.failure(error))
-                })
-                .disposed(by: disposeBag)
+                }
+            )
+            .disposed(by: disposeBag)
 
         return output
     }


### PR DESCRIPTION
## 💡 배경 및 개요
- 앱 접속 시 유저 정보 셋팅

Resolves: #887 

## 📃 작업내용
- Intro(스플래쉬) 뷰모델에서 유저 로그인 토큰 만료 체크 때문에 유저 정보를 요청하고 있어  그 요청에 끼워 넣음.

## 🙋‍♂️ 리뷰노트
x

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
