### PR TITLE
🔀 :: (#910) Credit 작업자 노래 리스트 인터렉션 추가

### DIFF
--- a/Projects/App/Support/Info.plist
+++ b/Projects/App/Support/Info.plist
@@ -128,6 +128,8 @@
 		<string>$(WMDOMAIN_SONGS)</string>
 		<key>WMDOMAIN_TEAM</key>
 		<string>$(WMDOMAIN_TEAM)</string>
+		<key>WMDOMAIN_CREDIT</key>
+		<string>$(WMDOMAIN_CREDIT)</string>
 		<key>WMDOMAIN_USER</key>
 		<string>$(WMDOMAIN_USER)</string>
 		<key>WMDOMAIN_PRICE</key>

--- a/Projects/Features/BaseFeature/Sources/Protocols/SongCartViewType.swift
+++ b/Projects/Features/BaseFeature/Sources/Protocols/SongCartViewType.swift
@@ -26,6 +26,7 @@ public enum SongCartType {
     case playlistStorage // 보관함 > 내 리스트 (함프)
     case myPlaylist // 보관함 > 플레이 리스트 상세 (함프)
     case WMPlaylist // 추천 플레이 리스트 상세 (함프)
+    case creditSong // 크레딧 작업자 노래 리스트 (백튼)
 }
 
 public extension SongCartViewType where Self: UIViewController {

--- a/Projects/Features/BaseFeature/Sources/Views/SongCartView.swift
+++ b/Projects/Features/BaseFeature/Sources/Views/SongCartView.swift
@@ -118,7 +118,7 @@ public extension SongCartView {
             playButton.isHidden = true
             removeButton.isHidden = false
 
-        case .chartSong, .artistSong, .WMPlaylist:
+        case .chartSong, .artistSong, .WMPlaylist, .creditSong:
             allSelectView.isHidden = false
             songAddButton.isHidden = false
             playListAddButton.isHidden = false

--- a/Projects/Features/CreditSongListFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Features/CreditSongListFeature/Demo/Sources/AppDelegate.swift
@@ -1,3 +1,4 @@
+import BaseFeatureInterface
 import CreditDomainTesting
 @testable import CreditSongListFeature
 import CreditSongListFeatureInterface
@@ -62,6 +63,21 @@ final class FakeCreditSongListTabItemFactory: CreditSongListTabItemFactory {
             creditSortType: sortType,
             fetchCreditSongListUseCase: fetchCreditSongListUseCase
         )
-        return Inject.ViewControllerHost(CreditSongListTabItemViewController(reactor: reactor))
+        return Inject.ViewControllerHost(
+            CreditSongListTabItemViewController(
+                reactor: reactor,
+                containSongsFactory: DummyContainSongsFactory()
+            )
+        )
+    }
+}
+
+final class DummyContainSongsFactory: ContainSongsFactory {
+    func makeView(songs: [String]) -> UIViewController {
+        let viewController = UIViewController()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            viewController.dismiss(animated: true)
+        }
+        return viewController
     }
 }

--- a/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/Component/CreditSongListTabItemComponent.swift
+++ b/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/Component/CreditSongListTabItemComponent.swift
@@ -1,3 +1,4 @@
+import BaseFeatureInterface
 import CreditDomainInterface
 import CreditSongListFeatureInterface
 import NeedleFoundation
@@ -5,6 +6,7 @@ import UIKit
 
 public protocol CreditSongListTabItemDependency: Dependency {
     var fetchCreditSongListUseCase: any FetchCreditSongListUseCase { get }
+    var containSongsFactory: any ContainSongsFactory { get }
 }
 
 public final class CreditSongListTabItemComponent: Component<CreditSongListTabItemDependency>,
@@ -15,7 +17,10 @@ public final class CreditSongListTabItemComponent: Component<CreditSongListTabIt
             creditSortType: sortType,
             fetchCreditSongListUseCase: dependency.fetchCreditSongListUseCase
         )
-        let viewController = CreditSongListTabItemViewController(reactor: reactor)
+        let viewController = CreditSongListTabItemViewController(
+            reactor: reactor,
+            containSongsFactory: dependency.containSongsFactory
+        )
         return viewController
     }
 }

--- a/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/CreditSongListTabItemReactor.swift
+++ b/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/CreditSongListTabItemReactor.swift
@@ -1,5 +1,7 @@
+import BaseFeature
 import CreditDomainInterface
 import CreditSongListFeatureInterface
