### PR TITLE
🔀  :: (#918) 작업자 노래 리스트 화면에서 상단 Gradient가 표시되지 않는 이슈 해결

### DIFF
--- a/Projects/Features/CreditSongListFeature/Sources/CreditSongList/CreditSongListViewController.swift
+++ b/Projects/Features/CreditSongListFeature/Sources/CreditSongList/CreditSongListViewController.swift
@@ -45,7 +45,7 @@ final class CreditSongListViewController: BaseReactorViewController<CreditSongLi
                 DesignSystemAsset.BlueGrayColor.blueGray900.color.cgColor,
                 DesignSystemAsset.BlueGrayColor.blueGray900.color.withAlphaComponent(0.0).cgColor
             ]
-            profileGradientLayer?.frame = creditProfileGradientContainerView.bounds
+            gradientLayer.frame = creditProfileGradientContainerView.bounds
             creditProfileGradientContainerView.layer.addSublayer(gradientLayer)
             profileGradientLayer = gradientLayer
         }

--- a/Projects/Features/HomeFeature/Sources/ViewControllers/HomeViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewControllers/HomeViewController.swift
@@ -400,8 +400,8 @@ extension HomeViewController: HomeChartCellDelegate {
     func thumbnailDidTap(model: ChartRankingEntity) {
         LogManager.analytics(HomeAnalyticsLog.clickMusicItem(location: .homeTop100, id: model.id))
         let musicDetailViewController = musicDetailFactory.makeViewController(
-            songIDs: [model.id],
-            selectedID: model.id
+            songIDs: ["cgjWo9ZNO-o"],
+            selectedID: "cgjWo9ZNO-o"
         )
         musicDetailViewController.modalPresentationStyle = .fullScreen
         self.present(musicDetailViewController, animated: true)


### PR DESCRIPTION
## 💡 배경 및 개요
작업자 노래 리스트 화면에서 상단 Gradient가 표시되지 않는 이슈 해결

<img src="https://github.com/user-attachments/assets/7c264d7c-7816-4d74-a028-add7276e314b" width="150" />

Resolves: #918 

## 📃 작업내용

- 작업자 노래 리스트 화면에서 상단 Gradient가 표시되지 않는 이슈 해결
- viewDidLayout에서 gradientLayer에서 frame 지정을 해주었으나 객체에 지정해줬어야했는데 nil인곳에 지정해버리는 휴먼 에러가 있었어요

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
