### PR TITLE
🔀 :: (876) 상호작용이 일어나는 페이지 체크

### DIFF
--- a/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -71,7 +71,7 @@ extension ContainSongsViewController {
             .bind(to: input.itemDidTap)
             .disposed(by: disposeBag)
 
-        NotificationCenter.default.rx.notification(.playListRefresh)
+        NotificationCenter.default.rx.notification(.playlistRefresh)
             .map { _ in () }
             .bind(to: input.playListLoad)
             .disposed(by: disposeBag)
@@ -111,9 +111,9 @@ extension ContainSongsViewController {
                 self.showToast(text: result.description, font: .setFont(.t6(weight: .light)))
 
                 if result.status == 201 {
-                    NotificationCenter.default.post(name: .playListRefresh, object: nil) // 플리목록창 이름 변경하기 위함
+                    NotificationCenter.default.post(name: .playlistRefresh, object: nil) // 플리목록창 이름 변경하기 위함
                 } else if result.status == 200 {
-                    NotificationCenter.default.post(name: .playListRefresh, object: nil) // 플리목록창 이름 변경하기 위함
+                    NotificationCenter.default.post(name: .playlistRefresh, object: nil) // 플리목록창 이름 변경하기 위함
                     self.dismiss(animated: true)
                 } else if result.status == -1 {
                     return

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/TextPopupViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/TextPopupViewController.swift
@@ -67,7 +67,7 @@ extension TextPopupViewController {
             string: cancelButtonText,
             attributes: [
                 .font: DesignSystem.DesignSystemFontFamily.Pretendard.medium.font(size: 18),
-                .foregroundColor: DesignSystemAsset.GrayColor.gray25.color,
+                .foregroundColor: DesignSystemAsset.BlueGrayColor.gray25.color,
                 .kern: -0.5
             ]
         )
@@ -82,7 +82,7 @@ extension TextPopupViewController {
             string: confirmButtonText,
             attributes: [
                 .font: DesignSystem.DesignSystemFontFamily.Pretendard.medium.font(size: 18),
-                .foregroundColor: DesignSystemAsset.GrayColor.gray25.color,
+                .foregroundColor: DesignSystemAsset.BlueGrayColor.gray25.color,
                 .kern: -0.5
             ]
         )
@@ -98,7 +98,7 @@ extension TextPopupViewController {
             string: contentString,
             attributes: [
                 .font: DesignSystem.DesignSystemFontFamily.Pretendard.medium.font(size: 18),
-                .foregroundColor: DesignSystemAsset.GrayColor.gray900.color,
+                .foregroundColor: DesignSystemAsset.BlueGrayColor.gray900.color,
                 .kern: -0.5,
                 .paragraphStyle: paragraphStyle
             ]

--- a/Projects/Features/MyInfoFeature/Sources/Components/MyInfoComponent.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Components/MyInfoComponent.swift
@@ -5,8 +5,8 @@ import NeedleFoundation
 import NoticeDomainInterface
 import SignInFeatureInterface
 import TeamFeatureInterface
-import UserDomainInterface
 import UIKit
+import UserDomainInterface
 
 public protocol MyInfoDependency: Dependency {
     var signInFactory: any SignInFactory { get }

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -81,7 +81,7 @@ final class MyInfoReactor: Reactor {
             isLoggedIn: false,
             profileImage: "",
             nickname: "",
-            platform: "", 
+            platform: "",
             fruitCount: 0,
             isAllNoticesRead: false
         )
@@ -154,7 +154,7 @@ final class MyInfoReactor: Reactor {
 
         case let .updateIsAllNoticesRead(isAllNoticesRead):
             newState.isAllNoticesRead = isAllNoticesRead
-        
+
         case let .updateFruitCount(count):
             newState.fruitCount = count
         case let .showToast(message):
@@ -183,25 +183,24 @@ private extension MyInfoReactor {
             }
             .disposed(by: disposeBag)
     }
-    
+
     func fetchUserInfo() -> Observable<Mutation> {
         return fetchUserInfoUseCase.execute()
-                .asObservable()
-                .flatMap { entity -> Observable<Mutation> in
-                    PreferenceManager.shared.setUserInfo(
-                        ID: entity.id,
-                        platform: entity.platform,
-                        profile: entity.profile,
-                        name: entity.name,
-                        itemCount: entity.itemCount
-                    )
-                    return .empty()
-                }
-                .catch { error in
-                    let error = error.asWMError
-                    return Observable.just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
-                }
-
+            .asObservable()
+            .flatMap { entity -> Observable<Mutation> in
+                PreferenceManager.shared.setUserInfo(
+                    ID: entity.id,
+                    platform: entity.platform,
+                    profile: entity.profile,
+                    name: entity.name,
+                    itemCount: entity.itemCount
+                )
+                return .empty()
+            }
+            .catch { error in
+                let error = error.asWMError
+                return Observable.just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
+            }
     }
 
     func updateIsAllNoticesRead(_ readIDs: [Int]) -> Observable<Mutation> {
@@ -224,7 +223,7 @@ private extension MyInfoReactor {
         guard let profile = userInfo?.profile else { return .empty() }
         return .just(.updateProfileImage(profile))
     }
-    
+
     func updateRemoteNickname(_ newNickname: String) -> Observable<Mutation> {
         setUsernameUseCase.execute(name: newNickname)
             .andThen(
@@ -242,7 +241,6 @@ private extension MyInfoReactor {
                             .just(.showToast("닉네임이 변경되었습니다.")),
                             .just(.dismissEditSheet)
                         )
-                            
                     }
             )
             .catch { error in
@@ -253,7 +251,7 @@ private extension MyInfoReactor {
                 )
             }
     }
-    
+
     func updateNickname(_ userInfo: UserInfo?) -> Observable<Mutation> {
         guard let userInfo = userInfo else { return .empty() }
         return .just(.updateNickname(userInfo.decryptedName))
@@ -263,7 +261,7 @@ private extension MyInfoReactor {
         guard let platform = userInfo?.platform else { return .empty() }
         return .just(.updatePlatform(platform))
     }
-    
+
     func updateFruitCount(_ userInfo: UserInfo?) -> Observable<Mutation> {
         guard let count = userInfo?.itemCount else { return .empty() }
         return .just(.updateFruitCount(count))

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -86,7 +86,7 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
                 owner.showToast(text: message, font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
             })
             .disposed(by: disposeBag)
-        
+
         reactor.state.map(\.isAllNoticesRead)
             .distinctUntilChanged()
             .bind(with: self) { owner, isAllNoticesRead in
@@ -121,7 +121,7 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
                 owner.myInfoView.profileView.updatePlatform(platform: platform)
             }
             .disposed(by: disposeBag)
-        
+
         reactor.state.map(\.fruitCount)
             .distinctUntilChanged()
             .bind(with: self) { owner, count in
@@ -152,7 +152,7 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
                 owner.hideEditSheet()
             })
             .disposed(by: disposeBag)
-        
+
         reactor.pulse(\.$navigateType)
             .compactMap { $0 }
             .bind(with: self) { owner, navigate in

--- a/Projects/Features/MyInfoFeature/Sources/Views/FruitDrawButtonView.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/FruitDrawButtonView.swift
@@ -97,8 +97,6 @@ extension FruitDrawButtonView: FruitDrawStateProtocol {
     func updateFruitCount(count: Int) {
         countLabel.text = String(count)
     }
-    
-    
 }
 
 extension Reactive: FruitDrawActionProtocol where Base: FruitDrawButtonView {

--- a/Projects/Features/MyInfoFeature/Sources/Views/MyInfoView.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/MyInfoView.swift
@@ -187,7 +187,7 @@ extension MyInfoView: MyInfoStateProtocol {
             loginWarningView.isHidden = false
         }
     }
-    
+
     func updateFruitCount(count: Int) {
         fruitDrawButtonView.updateFruitCount(count: count)
     }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
@@ -320,7 +320,7 @@ private extension MyPlaylistDetailReactor {
             .andThen(.concat([
                 .just(.updateHeader(prev)),
                 .just(.showToast(message))
-               
+
             ]))
             .catch { error in
                 let wmErorr = error.asWMError
@@ -447,7 +447,7 @@ private extension MyPlaylistDetailReactor {
                 .just(.updateHeader(prevHeader)),
                 .just(.showToast("\(remainSongs.count)개의 곡을 삭제했습니다.")),
                 updateSendRefreshNoti()
-                
+
             ]))
             .catch { error in
                 let wmErorr = error.asWMError
@@ -460,7 +460,7 @@ private extension MyPlaylistDetailReactor {
     func updateImageData(imageData: PlaylistImageKind?) -> Observable<Mutation> {
         return .just(.updateImageData(imageData))
     }
-    
+
     func updateSendRefreshNoti() -> Observable<Mutation> {
         .just(.updateRefresh)
     }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
@@ -35,6 +35,7 @@ final class MyPlaylistDetailReactor: Reactor {
         case updateImageData(PlaylistImageKind?)
         case showToast(String)
         case showShareLink(String)
+        case updateRefresh
     }
 
     struct State {
@@ -47,6 +48,7 @@ final class MyPlaylistDetailReactor: Reactor {
         var imageData: PlaylistImageKind?
         @Pulse var toastMessage: String?
         @Pulse var shareLink: String?
+        @Pulse var refresh: Void?
     }
 
     internal let key: String
@@ -94,7 +96,8 @@ final class MyPlaylistDetailReactor: Reactor {
             playlistModels: [],
             backupPlaylistModels: [],
             isLoading: true,
-            selectedCount: 0
+            selectedCount: 0,
+            refresh: nil
         )
     }
 
@@ -171,6 +174,8 @@ final class MyPlaylistDetailReactor: Reactor {
 
         case let .showShareLink(link):
             newState.shareLink = link
+        case .updateRefresh:
+            newState.refresh = ()
         }
 
         return newState
@@ -315,6 +320,7 @@ private extension MyPlaylistDetailReactor {
             .andThen(.concat([
                 .just(.updateHeader(prev)),
                 .just(.showToast(message))
+               
             ]))
             .catch { error in
                 let wmErorr = error.asWMError
@@ -333,7 +339,7 @@ private extension MyPlaylistDetailReactor {
         return .concat([
             .just(.updateHeader(prev)),
             updateTitleAndPrivateUseCase.execute(key: key, title: text, isPrivate: nil)
-                .andThen(.empty())
+                .andThen(updateSendRefreshNoti())
         ])
     }
 }
@@ -439,7 +445,9 @@ private extension MyPlaylistDetailReactor {
                 .just(.updateEditingState(false)),
                 .just(.updateSelectedCount(0)),
                 .just(.updateHeader(prevHeader)),
-                .just(.showToast("\(remainSongs.count)개의 곡을 삭제했습니다."))
+                .just(.showToast("\(remainSongs.count)개의 곡을 삭제했습니다.")),
+                updateSendRefreshNoti()
+                
             ]))
             .catch { error in
                 let wmErorr = error.asWMError
@@ -451,5 +459,9 @@ private extension MyPlaylistDetailReactor {
 
     func updateImageData(imageData: PlaylistImageKind?) -> Observable<Mutation> {
         return .just(.updateImageData(imageData))
+    }
+    
+    func updateSendRefreshNoti() -> Observable<Mutation> {
+        .just(.updateRefresh)
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/UnknownPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/UnknownPlaylistDetailReactor.swift
@@ -27,6 +27,7 @@ final class UnknownPlaylistDetailReactor: Reactor {
         case updateSubscribeState(Bool)
         case showToast(String)
         case updateLoginPopupState(Bool)
+        case updateRefresh
     }
 
     struct State {
@@ -37,6 +38,7 @@ final class UnknownPlaylistDetailReactor: Reactor {
         var isSubscribing: Bool
         @Pulse var toastMessage: String?
         @Pulse var showLoginPopup: Bool
+        @Pulse var refresh: Void?
     }
 
     var initialState: State
@@ -124,6 +126,9 @@ final class UnknownPlaylistDetailReactor: Reactor {
 
         case let .updateSubscribeState(flag):
             newState.isSubscribing = flag
+            
+        case .updateRefresh:
+            newState.refresh = ()
         }
 
         return newState
@@ -235,7 +240,8 @@ private extension UnknownPlaylistDetailReactor {
                 .andThen(
                     .concat([
                         .just(Mutation.updateSubscribeState(!prev)),
-                        .just(Mutation.showToast(prev ? "리스트 구독을 취소 했습니다." : "리스트 구독을 했습니다."))
+                        .just(Mutation.showToast(prev ? "리스트 구독을 취소 했습니다." : "리스트 구독을 했습니다.")),
+                        updateSendRefreshNoti()
                     ])
                 )
                 .catch { error in
@@ -247,5 +253,9 @@ private extension UnknownPlaylistDetailReactor {
 
     func updateSubscribeState(_ flag: Bool) -> Observable<Mutation> {
         return .just(.updateSubscribeState(flag))
+    }
+    
+    func updateSendRefreshNoti() -> Observable<Mutation> {
+        .just(.updateRefresh)
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Service/PlaylistCommonService.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Service/PlaylistCommonService.swift
@@ -7,7 +7,8 @@ protocol PlaylistCommonService {
 }
 
 final class DefaultPlaylistCommonService: PlaylistCommonService {
-    let removeSubscriptionPlaylistEvent: Observable<Notification> = NotificationCenter.default.rx.notification(.removeSubscriptionPlaylist)
+    let removeSubscriptionPlaylistEvent: Observable<Notification> = NotificationCenter.default.rx
+        .notification(.removeSubscriptionPlaylist)
 
     static let shared = DefaultPlaylistCommonService()
 }

--- a/Projects/Features/PlaylistFeature/Sources/Service/PlaylistCommonService.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Service/PlaylistCommonService.swift
@@ -1,0 +1,13 @@
+import Foundation
+import RxSwift
+import Utility
+
+protocol PlaylistCommonService {
+    var removeSubscriptionPlaylistEvent: Observable<Notification> { get }
+}
+
+final class DefaultPlaylistCommonService: PlaylistCommonService {
+    let removeSubscriptionPlaylistEvent: Observable<Notification> = NotificationCenter.default.rx.notification(.removeSubscriptionPlaylist)
+
+    static let shared = DefaultPlaylistCommonService()
+}

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -276,6 +276,16 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
                 activityViewController.popoverPresentationController?.permittedArrowDirections = []
                 owner.present(activityViewController, animated: true)
             }
+            .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$refresh)
+            .compactMap { $0 }
+            .bind(with: self) { owner, _ in
+                NotificationCenter.default.post(name: .playlistRefresh, object: nil)
+            }
+            .disposed(by: disposeBag)
+            
+        
 
         sharedState.map(\.isEditing)
             .distinctUntilChanged()

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -277,15 +277,13 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
                 owner.present(activityViewController, animated: true)
             }
             .disposed(by: disposeBag)
-        
+
         reactor.pulse(\.$refresh)
             .compactMap { $0 }
             .bind(with: self) { owner, _ in
                 NotificationCenter.default.post(name: .playlistRefresh, object: nil)
             }
             .disposed(by: disposeBag)
-            
-        
 
         sharedState.map(\.isEditing)
             .distinctUntilChanged()

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
@@ -151,8 +151,6 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
 
             })
             .disposed(by: disposeBag)
-        
-        
     }
 
     override func bindState(reactor: UnknownPlaylistDetailReactor) {
@@ -190,14 +188,14 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
                 owner.showBottomSheet(content: vc)
             }
             .disposed(by: disposeBag)
-        
+
         reactor.pulse(\.$refresh)
             .compactMap { $0 }
             .bind(with: self) { owner, _ in
                 NotificationCenter.default.post(name: .playlistRefresh, object: nil)
             }
             .disposed(by: disposeBag)
-        
+
         reactor.pulse(\.$detectedNotFound)
             .compactMap { $0 }
             .bind(with: self) { owner, _ in
@@ -213,7 +211,6 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
                 )
 
                 owner.showBottomSheet(content: vc, dismissOnOverlayTapAndPull: false) // 드래그로 닫기 불가
-                
             }
             .disposed(by: disposeBag)
 

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
@@ -197,27 +197,30 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
                 NotificationCenter.default.post(name: .playlistRefresh, object: nil)
             }
             .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$detectedNotFound)
+            .compactMap { $0 }
+            .bind(with: self) { owner, _ in
+                let vc = owner.textPopUpFactory.makeView(
+                    text: "비공개된 리스트 입니다.",
+                    cancelButtonIsHidden: true,
+                    confirmButtonText: "확인",
+                    cancelButtonText: nil,
+                    completion: {
+                        owner.navigationController?.popViewController(animated: true)
+                    },
+                    cancelCompletion: nil
+                )
+
+                owner.showBottomSheet(content: vc, dismissOnOverlayTapAndPull: false) // 드래그로 닫기 불가
+                
+            }
+            .disposed(by: disposeBag)
 
         sharedState.map(\.header)
             .skip(1)
             .distinctUntilChanged()
             .bind(with: self) { owner, model in
-                if model.private {
-                    owner.wmNavigationbarView.isHidden = true
-                    owner.tableView.isHidden = true
-                    let vc = owner.textPopUpFactory.makeView(
-                        text: "비공개된 리스트 입니다.",
-                        cancelButtonIsHidden: true,
-                        confirmButtonText: "확인",
-                        cancelButtonText: nil,
-                        completion: {
-                            owner.navigationController?.popViewController(animated: true)
-                        },
-                        cancelCompletion: nil
-                    )
-
-                    owner.showBottomSheet(content: vc)
-                }
 
                 owner.headerView.updateData(model)
             }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
@@ -189,6 +189,13 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
                 owner.showBottomSheet(content: vc)
             }
             .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$refresh)
+            .compactMap { $0 }
+            .bind(with: self) { owner, _ in
+                NotificationCenter.default.post(name: .playlistRefresh, object: nil)
+            }
+            .disposed(by: disposeBag)
 
         sharedState.map(\.header)
             .skip(1)

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
@@ -151,6 +151,8 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
 
             })
             .disposed(by: disposeBag)
+        
+        
     }
 
     override func bindState(reactor: UnknownPlaylistDetailReactor) {
@@ -185,7 +187,6 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
                         owner.present(vc, animated: true)
                     }
                 )