+import Localization
 import ReactorKit
 
 final class CreditSongListTabItemReactor: Reactor {
@@ -9,14 +11,35 @@ final class CreditSongListTabItemReactor: Reactor {
 
     enum Action {
         case viewDidLoad
+        case songDidTap(id: String)
+        case randomPlayButtonDidTap
+        case allSelectButtonDidTap
+        case allDeselectButtonDidTap
+        case addSongButtonDidTap
+        case addPlaylistButtonDidTap
+        case playButtonDidTap
+        case reachedBottom
     }
 
     enum Mutation {
+        case updateSelectedSongs(Set<String>)
         case updateSongs([CreditSongModel])
+        case updateNavigateType(NavigateType?)
+        case updateIsLoading(Bool)
+        case updateToastMessage(String)
+    }
+
+    enum NavigateType {
+        case playYoutube(ids: [String])
+        case containSongs(ids: [String])
     }
 
     struct State {
         var songs: [CreditSongModel] = []
+        var selectedSongs: Set<String> = []
+        @Pulse var navigateType: NavigateType?
+        @Pulse var isLoading = false
+        @Pulse var toastMessage: String?
     }
 
     private var page: Int = 1
@@ -40,6 +63,22 @@ final class CreditSongListTabItemReactor: Reactor {
         switch action {
         case .viewDidLoad:
             return viewDidLoad()
+        case let .songDidTap(id):
+            return songDidTap(id: id)
+        case .randomPlayButtonDidTap:
+            return randomPlayButtonDidTap()
+        case .allSelectButtonDidTap:
+            return allSelectButtonDidTap()
+        case .allDeselectButtonDidTap:
+            return allDeselectButtonDidTap()
+        case .addSongButtonDidTap:
+            return addSongButtonDidTap()
+        case .addPlaylistButtonDidTap:
+            return addPlaylistButtonDidTap()
+        case .playButtonDidTap:
+            return playButtonDidTap()
+        case .reachedBottom:
+            return reachedBottom()
         }
         return .empty()
     }
@@ -50,14 +89,88 @@ final class CreditSongListTabItemReactor: Reactor {
         switch mutation {
         case let .updateSongs(songs):
             newState.songs = songs
+        case let .updateSelectedSongs(selectedSongs):
+            newState.selectedSongs = selectedSongs
+        case let .updateNavigateType(navigateType):
+            newState.navigateType = navigateType
+        case let .updateIsLoading(isLoading):
+            newState.isLoading = isLoading
+        case let .updateToastMessage(toastMessage):
+            newState.toastMessage = toastMessage
         }
 
         return newState
     }
 }
 
+// MARK: - Mutate
+
 private extension CreditSongListTabItemReactor {
     func viewDidLoad() -> Observable<Mutation> {
+        let initialCreditSongListObservable = fetchPaginatedCreditSongList()
+            .map(Mutation.updateSongs)
+        return withLoadingMutation(observable: initialCreditSongListObservable)
+    }
+
+    func songDidTap(id: String) -> Observable<Mutation> {
+        var currentSelectedSongIDs = currentState.selectedSongs
+        if currentSelectedSongIDs.contains(id) {
+            currentSelectedSongIDs.remove(id)
+        } else {
+            currentSelectedSongIDs.insert(id)
+        }
+        return .just(.updateSelectedSongs(currentSelectedSongIDs))
+    }
+
+    func randomPlayButtonDidTap() -> Observable<Mutation> {
+        let randomSongs = currentState.songs.map(\.id)
+            .shuffled()
+            .prefix(50)
+        let songs = Array(randomSongs)
+        return navigateMutation(navigateType: .playYoutube(ids: songs))
+    }
+
+    func allSelectButtonDidTap() -> Observable<Mutation> {
+        let allSongIDs = Set(currentState.songs.map(\.id))
+        return .just(.updateSelectedSongs(allSongIDs))
+    }
+
+    func allDeselectButtonDidTap() -> Observable<Mutation> {
+        return .just(.updateSelectedSongs([]))
+    }
+
+    func addSongButtonDidTap() -> Observable<Mutation> {
+        let containingSongIDs = currentState.songs
+            .filter { currentState.selectedSongs.contains($0.id) }
+            .map(\.id)
+        return navigateMutation(navigateType: .containSongs(ids: containingSongIDs))
+    }
+
+    func addPlaylistButtonDidTap() -> Observable<Mutation> {
+        let appendingSongs = currentState.songs
+            .filter { currentState.selectedSongs.contains($0.id) }
+            .map { PlaylistItem(id: $0.id, title: $0.title, artist: $0.artist) }
+        PlayState.shared.append(contentsOf: appendingSongs)
+        return .just(.updateToastMessage(Localization.LocalizationStrings.addList))
+    }
+
+    func playButtonDidTap() -> Observable<Mutation> {
+        let containTargetSongIDs = Array(currentState.selectedSongs)
+        return navigateMutation(navigateType: .playYoutube(ids: containTargetSongIDs))
+    }
+
+    func reachedBottom() -> Observable<Mutation> {
+        let initialCreditSongListObservable = fetchPaginatedCreditSongList()
+            .map { [weak self] in return $0 + (self?.currentState.songs ?? []) }
+            .map(Mutation.updateSongs)
+        return withLoadingMutation(observable: initialCreditSongListObservable)
+    }
+}
+
+// MARK: - Private Methods
+
+private extension CreditSongListTabItemReactor {
+    func fetchPaginatedCreditSongList() -> Observable<[CreditSongModel]> {
         return fetchCreditSongListUseCase.execute(
             name: workerName,
             order: creditSortType.toDomain(),
@@ -68,8 +181,22 @@ private extension CreditSongListTabItemReactor {
             self?.page += 1
         })
         .map { $0.map { CreditSongModel(songEntity: $0) } }
-        .map(Mutation.updateSongs)
         .asObservable()
+    }
+
+    func withLoadingMutation(observable: Observable<Mutation>) -> Observable<Mutation> {
+        return .concat(
+            .just(.updateIsLoading(true)),
+            observable,
+            .just(.updateIsLoading(false))
+        )
+    }
+
+    func navigateMutation(navigateType: NavigateType) -> Observable<Mutation> {
+        return .concat(
+            .just(.updateNavigateType(navigateType)),
+            .just(.updateNavigateType(nil))
+        )
     }
 }
 

--- a/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/View/CreditSongCollectionHeaderView.swift
+++ b/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/View/CreditSongCollectionHeaderView.swift
@@ -1,13 +1,16 @@
 import SnapKit
 import Then
 import UIKit
+import Utility
 
 final class CreditSongCollectionHeaderView: UICollectionReusableView {
     private let randomPlayButton = RandomPlayButton()
+    private var playButtonHandler: (() -> Void)?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupViews()
+        bind()
     }
 
     @available(*, unavailable)
@@ -20,10 +23,20 @@ final class CreditSongCollectionHeaderView: UICollectionReusableView {
         layer.zPosition = 1
     }
 
+    func setPlayButtonHandler(handler: @escaping () -> Void) {
+        self.playButtonHandler = handler
+    }
+
     private func setupViews() {
         addSubview(randomPlayButton)
         randomPlayButton.snp.makeConstraints {
             $0.edges.equalToSuperview()
+        }
+    }
+
+    private func bind() {
+        randomPlayButton.addAction { [weak self] in
+            self?.playButtonHandler?()
         }
     }
 }

