### PR TITLE
🔀 :: (#961) 내 정보:: 로그인/아웃 시 열매 카운트 갱신

### DIFF
--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -268,7 +268,9 @@ private extension MyInfoReactor {
     }
 
     func updateFruitCount(_ userInfo: UserInfo?) -> Observable<Mutation> {
-        guard let count = userInfo?.itemCount else { return .empty() }
+        guard let count = userInfo?.itemCount else { 
+            return .just(.updateFruitCount(-1))
+        }
         return .just(.updateFruitCount(count))
     }
 

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -268,7 +268,7 @@ private extension MyInfoReactor {
     }
 
     func updateFruitCount(_ userInfo: UserInfo?) -> Observable<Mutation> {
-        guard let count = userInfo?.itemCount else { 
+        guard let count = userInfo?.itemCount else {
             return .just(.updateFruitCount(-1))
         }
         return .just(.updateFruitCount(count))

--- a/Projects/Features/MyInfoFeature/Sources/Views/FruitDrawButtonView.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/FruitDrawButtonView.swift
@@ -32,9 +32,9 @@ final class FruitDrawButtonView: UIView {
     )
 
     let countLabel = WMLabel(
-        text: "0개",
+        text: "",
         textColor: DesignSystemAsset.PrimaryColorV2.point.color,
-        font: .t5(weight: .medium),
+        font: .t5(weight: .bold),
         alignment: .center,
         lineHeight: UIFont.WMFontSystem.t5().lineHeight,
         kernValue: -0.5
@@ -95,7 +95,7 @@ extension FruitDrawButtonView {
 
 extension FruitDrawButtonView: FruitDrawStateProtocol {
     func updateFruitCount(count: Int) {
-        countLabel.text = String(count)
+        countLabel.text = count >= 0 ? "\(count)개" : ""
     }
 }
 


### PR DESCRIPTION
## 💡 배경 및 개요
- 로그아웃을 해도 로그인 상태였을때 열매 갯수가 그대로 남아있음

Resolves: #961 

## 📃 작업내용
- 폰트 변경(medium > bold)
- n"개" 텍스트 추가
- 로그인/아웃 시 열매 카운트 갱신 (로그아웃 상태는 카운트를 "마이너스" 값으로 보내 표기하지 않음)

## 🙋‍♂️ 리뷰노트
x

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
