### PR TITLE
🔀  :: (#912) 재생목록 화면 인터렉션 및 UI 반영

### DIFF
--- a/Projects/Features/LyricHighlightingFeature/Sources/ViewControllers/LyricHighlightingViewController.swift
+++ b/Projects/Features/LyricHighlightingFeature/Sources/ViewControllers/LyricHighlightingViewController.swift
@@ -244,7 +244,6 @@ private extension LyricHighlightingViewController {
             with: URL(string: WMImageAPI.fetchYoutubeThumbnailHD(id: output.updateInfo.value.songID).toString),
             options: [
                 .waitForCache,
-                .onlyFromCache,
                 .transition(.fade(0.2)),
                 .forceTransition,
                 .processor(

--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailView.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailView.swift
@@ -199,7 +199,6 @@ extension MusicDetailView: MusicDetailStateProtocol {
             with: URL(string: imageURL),
             options: [
                 .waitForCache,
-                .onlyFromCache,
                 .transition(.fade(0.5)),
                 .forceTransition,
                 .processor(

--- a/Projects/Features/PlaylistFeature/Sources/Components/PlaylistComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/PlaylistComponent.swift
@@ -6,6 +6,7 @@ import UIKit
 
 public protocol PlaylistDependency: Dependency {
     var containSongsFactory: any ContainSongsFactory { get }
+    var songDetailPresenter: any SongDetailPresentable { get }
 }
 
 public final class PlaylistComponent: Component<PlaylistDependency>, PlaylistFactory {
@@ -13,7 +14,8 @@ public final class PlaylistComponent: Component<PlaylistDependency>, PlaylistFac
         let viewModel = PlaylistViewModel()
         let viewController = PlaylistViewController(
             viewModel: viewModel,
-            containSongsFactory: dependency.containSongsFactory
+            containSongsFactory: dependency.containSongsFactory,
+            songDetailPresenter: dependency.songDetailPresenter
         )
         return viewController
     }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -501,6 +501,10 @@ extension MyPlaylistDetailViewController: PlaylistTableViewCellDelegate {
         self.present(vc, animated: true)
     }
 
+    func playButtonDidTap(key: String) {
+        WakmusicYoutubePlayer(id: key).play()
+    }
+
     func superButtonTapped(index: Int) {
         tableView.deselectRow(at: IndexPath(row: index, section: 0), animated: false)
         reactor?.action.onNext(.itemDidTap(index))

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController+Delegate.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController+Delegate.swift
@@ -45,6 +45,16 @@ extension PlaylistViewController: UITableViewDelegate {
         return .none // 편집모드 시 왼쪽 버튼을 숨기려면 .none을 리턴합니다.
     }
 
+    public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        72
+    }
+
+    public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let playbuttonGroupView = PlayButtonGroupView()
+        playbuttonGroupView.delegate = self
+        return playbuttonGroupView
+    }
+
     public func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
         return false // 편집모드 시 셀의 들여쓰기를 없애려면 false를 리턴합니다.
     }
@@ -56,7 +66,7 @@ extension PlaylistViewController: UITableViewDelegate {
         return dragIndicatorView
     }
 
-    public func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+    public func tableView(_ tableView: UITableView, canFocusRowAt indexPath: IndexPath) -> Bool {
         return true // 모든 Cell 을 이동 가능하게 설정합니다.
     }
 
@@ -73,10 +83,34 @@ extension PlaylistViewController: UITableViewDelegate {
     }
 }
 
+extension PlaylistViewController: PlayButtonGroupViewDelegate {
+    public func play(_ event: PlayEvent) {
+        switch event {
+        case .allPlay:
+            let songIDs = output.playlists.value
+                .map(\.id)
+                .prefix(50)
+            WakmusicYoutubePlayer(ids: Array(songIDs)).play()
+
+        case .shufflePlay:
+            let songIDs = output.playlists.value
+                .map(\.id)
+                .shuffled()
+                .prefix(50)
+            WakmusicYoutubePlayer(ids: Array(songIDs)).play()
+        }
+    }
+}
+
 extension PlaylistViewController: PlaylistTableViewCellDelegate {
     func thumbnailDidTap(key: String) {
-        #warning("백튼님 여기 나중에 musicDetail 연결하시면됩니다.")
-        //
+        self.dismiss(animated: true) { [songDetailPresenter] in
+            songDetailPresenter.present(id: key)
+        }
+    }
+
+    func playButtonDidTap(key: String) {
+        WakmusicYoutubePlayer(id: key).play()
     }
 
     func superButtonTapped(index: Int) {

--- a/Projects/Features/PlaylistFeature/Sources/Views/PlayListView.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/PlayListView.swift
@@ -65,68 +65,9 @@ public final class PlaylistView: UIView {
         $0.separatorStyle = .none
         $0.rowHeight = 60
         $0.estimatedRowHeight = 60
+        $0.sectionHeaderTopPadding = 0
         $0.backgroundColor = DesignSystemAsset.BlueGrayColor.blueGray100.color
         $0.showsVerticalScrollIndicator = true
-    }
-
-    private lazy var blurEffectView = UIVisualEffectView().then {
-        $0.effect = UIBlurEffect(style: .regular)
-    }
-
-    private lazy var homeIndicatorBackgroundView = UIView().then {
-        $0.backgroundColor = UIColor(red: 1, green: 1, blue: 1, alpha: 0.5)
-    }
-
-    internal lazy var miniPlayerView = UIView().then {
-        $0.backgroundColor = UIColor(red: 1, green: 1, blue: 1, alpha: 0.5)
-    }
-
-    internal lazy var miniPlayerContentView = UIView()
-
-    internal lazy var miniPlayerStackView = UIStackView().then {
-        $0.axis = .horizontal
-        $0.distribution = .fillEqually
-        $0.spacing = (APP_WIDTH() < 375) ? 10 : 16
-    }
-
-    internal lazy var totalPlayTimeView = UIView().then {
-        $0.backgroundColor = DesignSystemAsset.GrayColor.gray300.color
-    }
-
-    internal lazy var currentPlayTimeView = UIView().then {
-        $0.backgroundColor = DesignSystemAsset.PrimaryColor.point.color
-    }
-
-    internal lazy var thumbnailImageView = UIImageView().then {
-        $0.image = DesignSystemAsset.Player.dummyThumbnailSmall.image
-        $0.contentMode = .scaleAspectFill
-        $0.layer.cornerRadius = 4
-        $0.clipsToBounds = true
-    }
-
-    internal lazy var repeatButton = UIButton().then {
-        $0.setImage(DesignSystemAsset.Player.repeatOff.image, for: .normal)
-        $0.tintColor = .systemGray
-    }
-
-    internal lazy var playButton = UIButton().then {
-        $0.setImage(DesignSystemAsset.Player.miniPlay.image, for: .normal)
-        $0.tintColor = .systemGray
-    }
-
-    internal lazy var prevButton = UIButton().then {
-        $0.setImage(DesignSystemAsset.Player.prevOn.image, for: .normal)
-        $0.tintColor = .systemGray
-    }
-
-    internal lazy var nextButton = UIButton().then {
-        $0.setImage(DesignSystemAsset.Player.nextOn.image, for: .normal)
-        $0.tintColor = .systemGray
-    }
-
-    internal lazy var shuffleButton = UIButton().then {
-        $0.setImage(DesignSystemAsset.Player.shuffleOff.image, for: .normal)
-        $0.tintColor = .systemGray
     }
 
     override init(frame: CGRect) {
@@ -147,9 +88,6 @@ private extension PlaylistView {
         self.configureContent()
         self.configureTitleBar()
         self.configurePlaylist()
-        self.configureBlur()
-        self.configureMiniPlayer()
-        self.configreHomeIndicatorBackgroundView()
     }
 
     private func configureSubViews() {
@@ -160,19 +98,6 @@ private extension PlaylistView {
         titleBarView.addSubview(titleCountStackView)
         titleBarView.addSubview(editButton)
         contentView.addSubview(playlistTableView)
-        contentView.addSubview(blurEffectView)
-        contentView.addSubview(miniPlayerView)
-        contentView.addSubview(homeIndicatorBackgroundView)
-        miniPlayerView.addSubview(miniPlayerContentView)
-        miniPlayerContentView.addSubview(thumbnailImageView)
-        miniPlayerContentView.addSubview(miniPlayerStackView)
-        miniPlayerView.addSubview(totalPlayTimeView)
-        totalPlayTimeView.addSubview(currentPlayTimeView)
-        miniPlayerView.addSubview(repeatButton)
-        miniPlayerView.addSubview(prevButton)
-        miniPlayerView.addSubview(playButton)
-        miniPlayerView.addSubview(nextButton)
-        miniPlayerView.addSubview(shuffleButton)
     }
 
     private func configureBackground() {
@@ -216,68 +141,12 @@ private extension PlaylistView {
 
     private func configurePlaylist() {
         playlistTableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: 56))
-        playlistTableView.verticalScrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: 56, right: 0)
+        playlistTableView.verticalScrollIndicatorInsets = UIEdgeInsets(top: 72, left: 0, bottom: 56, right: 0)
+        playlistTableView.contentInset = .init(top: 0, left: 0, bottom: 56, right: 0)
         playlistTableView.snp.makeConstraints {
             $0.top.equalTo(titleBarView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview()
-        }
-    }
-
-    private func configureBlur() {
-        blurEffectView.snp.makeConstraints {
-            $0.height.equalTo(56 + SAFEAREA_BOTTOM_HEIGHT())
-            $0.bottom.left.right.equalToSuperview()
-        }
-    }
-
-    private func configureMiniPlayer() {
-        miniPlayerView.snp.makeConstraints {
-            $0.height.equalTo(56)
-            $0.left.right.equalToSuperview()
-            $0.bottom.equalToSuperview().offset(-SAFEAREA_BOTTOM_HEIGHT())
-        }
-
-        totalPlayTimeView.snp.makeConstraints {
-            $0.height.equalTo(1)
-            $0.top.left.right.equalToSuperview()
-        }
-
-        currentPlayTimeView.snp.makeConstraints {
-            $0.top.left.bottom.equalToSuperview()
-            $0.width.equalToSuperview().multipliedBy(0)
-        }
-
-        miniPlayerContentView.snp.makeConstraints {
-            $0.top.bottom.equalToSuperview()
-            $0.horizontalEdges.equalToSuperview().inset(UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 20))
-        }
-
-        thumbnailImageView.snp.makeConstraints {
-            let height = 40
-            let width = height * 16 / 9
-            $0.centerY.equalToSuperview()
-            $0.left.equalToSuperview()
-            $0.width.equalTo(width)
-            $0.height.equalTo(height)
-        }
-
-        miniPlayerStackView.snp.makeConstraints {
-            $0.top.bottom.equalToSuperview()
-            $0.right.equalToSuperview()
-        }
-
-        miniPlayerStackView.addArrangedSubview(repeatButton)
-        miniPlayerStackView.addArrangedSubview(prevButton)
-        miniPlayerStackView.addArrangedSubview(playButton)
-        miniPlayerStackView.addArrangedSubview(nextButton)
-        miniPlayerStackView.addArrangedSubview(shuffleButton)
-    }
-
-    private func configreHomeIndicatorBackgroundView() {
-        homeIndicatorBackgroundView.snp.makeConstraints {
-            $0.height.equalTo(SAFEAREA_BOTTOM_HEIGHT())
-            $0.left.right.bottom.equalToSuperview()
         }
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Views/PlaylistTableViewCell.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/PlaylistTableViewCell.swift
@@ -1,6 +1,8 @@
 import DesignSystem
 import Kingfisher
 import Lottie
+import RxGesture
+import RxSwift
 import SnapKit
 import SongsDomainInterface
 import Then
@@ -10,6 +12,7 @@ import Utility
 internal protocol PlaylistTableViewCellDelegate: AnyObject {
     func superButtonTapped(index: Int)
     func thumbnailDidTap(key: String)
+    func playButtonDidTap(key: String)
 }
 
 internal class PlaylistTableViewCell: UITableViewCell {
@@ -65,6 +68,7 @@ internal class PlaylistTableViewCell: UITableViewCell {
     internal var model: (index: Int, model: PlaylistItemModel?) = (0, nil)
 
     internal var isAnimating: Bool = false
+    private let disposeBag = DisposeBag()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -99,10 +103,7 @@ internal class PlaylistTableViewCell: UITableViewCell {
         }
 
         thumbnailButton.snp.makeConstraints {
-            $0.centerY.equalTo(thumbnailImageView)
-            $0.left.equalTo(thumbnailButton)
-            $0.width.equalTo(width)
-            $0.height.equalTo(height)
+            $0.edges.equalTo(thumbnailImageView)
         }
 
         titleArtistStackView.snp.makeConstraints {
@@ -156,6 +157,17 @@ extension PlaylistTableViewCell {
 
             self?.delegate?.thumbnailDidTap(key: song.id)
         }
+
+        playImageView.rx.tapGesture()
+            .when(.recognized)
+            .bind(with: self) { owner, _ in
+                guard let song = owner.model.model else {
+                    return
+                }
+
+                owner.delegate?.playButtonDidTap(key: song.id)
+            }
+            .disposed(by: disposeBag)
 
         superButton.addAction { [weak self] in
             self?.delegate?.superButtonTapped(index: self?.model.index ?? 0)


### PR DESCRIPTION
## 💡 배경 및 개요
- 재생목록 화면 인터렉션 추가
- UI 변경사항 반영

Resolves: #912 
Resolved: #798 

## 📃 작업내용

- 전체재생, 랜덤재생 추가
- 재생목록 PanGesture 제거
- 곡이 있음에도 재생목록 페이지 최하단에 "곡이 없습니다" 가 뜨는 이슈 해결

이외
- MusicDetail, LyricsHighlighting 등 배경에 썸네일을 블러로 표시하는 로직에 다운로드 options에 onlyFromCache 옵션 제거
  - waitForCache와 onlyFromCache가 동시에 있으면 오직 캐시를 기다릴 줄 알았는데.. 캐시가 그냥 없으면 넘어가더라구요.. wait도 안하구요.
- 여타 Play 버튼이 있는 화면에 Youtube Play 추가 (재생목록, MyPlaylist)

## 🙋‍♂️ 리뷰노트

#921 
https://discord.com/channels/979764222424657930/1267850815113269350
현재 재생목록 화면이 노래들의 Drag 가 동작을 할 수 없는 상황이에요. 
혹시나 FittedSheets를 사용하면서 이를 해결할 수 없다면 showBottomSheet 대신 overFullScreen present로 다시 돌아가는걸 고려해야할 상황일 수도 있어요. @KangTaeHoon 

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
