### PR TITLE
🔀  :: (#895) 로그인 여부에 따라 자동으로 my/unkwown 플레이리스트 스위칭

### DIFF
--- a/Projects/App/Sources/Application/AppComponent+Playlist.swift
+++ b/Projects/App/Sources/Application/AppComponent+Playlist.swift
@@ -127,4 +127,10 @@ public extension AppComponent {
             RequestCustomImageURLUseCaseImpl(playlistRepository: playlistRepository)
         }
     }
+    
+    var requestPlaylistOwnerIdUsecase: any RequestPlaylistOwnerIdUsecase {
+        shared {
+            RequestPlaylistOwnerIdUsecaseImpl(playlistRepository: playlistRepository)
+        }
+    }
 }

--- a/Projects/App/Sources/Application/AppComponent+Playlist.swift
+++ b/Projects/App/Sources/Application/AppComponent+Playlist.swift
@@ -128,9 +128,9 @@ public extension AppComponent {
         }
     }
     
-    var requestPlaylistOwnerIdUsecase: any RequestPlaylistOwnerIdUsecase {
+    var requestPlaylistOwnerIDUsecase: any RequestPlaylistOwnerIDUsecase {
         shared {
-            RequestPlaylistOwnerIdUsecaseImpl(playlistRepository: playlistRepository)
+            RequestPlaylistOwnerIDUsecaseImpl(playlistRepository: playlistRepository)
         }
     }
 }

--- a/Projects/Domains/PlaylistDomain/Interface/DataSource/RemotePlaylistDataSource.swift
+++ b/Projects/Domains/PlaylistDomain/Interface/DataSource/RemotePlaylistDataSource.swift
@@ -17,5 +17,5 @@ public protocol RemotePlaylistDataSource {
     func checkSubscription(key: String) -> Single<Bool>
     func requestCustomImageURL(key: String, imageSize: Int) -> Single<CustomImageURLEntity>
     func uploadCustomImage(presignedURL: String, data: Data) -> Completable
-    func requestPlaylistOwnerId(key: String) -> Single<PlaylistOwnerIdEntity>
+    func requestPlaylistOwnerID(key: String) -> Single<PlaylistOwnerIDEntity>
 }

--- a/Projects/Domains/PlaylistDomain/Interface/DataSource/RemotePlaylistDataSource.swift
+++ b/Projects/Domains/PlaylistDomain/Interface/DataSource/RemotePlaylistDataSource.swift
@@ -17,4 +17,5 @@ public protocol RemotePlaylistDataSource {
     func checkSubscription(key: String) -> Single<Bool>
     func requestCustomImageURL(key: String, imageSize: Int) -> Single<CustomImageURLEntity>
     func uploadCustomImage(presignedURL: String, data: Data) -> Completable
+    func requestPlaylistOwnerId(key: String) -> Single<PlaylistOwnerIdEntity>
 }

