### PR TITLE
🔀  :: (#899) 음악 상세 페이지 음악 제목, 아티스트 WMLabel -> WMFlowLabel 전환

### DIFF
--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/Views/MusicControlView/MusicControlView.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/Views/MusicControlView/MusicControlView.swift
@@ -23,12 +23,12 @@ private protocol MusicControlActionProtocol {
 }
 
 final class MusicControlView: UIView {
-    private let titleLabel: WMLabel = WMLabel(
+    private let titleLabel: WMFlowLabel = WMFlowLabel(
         text: "",
         textColor: DesignSystemAsset.BlueGrayColor.gray25.color,
         font: .t4(weight: .medium)
     )
-    private let artistLabel: WMLabel = WMLabel(
+    private let artistLabel: WMFlowLabel = WMFlowLabel(
         text: "",
         textColor: DesignSystemAsset.BlueGrayColor.gray100.color.withAlphaComponent(0.6),
         font: .t5(weight: .medium)
@@ -128,6 +128,7 @@ private extension MusicControlView {
         titleStackView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.top.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(20)
         }
 
         playStackView.snp.makeConstraints {

--- a/Projects/UsertInterfaces/DesignSystem/Sources/WMFlowLabel.swift
+++ b/Projects/UsertInterfaces/DesignSystem/Sources/WMFlowLabel.swift
@@ -16,7 +16,7 @@ public final class WMFlowLabel: MarqueeLabel {
         font: UIFont.WMFontSystem,
         alignment: NSTextAlignment = .left,
         lineHeight: CGFloat? = nil,
-        kernValue: Double? = nil,
+        kernValue: Double? = -0.5,
         lineSpacing: CGFloat? = nil,
         lineHeightMultiple: CGFloat? = nil,
         leadingBuffer: CGFloat = 0,


### PR DESCRIPTION
## 💡 배경 및 개요
음악 제목 혹은 아티스트(이건 실제로 그런지 케이스 확인 없음) 문자열이 길어서 텍스트가 짤리는 현상이 있었어요
음악 상세 페이지 음악 제목, 아티스트 WMLabel -> WMFlowLabel 전환

Resolves: #899

## 📃 작업내용

- 음악 상세 페이지 음악 제목, 아티스트 WMLabel -> WMFlowLabel 전환

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