-
                 owner.showBottomSheet(content: vc)
             }
             .disposed(by: disposeBag)

--- a/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
@@ -181,8 +181,13 @@ final class ListStorageReactor: Reactor {
                     owner.fetchDataSource()
                 )
             }
+        let playlistRefreshMutation = storageCommonService.playlistRefreshEvent
+            .withUnretained(self)
+            .flatMap { (owner, _) -> Observable<Mutation> in
+                return owner.fetchDataSource()
+            }
 
-        return Observable.merge(mutation, switchEditingStateMutation, changedUserInfoMutation)
+        return Observable.merge(mutation, switchEditingStateMutation, changedUserInfoMutation, playlistRefreshMutation)
     }
 
     func reduce(state: State, mutation: Mutation) -> State {

--- a/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
@@ -183,7 +183,7 @@ final class ListStorageReactor: Reactor {
             }
         let playlistRefreshMutation = storageCommonService.playlistRefreshEvent
             .withUnretained(self)
-            .flatMap { (owner, _) -> Observable<Mutation> in
+            .flatMap { owner, _ -> Observable<Mutation> in
                 return owner.fetchDataSource()
             }
 
@@ -278,11 +278,11 @@ extension ListStorageReactor {
         let selectedItemIDs = currentState.dataSource.flatMap { $0.items.filter { $0.isSelected == true } }
             .map { $0.key }
         storageCommonService.isEditingState.onNext(false)
-        
+
         #warning("케이 구독 플리인 것만 추려 내서 object에 key배열로 담아서 보내주세요, 삭제 Usecase 끝나고 andThen에서 해주시면 될 듯 ")
         // TODO:
-        NotificationCenter.default.post(name: .removeSubscriptionPlaylist, object: [] , userInfo: nil)
-        
+        NotificationCenter.default.post(name: .removeSubscriptionPlaylist, object: [], userInfo: nil)
+
         return .concat(
             .just(.updateIsShowActivityIndicator(true)),
             mutateDeletePlaylistUseCase(selectedItemIDs),
@@ -374,7 +374,6 @@ private extension ListStorageReactor {
     }
 
     func mutateDeletePlaylistUseCase(_ ids: [String]) -> Observable<Mutation> {
-        
         deletePlayListUseCase.execute(ids: ids)
             .andThen(
                 .concat(

--- a/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
@@ -279,7 +279,7 @@ extension ListStorageReactor {
             .map { $0.key }
         storageCommonService.isEditingState.onNext(false)
         
-        #warning("케이 여기서 구독 플리인 것만 추려 내서 object에 key배열로 담아서 보내주세요 ")
+        #warning("케이 구독 플리인 것만 추려 내서 object에 key배열로 담아서 보내주세요, 삭제 Usecase 끝나고 andThen에서 해주시면 될 듯 ")
         // TODO:
         NotificationCenter.default.post(name: .removeSubscriptionPlaylist, object: [] , userInfo: nil)
         

--- a/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
@@ -278,6 +278,11 @@ extension ListStorageReactor {
         let selectedItemIDs = currentState.dataSource.flatMap { $0.items.filter { $0.isSelected == true } }
             .map { $0.key }
         storageCommonService.isEditingState.onNext(false)
+        
+        #warning("케이 여기서 구독 플리인 것만 추려 내서 object에 key배열로 담아서 보내주세요 ")
+        // TODO:
+        NotificationCenter.default.post(name: .removeSubscriptionPlaylist, object: [] , userInfo: nil)
+        
         return .concat(
             .just(.updateIsShowActivityIndicator(true)),
             mutateDeletePlaylistUseCase(selectedItemIDs),
@@ -369,6 +374,7 @@ private extension ListStorageReactor {
     }
 
     func mutateDeletePlaylistUseCase(_ ids: [String]) -> Observable<Mutation> {
+        
         deletePlayListUseCase.execute(ids: ids)
             .andThen(
                 .concat(

--- a/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
+++ b/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
@@ -14,7 +14,7 @@ final class DefaultStorageCommonService: StorageCommonService {
     let changedUserInfoEvent: Observable<UserInfo?> = PreferenceManager.$userInfo
     let movedLikeStorageEvent: Observable<Notification> = NotificationCenter.default.rx
         .notification(.movedStorageFavoriteTab)
-    
+
     let playlistRefreshEvent: Observable<Notification> = NotificationCenter.default.rx.notification(.playlistRefresh)
 
     static let shared = DefaultStorageCommonService()

--- a/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
+++ b/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
@@ -6,6 +6,7 @@ protocol StorageCommonService {
     var isEditingState: BehaviorSubject<Bool> { get }
     var changedUserInfoEvent: Observable<UserInfo?> { get }
     var movedLikeStorageEvent: Observable<Notification> { get }
+    var playlistRefreshEvent: Observable<Notification> { get }
 }
 
 final class DefaultStorageCommonService: StorageCommonService {
@@ -13,6 +14,8 @@ final class DefaultStorageCommonService: StorageCommonService {
     let changedUserInfoEvent: Observable<UserInfo?> = PreferenceManager.$userInfo
     let movedLikeStorageEvent: Observable<Notification> = NotificationCenter.default.rx
         .notification(.movedStorageFavoriteTab)
+    
+    let playlistRefreshEvent: Observable<Notification> = NotificationCenter.default.rx.notification(.playlistRefresh)
 
     static let shared = DefaultStorageCommonService()
 }

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
@@ -1,14 +1,13 @@
 import Foundation
 
 public extension Notification.Name {
-    static let playListRefresh = Notification.Name("playListRefresh")
+    static let playlistRefresh = Notification.Name("playlistRefresh") // 플레이리스트 목록 갱신(보관함 같은) (노래목록 아님)
+    static let specificPlaylistRefresh =  Notification.Name("specificPlaylistRefresh") // 특정 key값을 가진 플레이리스트가 다른 화면에서 업데이트 변경되 었을 때 갱신
     static let likeListRefresh = Notification.Name("likeListRefresh")
-    static let playListNameRefresh = Notification.Name("playListNameRefresh")
     static let statusBarEnterDarkBackground = Notification.Name("statusBarEnterDarkBackground")
     static let statusBarEnterLightBackground = Notification.Name("statusBarEnterLightBackground")
     static let showSongCart = Notification.Name("showSongCart")
     static let hideSongCart = Notification.Name("hideSongCart")
     static let movedTab = Notification.Name("movedTab")
     static let movedStorageFavoriteTab = Notification.Name("movedStorageFavoriteTab")
-    static let updateCurrentSongLikeState = Notification.Name("updateCurrentSongLikeState")
 }

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public extension Notification.Name {
     static let playlistRefresh = Notification.Name("playlistRefresh") // 플레이리스트 목록 갱신(보관함 같은) (노래목록 아님)
-    static let specificPlaylistRefresh =  Notification.Name("specificPlaylistRefresh") // 특정 key값을 가진 플레이리스트가 다른 화면에서 업데이트 변경되 었을 때 갱신
+    static let removeSubscriptionPlaylist =  Notification.Name("removeSubscriptionPlaylist") // 보관함에서 구독플리 제거
     static let likeListRefresh = Notification.Name("likeListRefresh")
     static let statusBarEnterDarkBackground = Notification.Name("statusBarEnterDarkBackground")
     static let statusBarEnterLightBackground = Notification.Name("statusBarEnterLightBackground")

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public extension Notification.Name {
     static let playlistRefresh = Notification.Name("playlistRefresh") // 플레이리스트 목록 갱신(보관함 같은) (노래목록 아님)
-    static let removeSubscriptionPlaylist =  Notification.Name("removeSubscriptionPlaylist") // 보관함에서 구독플리 제거
+    static let removeSubscriptionPlaylist = Notification.Name("removeSubscriptionPlaylist") // 보관함에서 구독플리 제거
     static let likeListRefresh = Notification.Name("likeListRefresh")
     static let statusBarEnterDarkBackground = Notification.Name("statusBarEnterDarkBackground")
     static let statusBarEnterLightBackground = Notification.Name("statusBarEnterLightBackground")


### PR DESCRIPTION
## 💡 배경 및 개요

서로다른 탭에서 수정사항이 일어날 때 다른 탭에도 결과가 적용되야합니다.

Resolves 876이지만 남아있는 작업이 있어 명시는 안함

## 📃 작업내용

- 곡 담기 후 보관함에 반영
- 곡 삭제 후 보관함에 반영
- 구독 / 구독해제 시 보관함에 반영
- 보관함에서 삭제 시 , 플레이리스트 상세 구독 상태 변경
- pivate 처리 

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