--- a/Projects/Domains/PlaylistDomain/Interface/Entity/PlaylistOwnerIDEntity.swift
+++ b/Projects/Domains/PlaylistDomain/Interface/Entity/PlaylistOwnerIDEntity.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct PlaylistOwnerIdEntity {
+public struct PlaylistOwnerIDEntity {
     public init(
         ownerID: String
     ) {

--- a/Projects/Domains/PlaylistDomain/Interface/Entity/PlaylistOwnerIdEntity.swift
+++ b/Projects/Domains/PlaylistDomain/Interface/Entity/PlaylistOwnerIdEntity.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct PlaylistOwnerIdEntity {
+    public init(
+        ownerId: String
+    ) {
+        self.ownerId = ownerId
+    }
+
+    public let ownerId: String
+}

--- a/Projects/Domains/PlaylistDomain/Interface/Entity/PlaylistOwnerIdEntity.swift
+++ b/Projects/Domains/PlaylistDomain/Interface/Entity/PlaylistOwnerIdEntity.swift
@@ -2,10 +2,10 @@ import Foundation
 
 public struct PlaylistOwnerIdEntity {
     public init(
-        ownerId: String
+        ownerID: String
     ) {
-        self.ownerId = ownerId
+        self.ownerID = ownerID
     }
 
-    public let ownerId: String
+    public let ownerID: String
 }

--- a/Projects/Domains/PlaylistDomain/Interface/Repository/PlaylistRepository.swift
+++ b/Projects/Domains/PlaylistDomain/Interface/Repository/PlaylistRepository.swift
@@ -17,5 +17,5 @@ public protocol PlaylistRepository {
     func checkSubscription(key: String) -> Single<Bool>
     func requestCustomImageURL(key: String, imageSize: Int) -> Single<CustomImageURLEntity>
     func uploadCustomImage(presignedURL: String, data: Data) -> Completable
-    func requestPlaylistOwnerId(key: String) -> Single<PlaylistOwnerIdEntity>
+    func requestPlaylistOwnerID(key: String) -> Single<PlaylistOwnerIDEntity>
 }

--- a/Projects/Domains/PlaylistDomain/Interface/Repository/PlaylistRepository.swift
+++ b/Projects/Domains/PlaylistDomain/Interface/Repository/PlaylistRepository.swift
@@ -17,4 +17,5 @@ public protocol PlaylistRepository {
     func checkSubscription(key: String) -> Single<Bool>
     func requestCustomImageURL(key: String, imageSize: Int) -> Single<CustomImageURLEntity>
     func uploadCustomImage(presignedURL: String, data: Data) -> Completable
+    func requestPlaylistOwnerId(key: String) -> Single<PlaylistOwnerIdEntity>
 }

--- a/Projects/Domains/PlaylistDomain/Interface/UseCase/RequestPlaylistOwnerIDUsecase.swift
+++ b/Projects/Domains/PlaylistDomain/Interface/UseCase/RequestPlaylistOwnerIDUsecase.swift
@@ -1,0 +1,7 @@
+import BaseDomainInterface
+import Foundation
+import RxSwift
+
+public protocol RequestPlaylistOwnerIDUsecase {
+    func execute(key: String) -> Single<PlaylistOwnerIDEntity>
+}

--- a/Projects/Domains/PlaylistDomain/Interface/UseCase/RequestPlaylistOwnerIdUsecase.swift
+++ b/Projects/Domains/PlaylistDomain/Interface/UseCase/RequestPlaylistOwnerIdUsecase.swift
@@ -1,7 +1,0 @@
-import BaseDomainInterface
-import Foundation
-import RxSwift
-
-public protocol RequestPlaylistOwnerIdUsecase {
-    func execute(key: String) -> Single<PlaylistOwnerIdEntity>
-}

--- a/Projects/Domains/PlaylistDomain/Interface/UseCase/RequestPlaylistOwnerIdUsecase.swift
+++ b/Projects/Domains/PlaylistDomain/Interface/UseCase/RequestPlaylistOwnerIdUsecase.swift
@@ -1,0 +1,7 @@
+import BaseDomainInterface
+import Foundation
+import RxSwift
+
+public protocol RequestPlaylistOwnerIdUsecase {
+    func execute(key: String) -> Single<PlaylistOwnerIdEntity>
+}

--- a/Projects/Domains/PlaylistDomain/Sources/API/PlaylistAPI.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/API/PlaylistAPI.swift
@@ -19,7 +19,7 @@ public enum PlaylistAPI {
     case subscribePlaylist(key: String, isSubscribing: Bool) // 플레이리스트 구독하기 / 구독 취소하기
     case checkSubscription(key: String)
     case fetchRecommendPlaylist // 추천 플리 불러오기
-    case requestPlaylistOwner(key: String) // playlist ownerId 요청하기
+    case requestPlaylistOwnerID(key: String) // playlist ownerId 요청하기
 }
 
 extension PlaylistAPI: WMAPI {
@@ -58,14 +58,14 @@ extension PlaylistAPI: WMAPI {
 
         case let .subscribePlaylist(key, _), let .checkSubscription(key):
             return "/\(key)/subscription"
-        case let .requestPlaylistOwner(key):
+        case let .requestPlaylistOwnerID(key):
             return "/\(key)/owner"
         }
     }
 
     public var method: Moya.Method {
         switch self {
-        case .fetchRecommendPlaylist, .fetchPlaylistDetail, .fetchPlaylistSongs, .checkSubscription, .requestPlaylistOwner:
+        case .fetchRecommendPlaylist, .fetchPlaylistDetail, .fetchPlaylistSongs, .checkSubscription, .requestPlaylistOwnerID:
             return .get
 
         case .createPlaylist, .addSongIntoPlaylist, .requestCustomImageURL:
@@ -84,7 +84,7 @@ extension PlaylistAPI: WMAPI {
 
     public var task: Moya.Task {
         switch self {
-        case .fetchRecommendPlaylist, .fetchPlaylistDetail, .fetchPlaylistSongs, .subscribePlaylist, .checkSubscription , .requestPlaylistOwner:
+        case .fetchRecommendPlaylist, .fetchPlaylistDetail, .fetchPlaylistSongs, .subscribePlaylist, .checkSubscription , .requestPlaylistOwnerID:
             return .requestPlain
 
         case let .updateTitleAndPrivate(_, title: title, isPrivate: isPrivate):
@@ -130,7 +130,7 @@ extension PlaylistAPI: WMAPI {
 
         case .createPlaylist, .updatePlaylist, .addSongIntoPlaylist, .requestCustomImageURL,
                 .removeSongs, .updateTitleAndPrivate, .uploadDefaultImage, .subscribePlaylist,
-                .checkSubscription, .requestPlaylistOwner:
+                .checkSubscription, .requestPlaylistOwnerID:
             return .accessToken
         }
     }

--- a/Projects/Domains/PlaylistDomain/Sources/API/PlaylistAPI.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/API/PlaylistAPI.swift
@@ -19,6 +19,7 @@ public enum PlaylistAPI {
     case subscribePlaylist(key: String, isSubscribing: Bool) // 플레이리스트 구독하기 / 구독 취소하기
     case checkSubscription(key: String)
     case fetchRecommendPlaylist // 추천 플리 불러오기
+    case requestPlaylistOwner(key: String) // playlist ownerId 요청하기
 }
 
 extension PlaylistAPI: WMAPI {
@@ -57,12 +58,14 @@ extension PlaylistAPI: WMAPI {
 
         case let .subscribePlaylist(key, _), let .checkSubscription(key):
             return "/\(key)/subscription"
+        case let .requestPlaylistOwner(key):
+            return "/\(key)/owner"
         }
     }
 
     public var method: Moya.Method {
         switch self {
-        case .fetchRecommendPlaylist, .fetchPlaylistDetail, .fetchPlaylistSongs, .checkSubscription:
+        case .fetchRecommendPlaylist, .fetchPlaylistDetail, .fetchPlaylistSongs, .checkSubscription, .requestPlaylistOwner:
             return .get
 
         case .createPlaylist, .addSongIntoPlaylist, .requestCustomImageURL:
@@ -81,7 +84,7 @@ extension PlaylistAPI: WMAPI {
 
     public var task: Moya.Task {
         switch self {
-        case .fetchRecommendPlaylist, .fetchPlaylistDetail, .fetchPlaylistSongs, .subscribePlaylist, .checkSubscription:
+        case .fetchRecommendPlaylist, .fetchPlaylistDetail, .fetchPlaylistSongs, .subscribePlaylist, .checkSubscription , .requestPlaylistOwner:
             return .requestPlain
 
         case let .updateTitleAndPrivate(_, title: title, isPrivate: isPrivate):
@@ -119,7 +122,7 @@ extension PlaylistAPI: WMAPI {
 
     public var jwtTokenType: JwtTokenType {
         switch self {
-        case .fetchRecommendPlaylist, .fetchPlaylistSongs:
+        case .fetchRecommendPlaylist, .fetchPlaylistSongs, .requestPlaylistOwner:
             return .none
 
         case let .fetchPlaylistDetail(_, type):

--- a/Projects/Domains/PlaylistDomain/Sources/API/PlaylistAPI.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/API/PlaylistAPI.swift
@@ -122,14 +122,15 @@ extension PlaylistAPI: WMAPI {
 
     public var jwtTokenType: JwtTokenType {
         switch self {
-        case .fetchRecommendPlaylist, .fetchPlaylistSongs, .requestPlaylistOwner:
+        case .fetchRecommendPlaylist, .fetchPlaylistSongs:
             return .none
 
         case let .fetchPlaylistDetail(_, type):
             return type == .my ? .accessToken : .none
 
         case .createPlaylist, .updatePlaylist, .addSongIntoPlaylist, .requestCustomImageURL,
-             .removeSongs, .updateTitleAndPrivate, .uploadDefaultImage, .subscribePlaylist, .checkSubscription:
+                .removeSongs, .updateTitleAndPrivate, .uploadDefaultImage, .subscribePlaylist,
+                .checkSubscription, .requestPlaylistOwner:
             return .accessToken
         }
     }

--- a/Projects/Domains/PlaylistDomain/Sources/DataSource/RemotePlaylistDataSourceImpl.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/DataSource/RemotePlaylistDataSourceImpl.swift
@@ -84,9 +84,9 @@ public final class RemotePlaylistDataSourceImpl: BaseRemoteDataSource<PlaylistAP
     }
     
     
-    public func requestPlaylistOwnerId(key: String) -> Single<PlaylistOwnerIdEntity> {
-        return request(.requestPlaylistOwner(key: key))
-            .map(PlaylistOwnerIdResponseDTO.self)
+    public func requestPlaylistOwnerID(key: String) -> Single<PlaylistOwnerIDEntity> {
+        return request(.requestPlaylistOwnerID(key: key))
+            .map(PlaylistOwnerIDResponseDTO.self)
             .map{ $0.toDomain() }
     }
 }

--- a/Projects/Domains/PlaylistDomain/Sources/DataSource/RemotePlaylistDataSourceImpl.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/DataSource/RemotePlaylistDataSourceImpl.swift
@@ -82,4 +82,11 @@ public final class RemotePlaylistDataSourceImpl: BaseRemoteDataSource<PlaylistAP
             .request(CustomPlaylistImageAPI.uploadCustomImage(url: presignedURL, data: data))
             .asCompletable()
     }
+    
+    
+    public func requestPlaylistOwnerId(key: String) -> Single<PlaylistOwnerIdEntity> {
+        return request(.requestPlaylistOwner(key: key))
+            .map(PlaylistOwnerIdResponseDTO.self)
+            .map{ $0.toDomain() }
+    }
 }

--- a/Projects/Domains/PlaylistDomain/Sources/Repository/PlaylistRepositoryImpl.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/Repository/PlaylistRepositoryImpl.swift
@@ -5,6 +5,7 @@ import RxSwift
 import SongsDomainInterface
 
 public final class PlaylistRepositoryImpl: PlaylistRepository {
+ 
     private let remotePlaylistDataSource: any RemotePlaylistDataSource
 
     public init(
@@ -63,5 +64,9 @@ public final class PlaylistRepositoryImpl: PlaylistRepository {
 
     public func uploadCustomImage(presignedURL: String, data: Data) -> Completable {
         remotePlaylistDataSource.uploadCustomImage(presignedURL: presignedURL, data: data)
+    }
+    
+    public func requestPlaylistOwnerId(key: String) -> Single<PlaylistOwnerIdEntity> {
+        remotePlaylistDataSource.requestPlaylistOwnerId(key: key)
     }
 }

--- a/Projects/Domains/PlaylistDomain/Sources/Repository/PlaylistRepositoryImpl.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/Repository/PlaylistRepositoryImpl.swift
@@ -66,7 +66,7 @@ public final class PlaylistRepositoryImpl: PlaylistRepository {
         remotePlaylistDataSource.uploadCustomImage(presignedURL: presignedURL, data: data)
     }
     
-    public func requestPlaylistOwnerId(key: String) -> Single<PlaylistOwnerIdEntity> {
-        remotePlaylistDataSource.requestPlaylistOwnerId(key: key)
+    public func requestPlaylistOwnerID(key: String) -> Single<PlaylistOwnerIDEntity> {
+        remotePlaylistDataSource.requestPlaylistOwnerID(key: key)
     }
 }

--- a/Projects/Domains/PlaylistDomain/Sources/ResponseDTO/PlaylistOwnerIdResponseDTO.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/ResponseDTO/PlaylistOwnerIdResponseDTO.swift
@@ -2,16 +2,16 @@ import Foundation
 import PlaylistDomainInterface
 
 public struct PlaylistOwnerIdResponseDTO: Decodable {
-    public let ownerId: String
+    public let ownerID: String
     
     enum CodingKeys : String , CodingKey {
-        case ownerId = "handle"
+        case ownerID = "handle"
     }
     
 }
 
 public extension PlaylistOwnerIdResponseDTO {
     func toDomain() -> PlaylistOwnerIdEntity {
-        PlaylistOwnerIdEntity(ownerId: ownerId)
+        PlaylistOwnerIdEntity(ownerID: ownerID)
     }
 }

--- a/Projects/Domains/PlaylistDomain/Sources/ResponseDTO/PlaylistOwnerIdResponseDTO.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/ResponseDTO/PlaylistOwnerIdResponseDTO.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PlaylistDomainInterface
 
-public struct PlaylistOwnerIdResponseDTO: Decodable {
+public struct PlaylistOwnerIDResponseDTO: Decodable {
     public let ownerID: String
     
     enum CodingKeys : String , CodingKey {
@@ -10,8 +10,8 @@ public struct PlaylistOwnerIdResponseDTO: Decodable {
     
 }
 
-public extension PlaylistOwnerIdResponseDTO {
-    func toDomain() -> PlaylistOwnerIdEntity {
-        PlaylistOwnerIdEntity(ownerID: ownerID)
+public extension PlaylistOwnerIDResponseDTO {
+    func toDomain() -> PlaylistOwnerIDEntity {
+        PlaylistOwnerIDEntity(ownerID: ownerID)
     }
 }

--- a/Projects/Domains/PlaylistDomain/Sources/ResponseDTO/PlaylistOwnerIdResponseDTO.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/ResponseDTO/PlaylistOwnerIdResponseDTO.swift
@@ -1,0 +1,17 @@
+import Foundation
+import PlaylistDomainInterface
+
+public struct PlaylistOwnerIdResponseDTO: Decodable {
+    public let ownerId: String
+    
+    enum CodingKeys : String , CodingKey {
+        case ownerId = "handle"
+    }
+    
+}
+
+public extension PlaylistOwnerIdResponseDTO {
+    func toDomain() -> PlaylistOwnerIdEntity {
+        PlaylistOwnerIdEntity(ownerId: ownerId)
+    }
+}

--- a/Projects/Domains/PlaylistDomain/Sources/UseCase/RequestPlaylistOwnerIDUsecaseImpl.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/UseCase/RequestPlaylistOwnerIDUsecaseImpl.swift
@@ -3,7 +3,7 @@ import Foundation
 import PlaylistDomainInterface
 import RxSwift
 
-public struct RequestPlaylistOwnerIdUsecaseImpl: RequestPlaylistOwnerIdUsecase {
+public struct RequestPlaylistOwnerIDUsecaseImpl: RequestPlaylistOwnerIDUsecase {
     private let playlistRepository: any PlaylistRepository
 
     public init(
@@ -12,7 +12,7 @@ public struct RequestPlaylistOwnerIdUsecaseImpl: RequestPlaylistOwnerIdUsecase {
         self.playlistRepository = playlistRepository
     }
 
-    public func execute(key: String) -> Single<PlaylistOwnerIdEntity> {
-        playlistRepository.requestPlaylistOwnerId(key: key)
+    public func execute(key: String) -> Single<PlaylistOwnerIDEntity> {
+        playlistRepository.requestPlaylistOwnerID(key: key)
     }
 }

--- a/Projects/Domains/PlaylistDomain/Sources/UseCase/RequestPlaylistOwnerIdUsecaseImpl.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/UseCase/RequestPlaylistOwnerIdUsecaseImpl.swift
@@ -1,0 +1,18 @@
+import BaseDomainInterface
+import Foundation
+import PlaylistDomainInterface
+import RxSwift
+
+public struct RequestPlaylistOwnerIdUsecaseImpl: RequestPlaylistOwnerIdUsecase {
+    private let playlistRepository: any PlaylistRepository
+
+    public init(
+        playlistRepository: PlaylistRepository
+    ) {
+        self.playlistRepository = playlistRepository
+    }
+
+    public func execute(key: String) -> Single<PlaylistOwnerIdEntity> {
+        playlistRepository.requestPlaylistOwnerId(key: key)
+    }
+}

--- a/Projects/Domains/SearchDomain/Interface/Entity/SearchPlaylistEntity.swift
+++ b/Projects/Domains/SearchDomain/Interface/Entity/SearchPlaylistEntity.swift
@@ -4,7 +4,7 @@ public struct SearchPlaylistEntity: Hashable, Equatable {
     public init(
         key: String,
         title: String,
-        ownerId: String,
+        ownerID: String,
         userName: String,
         image: String,
         date: String,
@@ -15,7 +15,7 @@ public struct SearchPlaylistEntity: Hashable, Equatable {
     ) {
         self.key = key
         self.title = title
-        self.ownerId = ownerId
+        self.ownerID = ownerID
         self.userName = userName
         self.image = image
         self.date = date
@@ -25,7 +25,7 @@ public struct SearchPlaylistEntity: Hashable, Equatable {
         self.isPrivate = isPrivate
     }
 
-    public let key, title, ownerId, image, date, userName: String
+    public let key, title, ownerID, image, date, userName: String
     public let count, subscribeCount: Int
     public let isPrivate: Bool
 

--- a/Projects/Domains/SearchDomain/Sources/DTO/SearchPlaylistDTO.swift
+++ b/Projects/Domains/SearchDomain/Sources/DTO/SearchPlaylistDTO.swift
@@ -40,7 +40,7 @@ public extension SearchPlaylistDTO {
         SearchPlaylistEntity(
             key: key,
             title: title,
-            ownerId: user.handle,
+            ownerID: user.handle,
             userName: user.name,
             image: imageUrl,
             date: (createdAt / 1000.0).unixTimeToDate.dateToString(format: "yyyy.MM.dd"),

--- a/Projects/Features/BaseFeature/Sources/Views/SongCartView.swift
+++ b/Projects/Features/BaseFeature/Sources/Views/SongCartView.swift
@@ -72,7 +72,7 @@ public class SongCartView: UIView {
 
         } else if button == songAddButton { // 노래담기
             guard Utility.PreferenceManager.userInfo != nil else {
-                showLoginPopup()
+               // showLoginPopup()
                 return
             }
             delegate?.buttonTapped(type: .addSong)
@@ -89,7 +89,7 @@ public class SongCartView: UIView {
 
             } else {
                 guard Utility.PreferenceManager.userInfo != nil else {
-                    showLoginPopup()
+                  //  showLoginPopup()
                     return
                 }
                 delegate?.buttonTapped(type: .remove)

--- a/Projects/Features/BaseFeature/Sources/Views/SongCartView.swift
+++ b/Projects/Features/BaseFeature/Sources/Views/SongCartView.swift
@@ -72,7 +72,7 @@ public class SongCartView: UIView {
 
         } else if button == songAddButton { // 노래담기
             guard Utility.PreferenceManager.userInfo != nil else {
-               // showLoginPopup()
+               showLoginPopup()
                 return
             }
             delegate?.buttonTapped(type: .addSong)
@@ -89,7 +89,7 @@ public class SongCartView: UIView {
 
             } else {
                 guard Utility.PreferenceManager.userInfo != nil else {
-                  //  showLoginPopup()
+                    showLoginPopup()
                     return
                 }
                 delegate?.buttonTapped(type: .remove)

--- a/Projects/Features/HomeFeature/Sources/ViewControllers/HomeViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewControllers/HomeViewController.swift
@@ -432,7 +432,7 @@ extension HomeViewController: HomeNewSongCellDelegate {
 extension HomeViewController: RecommendPlayListViewDelegate {
     public func itemSelected(model: RecommendPlaylistEntity) {
         LogManager.analytics(CommonAnalyticsLog.clickPlaylistItem(location: .home))
-        let viewController = playlistDetailFactory.makeView(key: model.key)
+        let viewController = playlistDetailFactory.makeWmView(key: model.key) // 왁뮤 플리 
         self.navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Projects/Features/HomeFeature/Sources/ViewControllers/HomeViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewControllers/HomeViewController.swift
@@ -432,7 +432,7 @@ extension HomeViewController: HomeNewSongCellDelegate {
 extension HomeViewController: RecommendPlayListViewDelegate {
     public func itemSelected(model: RecommendPlaylistEntity) {
         LogManager.analytics(CommonAnalyticsLog.clickPlaylistItem(location: .home))
-        let viewController = playlistDetailFactory.makeView(key: model.key, kind: .wakmu)
+        let viewController = playlistDetailFactory.makeView(key: model.key)
         self.navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
@@ -124,7 +124,8 @@ private extension MainTabBarViewController {
         switch page {
         case "playlist":
             let key: String = params["key"] as? String ?? ""
-            let viewController = playlistDetailFactory.makeView(key: key)
+            #warning("함수 매개변수에 ownerId 넘겨주시면되여")
+            let viewController = playlistDetailFactory.makeView(key: key) // makeView(key: key, ownerId: ownerId) 넣어주시는 함수로 변경
             navigationController?.pushViewController(viewController, animated: true)
 
         default:

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
@@ -124,7 +124,7 @@ private extension MainTabBarViewController {
         switch page {
         case "playlist":
             let key: String = params["key"] as? String ?? ""
-            let viewController = playlistDetailFactory.makeView(key: key, kind: .unknown)
+            let viewController = playlistDetailFactory.makeView(key: key)
             navigationController?.pushViewController(viewController, animated: true)
 
         default:

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
@@ -124,8 +124,7 @@ private extension MainTabBarViewController {
         switch page {
         case "playlist":
             let key: String = params["key"] as? String ?? ""
-            #warning("함수 매개변수에 ownerId 넘겨주시면되여")
-            let viewController = playlistDetailFactory.makeView(key: key) // makeView(key: key, ownerId: ownerId) 넣어주시는 함수로 변경
+            let viewController = playlistDetailFactory.makeView(key: key)
             navigationController?.pushViewController(viewController, animated: true)
 
         default:

--- a/Projects/Features/PlaylistFeature/Interface/PlaylistDetailFactory.swift
+++ b/Projects/Features/PlaylistFeature/Interface/PlaylistDetailFactory.swift
@@ -8,6 +8,6 @@ public enum PlaylistDetailKind {
 }
 
 public protocol PlaylistDetailFactory {
-    func makeView(key: String, ownerId: String) -> UIViewController
     func makeView(key: String) -> UIViewController
+    func makeWmView(key: String) -> UIViewController
 }

--- a/Projects/Features/PlaylistFeature/Interface/PlaylistDetailFactory.swift
+++ b/Projects/Features/PlaylistFeature/Interface/PlaylistDetailFactory.swift
@@ -8,5 +8,6 @@ public enum PlaylistDetailKind {
 }
 
 public protocol PlaylistDetailFactory {
-    func makeView(key: String, kind: PlaylistDetailKind) -> UIViewController
+    func makeView(key: String, ownerId: String) -> UIViewController
+    func makeView(key: String) -> UIViewController
 }

--- a/Projects/Features/PlaylistFeature/Interface/PlaylistDetailNavigator.swift
+++ b/Projects/Features/PlaylistFeature/Interface/PlaylistDetailNavigator.swift
@@ -4,12 +4,20 @@ import UIKit
 public protocol PlaylistDetailNavigator {
     var playlistDetailFactory: any PlaylistDetailFactory { get }
 
-    func navigatePlaylistDetail(key: String, kind: PlaylistDetailKind)
+    func navigatePlaylistDetail(key: String, ownerId: String)
+    
+    func navigatePlaylistDetail(key: String)
 }
 
 public extension PlaylistDetailNavigator where Self: UIViewController {
-    func navigatePlaylistDetail(key: String, kind: PlaylistDetailKind) {
-        let dest = playlistDetailFactory.makeView(key: key, kind: kind)
+    func navigatePlaylistDetail(key: String, ownerId: String) {
+        let dest = playlistDetailFactory.makeView(key: key, ownerId: ownerId)
+
+        self.navigationController?.pushViewController(dest, animated: true)
+    }
+    
+    func navigatePlaylistDetail(key: String) {
+        let dest = playlistDetailFactory.makeView(key: key)
 
         self.navigationController?.pushViewController(dest, animated: true)
     }

--- a/Projects/Features/PlaylistFeature/Interface/PlaylistDetailNavigator.swift
+++ b/Projects/Features/PlaylistFeature/Interface/PlaylistDetailNavigator.swift
@@ -4,14 +4,14 @@ import UIKit
 public protocol PlaylistDetailNavigator {
     var playlistDetailFactory: any PlaylistDetailFactory { get }
 
-    func navigatePlaylistDetail(key: String, ownerId: String)
+    func navigateWmPlaylistDetail(key: String)
     
     func navigatePlaylistDetail(key: String)
 }
 
 public extension PlaylistDetailNavigator where Self: UIViewController {
-    func navigatePlaylistDetail(key: String, ownerId: String) {
-        let dest = playlistDetailFactory.makeView(key: key, ownerId: ownerId)
+    func navigateWmPlaylistDetail(key: String) {
+        let dest = playlistDetailFactory.makeWmView(key: key)
 
         self.navigationController?.pushViewController(dest, animated: true)
     }

--- a/Projects/Features/PlaylistFeature/Project.swift
+++ b/Projects/Features/PlaylistFeature/Project.swift
@@ -14,6 +14,7 @@ let project = Project.module(
                 .feature(target: .BaseFeature),
                 .feature(target: .PlaylistFeature, type: .interface),
                 .feature(target: .MusicDetailFeature, type: .interface),
+                .feature(target: .SignInFeature, type: .interface),
                 .domain(target: .AuthDomain, type: .interface),
                 .domain(target: .PlaylistDomain, type: .interface),
                 .domain(target: .ImageDomain, type: .interface)

--- a/Projects/Features/PlaylistFeature/Sources/Components/PlaylistDetailComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/PlaylistDetailComponent.swift
@@ -17,6 +17,7 @@ public final class PlaylistDetailComponent: Component<PlaylistDetailFactoryDepen
         let reactor = PlaylistDetailContainerReactor(key: key, requestPlaylistOwnerIdUsecase: dependency.requestPlaylistOwnerIdUsecase)
         
         return PlaylistDetailContainerViewController(reactor: reactor,
+                                                     key: key,
                                                      unknownPlaylistDetailFactory: dependency.unknownPlaylistDetailFactory, myPlaylistDetailFactory: dependency.myPlaylistDetailFactory)
     }
     

--- a/Projects/Features/PlaylistFeature/Sources/Components/PlaylistDetailComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/PlaylistDetailComponent.swift
@@ -9,14 +9,16 @@ public protocol PlaylistDetailFactoryDependency: Dependency {
 }
 
 public final class PlaylistDetailComponent: Component<PlaylistDetailFactoryDependency>, PlaylistDetailFactory {
-    public func makeView(key: String, kind: PlaylistDetailKind) -> UIViewController {
-        switch kind {
-        case .my:
-            return dependency.myPlaylistDetailFactory.makeView(key: key)
-        case .unknown:
-            return dependency.unknownPlaylistDetailFactory.makeView(key: key)
-        case .wakmu:
-            return dependency.wakmusicPlaylistDetailFactory.makeView(key: key)
-        }
+    
+    public func makeView(key: String) -> UIViewController {
+        return dependency.wakmusicPlaylistDetailFactory.makeView(key: key)
     }
+    
+    public func makeView(key: String, ownerId: String) -> UIViewController {
+        return PlaylistDetailContainerViewController(key: key, ownerId: ownerId,
+                                                     unknownPlaylistDetailFactory: dependency.unknownPlaylistDetailFactory,
+                                                     myPlaylistDetailFactory: dependency.myPlaylistDetailFactory)
+    }
+    
+
 }

--- a/Projects/Features/PlaylistFeature/Sources/Components/PlaylistDetailComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/PlaylistDetailComponent.swift
@@ -1,23 +1,28 @@
 import NeedleFoundation
 import PlaylistFeatureInterface
+import PlaylistDomainInterface
 import UIKit
 
 public protocol PlaylistDetailFactoryDependency: Dependency {
     var myPlaylistDetailFactory: any MyPlaylistDetailFactory { get }
     var unknownPlaylistDetailFactory: any UnknownPlaylistDetailFactory { get }
     var wakmusicPlaylistDetailFactory: any WakmusicPlaylistDetailFactory { get }
+    var requestPlaylistOwnerIdUsecase: any RequestPlaylistOwnerIdUsecase { get }
 }
 
 public final class PlaylistDetailComponent: Component<PlaylistDetailFactoryDependency>, PlaylistDetailFactory {
     
     public func makeView(key: String) -> UIViewController {
-        return dependency.wakmusicPlaylistDetailFactory.makeView(key: key)
+        
+        let reactor = PlaylistDetailContainerReactor(key: key, requestPlaylistOwnerIdUsecase: dependency.requestPlaylistOwnerIdUsecase)
+        
+        return PlaylistDetailContainerViewController(reactor: reactor,
+                                                     unknownPlaylistDetailFactory: dependency.unknownPlaylistDetailFactory, myPlaylistDetailFactory: dependency.myPlaylistDetailFactory)
     }
     
-    public func makeView(key: String, ownerId: String) -> UIViewController {
-        return PlaylistDetailContainerViewController(key: key, ownerId: ownerId,
-                                                     unknownPlaylistDetailFactory: dependency.unknownPlaylistDetailFactory,
-                                                     myPlaylistDetailFactory: dependency.myPlaylistDetailFactory)
+    
+    public func makeWmView(key: String) -> UIViewController {
+        return dependency.wakmusicPlaylistDetailFactory.makeView(key: key)
     }
     
 

--- a/Projects/Features/PlaylistFeature/Sources/Components/PlaylistDetailComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/PlaylistDetailComponent.swift
@@ -7,14 +7,14 @@ public protocol PlaylistDetailFactoryDependency: Dependency {
     var myPlaylistDetailFactory: any MyPlaylistDetailFactory { get }
     var unknownPlaylistDetailFactory: any UnknownPlaylistDetailFactory { get }
     var wakmusicPlaylistDetailFactory: any WakmusicPlaylistDetailFactory { get }
-    var requestPlaylistOwnerIdUsecase: any RequestPlaylistOwnerIdUsecase { get }
+    var requestPlaylistOwnerIDUsecase: any RequestPlaylistOwnerIDUsecase { get }
 }
 
 public final class PlaylistDetailComponent: Component<PlaylistDetailFactoryDependency>, PlaylistDetailFactory {
     
     public func makeView(key: String) -> UIViewController {
         
-        let reactor = PlaylistDetailContainerReactor(key: key, requestPlaylistOwnerIdUsecase: dependency.requestPlaylistOwnerIdUsecase)
+        let reactor = PlaylistDetailContainerReactor(key: key, requestPlaylistOwnerIDUsecase: dependency.requestPlaylistOwnerIDUsecase)
         
         return PlaylistDetailContainerViewController(reactor: reactor,
                                                      key: key,

--- a/Projects/Features/PlaylistFeature/Sources/Components/UnkwonPlaylistDetailComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/UnkwonPlaylistDetailComponent.swift
@@ -5,6 +5,7 @@ import MusicDetailFeatureInterface
 import NeedleFoundation
 import PlaylistDomainInterface
 import PlaylistFeatureInterface
+import SignInFeatureInterface
 import UIKit
 
 public protocol UnknownPlaylistDetailDependency: Dependency {
@@ -21,6 +22,8 @@ public protocol UnknownPlaylistDetailDependency: Dependency {
     var textPopUpFactory: any TextPopUpFactory { get }
 
     var musicDetailFactory: any MusicDetailFactory { get }
+    
+    var signInFactory: any SignInFactory { get }
 }
 
 public final class UnknownPlaylistDetailComponent: Component<UnknownPlaylistDetailDependency>,
@@ -36,7 +39,8 @@ public final class UnknownPlaylistDetailComponent: Component<UnknownPlaylistDeta
             ),
             containSongsFactory: dependency.containSongsFactory,
             textPopUpFactory: dependency.textPopUpFactory,
-            musicDetailFactory: dependency.musicDetailFactory
+            musicDetailFactory: dependency.musicDetailFactory,
+            signInFactory: dependency.signInFactory
         )
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
@@ -17,7 +17,7 @@ final class PlaylistDetailContainerReactor: Reactor {
      
     struct State {
         var isLoading: Bool
-        var ownerId: String?
+        var ownerID: String?
         @Pulse var toastMessgae: String?
     }
     
@@ -45,8 +45,8 @@ final class PlaylistDetailContainerReactor: Reactor {
         
         switch mutation {
             
-        case let .updateOwnerId(ownerId):
-            newState.ownerId = ownerId
+        case let .updateOwnerId(ownerID):
+            newState.ownerID = ownerID
         case let .showToastMessagae(message):
             newState.toastMessgae = message
         case let .updateLoadingState(flag):
@@ -64,9 +64,9 @@ extension PlaylistDetailContainerReactor{
         return requestPlaylistOwnerIdUsecase
             .execute(key: key)
             .asObservable()
-            .catchAndReturn(PlaylistOwnerIdEntity(ownerId: "__"))
+            .catchAndReturn(PlaylistOwnerIdEntity(ownerID: "__"))
             .flatMap({ entitiy -> Observable<Mutation> in
-                return .just(Mutation.updateOwnerId(entitiy.ownerId))
+                return .just(Mutation.updateOwnerId(entitiy.ownerID))
             })
         
     }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
@@ -60,19 +60,14 @@ final class PlaylistDetailContainerReactor: Reactor {
 
 extension PlaylistDetailContainerReactor{
     func updateOwnerId() -> Observable<Mutation> {
-        
-        return .concat([
-        
-            updateLoadingState(flag: true),
-            requestPlaylistOwnerIdUsecase
-                .execute(key: key)
-                .asObservable()
-                .catchAndReturn(PlaylistOwnerIdEntity(ownerId: "__"))
-                .flatMap({ entitiy -> Observable<Mutation> in
-                    return .just(Mutation.updateOwnerId(entitiy.ownerId))
-                }),
-            updateLoadingState(flag: false)
-        ])
+
+        return requestPlaylistOwnerIdUsecase
+            .execute(key: key)
+            .asObservable()
+            .catchAndReturn(PlaylistOwnerIdEntity(ownerId: "__"))
+            .flatMap({ entitiy -> Observable<Mutation> in
+                return .just(Mutation.updateOwnerId(entitiy.ownerId))
+            })
         
     }
     

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
@@ -6,11 +6,11 @@ import RxSwift
 final class PlaylistDetailContainerReactor: Reactor {
     
     enum Action {
-        case requestOwnerId
+        case requestOwnerID
     }
     
     enum Mutation {
-        case updateOwnerId(String)
+        case updateOwnerID(String)
         case updateLoadingState(Bool)
         case showToastMessagae(String)
     }
@@ -21,21 +21,21 @@ final class PlaylistDetailContainerReactor: Reactor {
         @Pulse var toastMessgae: String?
     }
     
-    private let requestPlaylistOwnerIdUsecase: any RequestPlaylistOwnerIdUsecase
+    private let requestPlaylistOwnerIDUsecase: any RequestPlaylistOwnerIDUsecase
     let key: String
     var initialState: State
     
-    init(key: String, requestPlaylistOwnerIdUsecase: any RequestPlaylistOwnerIdUsecase) {
+    init(key: String, requestPlaylistOwnerIDUsecase: any RequestPlaylistOwnerIDUsecase) {
         self.key = key
         initialState = State(isLoading: true)
-        self.requestPlaylistOwnerIdUsecase = requestPlaylistOwnerIdUsecase
+        self.requestPlaylistOwnerIDUsecase = requestPlaylistOwnerIDUsecase
     }
     
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .requestOwnerId:
-            return updateOwnerId()
+        case .requestOwnerID:
+            return updateOwnerID()
         }
     }
     
@@ -45,7 +45,7 @@ final class PlaylistDetailContainerReactor: Reactor {
         
         switch mutation {
             
-        case let .updateOwnerId(ownerID):
+        case let .updateOwnerID(ownerID):
             newState.ownerID = ownerID
         case let .showToastMessagae(message):
             newState.toastMessgae = message
@@ -59,14 +59,14 @@ final class PlaylistDetailContainerReactor: Reactor {
 }
 
 extension PlaylistDetailContainerReactor{
-    func updateOwnerId() -> Observable<Mutation> {
+    func updateOwnerID() -> Observable<Mutation> {
 
-        return requestPlaylistOwnerIdUsecase
+        return requestPlaylistOwnerIDUsecase
             .execute(key: key)
             .asObservable()
-            .catchAndReturn(PlaylistOwnerIdEntity(ownerID: "__"))
+            .catchAndReturn(PlaylistOwnerIDEntity(ownerID: "__"))
             .flatMap({ entitiy -> Observable<Mutation> in
-                return .just(Mutation.updateOwnerId(entitiy.ownerID))
+                return .just(Mutation.updateOwnerID(entitiy.ownerID))
             })
         
     }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
@@ -1,0 +1,83 @@
+import Foundation
+import ReactorKit
+import PlaylistDomainInterface
+import RxSwift
+
+final class PlaylistDetailContainerReactor: Reactor {
+    
+    enum Action {
+        case viewDidLoad
+    }
+    
+    enum Mutation {
+        case updateOwnerId(String)
+        case updateLoadingState(Bool)
+        case showToastMessagae(String)
+    }
+     
+    struct State {
+        var isLoading: Bool
+        var ownerId: String?
+        @Pulse var toastMessgae: String?
+    }
+    
+    private let requestPlaylistOwnerIdUsecase: any RequestPlaylistOwnerIdUsecase
+    let key: String
+    var initialState: State
+    
+    init(key: String, requestPlaylistOwnerIdUsecase: any RequestPlaylistOwnerIdUsecase) {
+        self.key = key
+        initialState = State(isLoading: true)
+        self.requestPlaylistOwnerIdUsecase = requestPlaylistOwnerIdUsecase
+    }
+    
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .viewDidLoad:
+            return updateOwnerId()
+        }
+    }
+    
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        
+        switch mutation {
+            
+        case let .updateOwnerId(ownerId):
+            newState.ownerId = ownerId
+        case let .showToastMessagae(message):
+            newState.toastMessgae = message
+        case let .updateLoadingState(flag):
+            newState.isLoading = flag
+        }
+        
+        return newState
+    }
+    
+}
+
+extension PlaylistDetailContainerReactor{
+    func updateOwnerId() -> Observable<Mutation> {
+        
+        return .concat([
+        
+            updateLoadingState(flag: true),
+            requestPlaylistOwnerIdUsecase
+                .execute(key: key)
+                .asObservable()
+                .catchAndReturn(PlaylistOwnerIdEntity(ownerId: "__"))
+                .flatMap({ entitiy -> Observable<Mutation> in
+                    return .just(Mutation.updateOwnerId(entitiy.ownerId))
+                }),
+            updateLoadingState(flag: false)
+        ])
+        
+    }
+    
+    func updateLoadingState(flag: Bool) -> Observable<Mutation> {
+        
+        return .just(.updateLoadingState(flag))
+    }
+}

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
@@ -6,7 +6,7 @@ import RxSwift
 final class PlaylistDetailContainerReactor: Reactor {
     
     enum Action {
-        case viewDidLoad
+        case requestOwnerId
     }
     
     enum Mutation {
@@ -34,7 +34,7 @@ final class PlaylistDetailContainerReactor: Reactor {
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .viewDidLoad:
+        case .requestOwnerId:
             return updateOwnerId()
         }
     }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -274,7 +274,7 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
                 activityViewController.popoverPresentationController?.permittedArrowDirections = []
                 owner.present(activityViewController, animated: true)
             }
-
+        
         sharedState.map(\.isEditing)
             .distinctUntilChanged()
             .bind(with: self) { owner, isEditing in

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
@@ -56,11 +56,12 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
                 
                 owner.remove(asChildViewController: owner.children.first)
                 
-                guard let userInfo else {
+                if userInfo == nil {
                     owner.add(asChildViewController: owner.unknownPlaylistVC)
-                    return
+                } else {
+                    reactor.action.onNext(.requestOwnerID)
                 }
-                reactor.action.onNext(.requestOwnerID)
+                 
               
             }
             .disposed(by: disposeBag)

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
@@ -74,20 +74,20 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
         let sharedState = reactor.state.share()
         
         
-        sharedState.map(\.ownerId)
+        sharedState.map(\.ownerID)
             .compactMap({ $0 })
             .distinctUntilChanged()
             .withLatestFrom(PreferenceManager.$userInfo){ ($0, $1) }
             .bind(with: self) { owner, info in
                 
-                let (ownerId, userInfo) = info
+                let (ownerID, userInfo) = info
                 
                 guard let userInfo else { return }
                 
                 
                 owner.remove(asChildViewController: owner.children.first)
                 
-                if ownerId == userInfo.decryptedID {
+                if ownerID == userInfo.decryptedID {
                     owner.add(asChildViewController: owner.myPlaylistVC)
                 } else {
                     owner.add(asChildViewController: owner.unknownPlaylistVC)

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
@@ -1,0 +1,79 @@
+import UIKit
+import SnapKit
+import Then
+import BaseFeature
+import Utility
+import PlaylistFeatureInterface
+import RxSwift
+
+final class PlaylistDetailContainerViewController: UIViewController ,ContainerViewType {
+    var contentView: UIView!
+    
+    private let key: String
+    private let ownerId: String
+    private let unknownPlaylistDetailFactory: any UnknownPlaylistDetailFactory
+    private let myPlaylistDetailFactory:  any MyPlaylistDetailFactory
+    private var disposeBag = DisposeBag()
+    
+    private lazy var unknownPlaylistVC = unknownPlaylistDetailFactory.makeView(key: key)
+    private lazy var myPlaylistVC = myPlaylistDetailFactory.makeView(key: key)
+    
+    private let containerView: UIView = UIView()
+    
+    
+    init(key: String, ownerId: String ,unknownPlaylistDetailFactory: any UnknownPlaylistDetailFactory,  myPlaylistDetailFactory: any MyPlaylistDetailFactory ) {
+        
+        self.key = key
+        self.ownerId = ownerId
+        self.unknownPlaylistDetailFactory = unknownPlaylistDetailFactory
+        self.myPlaylistDetailFactory = myPlaylistDetailFactory
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        contentView = containerView
+        addViews()
+        setLayout()
+        configureUI()
+    }
+}
+
+extension PlaylistDetailContainerViewController {
+    
+    private func addViews() {
+        self.view.addSubviews(containerView)
+    }
+    
+    private func setLayout() {
+        containerView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    private func configureUI() {
+        PreferenceManager.$userInfo
+            .bind(with: self) { owner, userInfo in
+                
+                guard let userInfo = userInfo else {
+                    owner.add(asChildViewController: owner.unknownPlaylistVC)
+                    return
+                }
+                
+                if userInfo.decryptedID == owner.ownerId {
+                    owner.add(asChildViewController: owner.myPlaylistVC)
+                } else {
+                    owner.add(asChildViewController: owner.unknownPlaylistVC)
+                }
+                
+            }
+            .disposed(by: disposeBag)
+        
+    }
+}

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
@@ -60,7 +60,7 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
                     owner.add(asChildViewController: owner.unknownPlaylistVC)
                     return
                 }
-                reactor.action.onNext(.requestOwnerId)
+                reactor.action.onNext(.requestOwnerID)
               
             }
             .disposed(by: disposeBag)

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
@@ -60,7 +60,6 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
                     owner.add(asChildViewController: owner.unknownPlaylistVC)
                     return
                 }
-                DEBUG_LOG("CHILD \(owner.children)")
                 reactor.action.onNext(.requestOwnerId)
               
             }
@@ -77,9 +76,14 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
         
         sharedState.map(\.ownerId)
             .compactMap({ $0 })
-            .bind(with: self) { owner, ownerId in
+            .distinctUntilChanged()
+            .withLatestFrom(PreferenceManager.$userInfo){ ($0, $1) }
+            .bind(with: self) { owner, info in
                 
-                guard let userInfo = PreferenceManager.userInfo else { return }
+                let (ownerId, userInfo) = info
+                
+                guard let userInfo else { return }
+                
                 
                 owner.remove(asChildViewController: owner.children.first)
                 
@@ -89,7 +93,6 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
                     owner.add(asChildViewController: owner.unknownPlaylistVC)
                 }
                 
-                DEBUG_LOG("CHILD \(owner.children)")
             }
             .disposed(by: disposeBag)
         

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
@@ -5,9 +5,12 @@ import BaseFeature
 import Utility
 import PlaylistFeatureInterface
 import RxSwift
+import DesignSystem
 
 final class PlaylistDetailContainerViewController: BaseReactorViewController<PlaylistDetailContainerReactor>, ContainerViewType {
-    var contentView: UIView! = UIView()
+    var contentView: UIView! = UIView().then {
+        $0.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
+    }
     private let unknownPlaylistDetailFactory: any UnknownPlaylistDetailFactory
     private let myPlaylistDetailFactory: any MyPlaylistDetailFactory
     private let key: String
@@ -90,14 +93,6 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
             }
             .disposed(by: disposeBag)
         
-//        sharedState.map(\.isLoading)
-//            .distinctUntilChanged()
-//            .bind(with: self) { owner, isLoading in
-//                owner.contentView.isHidden = isLoading
-//            }
-//            .disposed(by: disposeBag)
-        
-    
     
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
@@ -10,6 +10,7 @@ import SnapKit
 import SongsDomainInterface
 import Then
 import UIKit
+import SignInFeatureInterface
 import Utility
 
 final class UnknownPlaylistDetailViewController: BaseReactorViewController<UnknownPlaylistDetailReactor>,
@@ -23,6 +24,8 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
     private let textPopUpFactory: any TextPopUpFactory
 
     private let musicDetailFactory: any MusicDetailFactory
+    
+    private let signInFactory: any SignInFactory
 
     private var wmNavigationbarView: WMNavigationBarView = WMNavigationBarView()
 
@@ -62,11 +65,13 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
         reactor: UnknownPlaylistDetailReactor,
         containSongsFactory: any ContainSongsFactory,
         textPopUpFactory: any TextPopUpFactory,
-        musicDetailFactory: any MusicDetailFactory
+        musicDetailFactory: any MusicDetailFactory,
+        signInFactory: any SignInFactory
     ) {
         self.containSongsFactory = containSongsFactory
         self.textPopUpFactory = textPopUpFactory
         self.musicDetailFactory = musicDetailFactory
+        self.signInFactory = signInFactory
         super.init(reactor: reactor)
     }
 
@@ -171,7 +176,9 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
                     text: "로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?",
                     cancelButtonIsHidden: false,
                     completion: { () in
-                        NotificationCenter.default.post(name: .movedTab, object: 4)
+                        let vc = owner.signInFactory.makeView()
+                        vc.modalPresentationStyle = .fullScreen
+                        owner.present(vc, animated: true)
                     }
                 )
 

--- a/Projects/Features/PlaylistFeature/Testing/PlaylistDetailFactoryStub.swift
+++ b/Projects/Features/PlaylistFeature/Testing/PlaylistDetailFactoryStub.swift
@@ -2,7 +2,13 @@ import PlaylistFeatureInterface
 import UIKit
 
 public final class PlaylistDetailFactoryStub: PlaylistDetailFactory {
-    public func makeView(key: String, kind: PlaylistDetailKind) -> UIViewController {
+    public func makeView(key: String) -> UIViewController {
         return UIViewController()
     }
+    
+    public func makeWmView(key: String) -> UIViewController {
+        return UIViewController()
+    }
+    
+
 }

--- a/Projects/Features/SearchFeature/Project.swift
+++ b/Projects/Features/SearchFeature/Project.swift
@@ -18,6 +18,7 @@ let project = Project.module(
                     .feature(target: .SearchFeature, type: .interface),
                     .feature(target: .PlaylistFeature, type: .interface),
                     .feature(target: .MusicDetailFeature, type: .interface),
+                    .feature(target: .SignInFeature, type: .interface),
                     .domain(target: .SearchDomain, type: .interface),
                     .domain(target: .ChartDomain, type: .interface)
                 ]

--- a/Projects/Features/SearchFeature/Sources/After/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/After/ViewControllers/ListSearchResultViewController.swift
@@ -233,7 +233,7 @@ extension ListSearchResultViewController: UICollectionViewDelegate {
 
 
         LogManager.analytics(CommonAnalyticsLog.clickPlaylistItem(location: .search))
-        navigatePlaylistDetail(key: model.key, ownerId: model.ownerId)
+        navigatePlaylistDetail(key: model.key)
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/Projects/Features/SearchFeature/Sources/After/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/After/ViewControllers/ListSearchResultViewController.swift
@@ -231,11 +231,9 @@ extension ListSearchResultViewController: UICollectionViewDelegate {
             return
         }
 
-        let id = PreferenceManager.userInfo?.decryptedID ?? ""
-        let isMine = model.ownerId == id
 
         LogManager.analytics(CommonAnalyticsLog.clickPlaylistItem(location: .search))
-        navigatePlaylistDetail(key: model.key, kind: isMine ? .my : .unknown)
+        navigatePlaylistDetail(key: model.key, ownerId: model.ownerId)
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/Projects/Features/SearchFeature/Sources/After/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/After/ViewControllers/SongSearchResultViewController.swift
@@ -137,8 +137,12 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
 
         reactor.pulse(\.$toastMessage)
             .compactMap { $0 }
-            .bind(with: self) { owner, message in
-                owner.showToast(text: message, font: .setFont(.t6(weight: .light)))
+            .withLatestFrom(sharedState.map(\.selectedCount)){($0, $1)}
+            .bind(with: self) { owner, info in
+                
+                let(message, count) = (info.0, info.1)
+                
+                owner.showToast(text: message,options: count == .zero ?  [.tabBar] : [.tabBar, .songCart])
             }
             .disposed(by: disposeBag)
 
@@ -335,10 +339,7 @@ extension SongSearchResultViewController: SongCartViewDelegate {
             guard songs.count <= limit else {
                 showToast(
                     text: LocalizationStrings.overFlowContainWarning(songs.count - limit),
-
-                    font: .setFont(.t6(weight: .light)),
-
-                    verticalOffset: 56 + 10
+                    options: [.tabBar]
                 )
                 return
             }
@@ -353,10 +354,7 @@ extension SongSearchResultViewController: SongCartViewDelegate {
             guard songs.count <= limit else {
                 showToast(
                     text: LocalizationStrings.overFlowContainWarning(songs.count - limit),
-
-                    font: .setFont(.t6(weight: .light)),
-
-                    verticalOffset: 56 + 10
+                    options: [.tabBar]
                 )
                 return
             }
@@ -369,10 +367,7 @@ extension SongSearchResultViewController: SongCartViewDelegate {
             guard songs.count <= limit else {
                 showToast(
                     text: LocalizationStrings.overFlowPlayWarning(songs.count - limit),
-
-                    font: .setFont(.t6(weight: .light)),
-
-                    verticalOffset: 56 + 10
+                    options: [.tabBar]
                 )
                 return
             }

--- a/Projects/Features/SearchFeature/Sources/Before/ViewControllers/BeforeSearchContentViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/Before/ViewControllers/BeforeSearchContentViewController.swift
@@ -324,8 +324,7 @@ extension BeforeSearchContentViewController: UICollectionViewDelegate {
             WakmusicYoutubePlayer(id: model.id).play()
             LogManager.analytics(SearchAnalyticsLog.clickLatestWakmuYoutubeVideo)
         case let .recommend(model: model):
-
-            navigatePlaylistDetail(key: model.key)
+            navigateWmPlaylistDetail(key: model.key)
 
             #warning("추후 업데이트 시 사용")
 //        case let .popularList(model: model):

--- a/Projects/Features/SearchFeature/Sources/Before/ViewControllers/BeforeSearchContentViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/Before/ViewControllers/BeforeSearchContentViewController.swift
@@ -325,7 +325,7 @@ extension BeforeSearchContentViewController: UICollectionViewDelegate {
             LogManager.analytics(SearchAnalyticsLog.clickLatestWakmuYoutubeVideo)
         case let .recommend(model: model):
 
-            navigatePlaylistDetail(key: model.key, kind: .wakmu)
+            navigatePlaylistDetail(key: model.key)
 
             #warning("추후 업데이트 시 사용")
 //        case let .popularList(model: model):

--- a/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
@@ -37,7 +37,7 @@ final class ListStorageReactor: Reactor {
         case showToast(String)
         case showCreateListPopup
         case showDeletePopup(Int)
-        case showDetail(key: String, ownerId: String)
+        case showDetail(key: String)
         case hideSongCart
         case updateSelectedItemCount(Int)
         case showDrawFruitPopup
@@ -55,7 +55,7 @@ final class ListStorageReactor: Reactor {
         @Pulse var hideSongCart: Void?
         @Pulse var showCreateListPopup: Void?
         @Pulse var showDeletePopup: Int?
-        @Pulse var showDetail: (key: String, ownerId: String)?
+        @Pulse var showDetail: String?
         @Pulse var showDrawFruitPopup: Void?
     }
 
@@ -215,8 +215,8 @@ final class ListStorageReactor: Reactor {
             newState.showDeletePopup = itemCount
         case let .updateSelectedItemCount(count):
             newState.selectedItemCount = count
-        case let .showDetail(key, isMine):
-            newState.showDetail = (key, isMine)
+        case let .showDetail(key):
+            newState.showDetail = key
         case .showDrawFruitPopup:
             newState.showDrawFruitPopup = ()
         }
@@ -285,9 +285,9 @@ extension ListStorageReactor {
     func showDetail(_ indexPath: IndexPath) -> Observable<Mutation> {
         let selectedList = currentState.dataSource[indexPath.section].items[indexPath.row]
         let key = selectedList.key
-        let ownerId = selectedList.userId
 
-        return .just(.showDetail(key: key, ownerId: ownerId ))
+
+        return .just(.showDetail(key: key))
     }
 
     func addToCurrentPlaylist() -> Observable<Mutation> {

--- a/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
@@ -37,7 +37,7 @@ final class ListStorageReactor: Reactor {
         case showToast(String)
         case showCreateListPopup
         case showDeletePopup(Int)
-        case showDetail(key: String, isMine: Bool)
+        case showDetail(key: String, ownerId: String)
         case hideSongCart
         case updateSelectedItemCount(Int)
         case showDrawFruitPopup
@@ -55,7 +55,7 @@ final class ListStorageReactor: Reactor {
         @Pulse var hideSongCart: Void?
         @Pulse var showCreateListPopup: Void?
         @Pulse var showDeletePopup: Int?
-        @Pulse var showDetail: (key: String, isMine: Bool)?
+        @Pulse var showDetail: (key: String, ownerId: String)?
         @Pulse var showDrawFruitPopup: Void?
     }
 
@@ -285,9 +285,9 @@ extension ListStorageReactor {
     func showDetail(_ indexPath: IndexPath) -> Observable<Mutation> {
         let selectedList = currentState.dataSource[indexPath.section].items[indexPath.row]
         let key = selectedList.key
-        let isMine = PreferenceManager.userInfo?.decryptedID == selectedList.userId
+        let ownerId = selectedList.userId
 
-        return .just(.showDetail(key: key, isMine: isMine))
+        return .just(.showDetail(key: key, ownerId: ownerId ))
     }
 
     func addToCurrentPlaylist() -> Observable<Mutation> {

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
@@ -83,10 +83,8 @@ final class ListStorageViewController: BaseReactorViewController<ListStorageReac
 
         reactor.pulse(\.$showDetail)
             .compactMap { $0 }
-            .bind(with: self, onNext: { owner, detailInfo in
-                let key = detailInfo.key
-                let ownerId = detailInfo.ownerId
-                owner.navigatePlaylistDetail(key: key, ownerId: ownerId)
+            .bind(with: self, onNext: { owner, key in
+                owner.navigatePlaylistDetail(key: key)
             })
             .disposed(by: disposeBag)
 

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
@@ -85,8 +85,8 @@ final class ListStorageViewController: BaseReactorViewController<ListStorageReac
             .compactMap { $0 }
             .bind(with: self, onNext: { owner, detailInfo in
                 let key = detailInfo.key
-                let isMine = detailInfo.isMine
-                owner.navigatePlaylistDetail(key: key, kind: isMine ? .my : .unknown)
+                let ownerId = detailInfo.ownerId
+                owner.navigatePlaylistDetail(key: key, ownerId: ownerId)
             })
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 💡 배경 및 개요

로그인 전 unkwown을 보여준 후 로그인 해도 해당 플레이리스트가 그대로 unkwown임

Resolves: #895

## 📃 작업내용

```swift
navigateWmPlaylistDetail(key: String) -> 오직 왁뮤플리만

navigatePlaylistDetail(key: String) -> unknown / my 알아서 판단해줌
```

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