--- a/Projects/Features/HomeFeature/Sources/ViewControllers/HomeViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewControllers/HomeViewController.swift
@@ -400,7 +400,10 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDelegate
 extension HomeViewController: HomeChartCellDelegate {
     func thumbnailDidTap(model: ChartRankingEntity) {
         LogManager.analytics(HomeAnalyticsLog.clickMusicItem(location: .homeTop100, id: model.id))
-        let musicDetailViewController = musicDetailFactory.makeViewController(songIDs: [model.id], selectedID: model.id)
+        let musicDetailViewController = musicDetailFactory.makeViewController(
+            songIDs: [model.id],
+            selectedID: model.id
+        )
         musicDetailViewController.modalPresentationStyle = .fullScreen
         self.present(musicDetailViewController, animated: true)
     }

--- a/Projects/Features/SongCreditFeature/Sources/SongCreditViewController.swift
+++ b/Projects/Features/SongCreditFeature/Sources/SongCreditViewController.swift
@@ -17,7 +17,7 @@ final class SongCreditViewController: BaseReactorViewController<SongCreditReacto
     private let songCreditCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then {
         let songCreditLayout = CreditCollectionViewLayout()
         $0.collectionViewLayout = songCreditLayout
-        $0.contentInset = .init(top: 20, left: 20, bottom: 20, right: 20)
+        $0.contentInset = .init(top: 40, left: 20, bottom: 20, right: 20)
         $0.backgroundColor = .clear
     }
 

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+UIApplication.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+UIApplication.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+public extension UIApplication {
+    static func topVisibleViewController(
+        base: UIViewController? = UIApplication.keyRootViewController
+    ) -> UIViewController? {
+        if let nav = base as? UINavigationController {
+            return topVisibleViewController(base: nav.visibleViewController)
+        }
+        if let tab = base as? UITabBarController, let selected = tab.selectedViewController {
+            return topVisibleViewController(base: selected)
+        }
+        if let presented = base?.presentedViewController {
+            return topVisibleViewController(base: presented)
+        }
+        return base
+    }
+
+    static var keyRootViewController: UIViewController? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .filter { $0.activationState == .foregroundActive }
+            .first?
+            .keyWindow?
+            .rootViewController
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요
Credit 노래 리스트 페이지에서 노래를 선택했을 때의 인터렉션을 추가했어요

Resolves: #910

## 📃 작업내용

- Credit 노래 리스트 페이지에서 노래를 선택했을 때의 인터렉션을 추가
  - 전체 선택
  - 노래 담기
  - 재생목록 추가
  - 재생

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
