### PR TITLE
🔀 :: (#932) 음악 좋아요 비로그인 처리

### DIFF
--- a/Projects/Features/CreditSongListFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Features/CreditSongListFeature/Demo/Sources/AppDelegate.swift
@@ -3,6 +3,7 @@ import CreditDomainTesting
 @testable import CreditSongListFeature
 import CreditSongListFeatureInterface
 import Inject
+import SignInFeatureInterface
 import UIKit
 
 @main
@@ -66,7 +67,9 @@ final class FakeCreditSongListTabItemFactory: CreditSongListTabItemFactory {
         return Inject.ViewControllerHost(
             CreditSongListTabItemViewController(
                 reactor: reactor,
-                containSongsFactory: DummyContainSongsFactory()
+                containSongsFactory: DummyContainSongsFactory(),
+                textPopupFactory: DummyTextPopupFactory(),
+                signInFactory: DummySignInFactory()
             )
         )
     }
@@ -79,5 +82,24 @@ final class DummyContainSongsFactory: ContainSongsFactory {
             viewController.dismiss(animated: true)
         }
         return viewController
+    }
+}
+
+final class DummySignInFactory: SignInFactory {
+    func makeView() -> UIViewController {
+        return UIViewController()
+    }
+}
+
+final class DummyTextPopupFactory: TextPopUpFactory {
+    func makeView(
+        text: String?,
+        cancelButtonIsHidden: Bool,
+        confirmButtonText: String?,
+        cancelButtonText: String?,
+        completion: (() -> Void)?,
+        cancelCompletion: (() -> Void)?
+    ) -> UIViewController {
+        return UIViewController()
     }
 }

--- a/Projects/Features/CreditSongListFeature/Project.swift
+++ b/Projects/Features/CreditSongListFeature/Project.swift
@@ -9,6 +9,7 @@ let project = Project.module(
         .implements(module: .feature(.CreditSongListFeature), dependencies: [
             .feature(target: .BaseFeature),
             .feature(target: .CreditSongListFeature, type: .interface),
+            .feature(target: .SignInFeature, type: .interface),
             .domain(target: .CreditDomain, type: .interface)
         ]),
         .testing(module: .feature(.CreditSongListFeature), dependencies: [

--- a/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/Component/CreditSongListTabItemComponent.swift
+++ b/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/Component/CreditSongListTabItemComponent.swift
@@ -2,8 +2,8 @@ import BaseFeatureInterface
 import CreditDomainInterface
 import CreditSongListFeatureInterface
 import NeedleFoundation
-import UIKit
 import SignInFeatureInterface
+import UIKit
 
 public protocol CreditSongListTabItemDependency: Dependency {
     var fetchCreditSongListUseCase: any FetchCreditSongListUseCase { get }

--- a/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/Component/CreditSongListTabItemComponent.swift
+++ b/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/Component/CreditSongListTabItemComponent.swift
@@ -3,10 +3,13 @@ import CreditDomainInterface
 import CreditSongListFeatureInterface
 import NeedleFoundation
 import UIKit
+import SignInFeatureInterface
 
 public protocol CreditSongListTabItemDependency: Dependency {
     var fetchCreditSongListUseCase: any FetchCreditSongListUseCase { get }
     var containSongsFactory: any ContainSongsFactory { get }
+    var textPopUpFactory: any TextPopUpFactory { get }
+    var signInFactory: any SignInFactory { get }
 }
 
 public final class CreditSongListTabItemComponent: Component<CreditSongListTabItemDependency>,
@@ -19,7 +22,9 @@ public final class CreditSongListTabItemComponent: Component<CreditSongListTabIt
         )
         let viewController = CreditSongListTabItemViewController(
             reactor: reactor,
-            containSongsFactory: dependency.containSongsFactory
+            containSongsFactory: dependency.containSongsFactory,
+            textPopupFactory: dependency.textPopUpFactory,
+            signInFactory: dependency.signInFactory
         )
         return viewController
     }

--- a/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/CreditSongListTabItemViewController.swift
+++ b/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/CreditSongListTabItemViewController.swift
@@ -3,6 +3,7 @@ import BaseFeatureInterface
 import CreditSongListFeatureInterface
 import DesignSystem
 import RxSwift
+import SignInFeatureInterface
 import Then
 import UIKit
 import Utility
@@ -50,12 +51,18 @@ final class CreditSongListTabItemViewController:
         }
 
     private let containSongsFactory: any ContainSongsFactory
+    private let textPopupFactory: any TextPopUpFactory
+    private let signInFactory: any SignInFactory
 
     init(
         reactor: Reactor,
-        containSongsFactory: any ContainSongsFactory
+        containSongsFactory: any ContainSongsFactory,
+        textPopupFactory: any TextPopUpFactory,
+        signInFactory: any SignInFactory
     ) {
         self.containSongsFactory = containSongsFactory
+        self.textPopupFactory = textPopupFactory
+        self.signInFactory = signInFactory
         super.init(reactor: reactor)
     }
 
@@ -143,7 +150,11 @@ final class CreditSongListTabItemViewController:
                 case let .playYoutube(ids):
                     owner.playYoutube(ids: ids)
                 case let .containSongs(ids):
-                    owner.showContainSongs(ids: ids)
+                    owner.presentContainSongs(ids: ids)
+                case let .textPopup(text, completion):
+                    owner.presentTextPopup(text: text, completion: completion)
+                case .signIn:
+                    owner.presentSignIn()
                 }
             }
             .disposed(by: disposeBag)
@@ -270,9 +281,28 @@ extension CreditSongListTabItemViewController {
         WakmusicYoutubePlayer(ids: ids).play()
     }
 
-    private func showContainSongs(ids: [String]) {
+    private func presentContainSongs(ids: [String]) {
         let viewController = containSongsFactory.makeView(songs: ids)
-        viewController.modalPresentationStyle = .fullScreen
+        viewController.modalPresentationStyle = .overFullScreen
+        UIApplication.topVisibleViewController()?.present(viewController, animated: true)
+    }
+
+    private func presentTextPopup(text: String, completion: @escaping () -> Void) {
+        let viewController = textPopupFactory.makeView(
+            text: text,
+            cancelButtonIsHidden: false,
+            confirmButtonText: "확인",
+            cancelButtonText: "취소",
+            completion: completion,
+            cancelCompletion: nil
+        )
+
+        self.showBottomSheet(content: viewController)
+    }
+
+    private func presentSignIn() {
+        let viewController = signInFactory.makeView()
+        viewController.modalPresentationStyle = .overFullScreen
         UIApplication.topVisibleViewController()?.present(viewController, animated: true)
     }
 }

--- a/Projects/Features/MusicDetailFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Features/MusicDetailFeature/Demo/Sources/AppDelegate.swift
@@ -4,8 +4,8 @@ import Inject
 import LikeDomainInterface
 import LikeDomainTesting
 import LyricHighlightingFeatureInterface
-import RxSwift
 @testable import MusicDetailFeature
+import RxSwift
 import SignInFeatureInterface
 import SongCreditFeatureInterface
 import SongsDomainTesting

--- a/Projects/Features/MusicDetailFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Features/MusicDetailFeature/Demo/Sources/AppDelegate.swift
@@ -4,8 +4,9 @@ import Inject
 import LikeDomainInterface
 import LikeDomainTesting
 import LyricHighlightingFeatureInterface
-@testable import MusicDetailFeature
 import RxSwift
+@testable import MusicDetailFeature
+import SignInFeatureInterface
 import SongCreditFeatureInterface
 import SongsDomainTesting
 import UIKit
@@ -64,7 +65,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
                     reactor: reactor,
                     lyricHighlightingFactory: DummyLyricHighlightingFactory(),
                     songCreditFactory: DummySongCreditFactory(),
+                    signInFactory: DummySignInFactory(),
                     containSongsFactory: DummyContainSongsFactory(),
+                    textPopupFactory: DummyTextPopupFactory(),
                     playlistPresenterGlobalState: DummyPlaylistPresenterGlobalState()
                 )
             )
@@ -90,6 +93,25 @@ final class DummyContainSongsFactory: ContainSongsFactory {
 
 final class DummySongCreditFactory: SongCreditFactory {
     func makeViewController(songID: String) -> UIViewController {
+        return UIViewController()
+    }
+}
+
+final class DummySignInFactory: SignInFactory {
+    func makeView() -> UIViewController {
+        return UIViewController()
+    }
+}
+
+final class DummyTextPopupFactory: TextPopUpFactory {
+    func makeView(
+        text: String?,
+        cancelButtonIsHidden: Bool,
+        confirmButtonText: String?,
+        cancelButtonText: String?,
+        completion: (() -> Void)?,
+        cancelCompletion: (() -> Void)?
+    ) -> UIViewController {
         return UIViewController()
     }
 }

--- a/Projects/Features/MusicDetailFeature/Project.swift
+++ b/Projects/Features/MusicDetailFeature/Project.swift
@@ -11,6 +11,7 @@ let project = Project.module(
             .feature(target: .BaseFeature),
             .feature(target: .LyricHighlightingFeature, type: .interface),
             .feature(target: .SongCreditFeature, type: .interface),
+            .feature(target: .SignInFeature, type: .interface),
             .domain(target: .SongsDomain, type: .interface),
             .domain(target: .LikeDomain, type: .interface)
         ]),

--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/Component/MusicDetailComponent.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/Component/MusicDetailComponent.swift
@@ -4,6 +4,7 @@ import LikeDomainInterface
 import LyricHighlightingFeatureInterface
 import MusicDetailFeatureInterface
 import NeedleFoundation
+import SignInFeatureInterface
 import SongCreditFeatureInterface
 import SongsDomainInterface
 import UIKit
@@ -12,7 +13,9 @@ public protocol MusicDetailDependency: Dependency {
     var fetchSongUseCase: any FetchSongUseCase { get }
     var lyricHighlightingFactory: any LyricHighlightingFactory { get }
     var songCreditFactory: any SongCreditFactory { get }
+    var signInFactory: any SignInFactory { get }
     var containSongsFactory: any ContainSongsFactory { get }
+    var textPopUpFactory: any TextPopUpFactory { get }
     var playlistPresenterGlobalState: any PlayListPresenterGlobalStateProtocol { get }
     var addLikeSongUseCase: any AddLikeSongUseCase { get }
     var cancelLikeSongUseCase: any CancelLikeSongUseCase { get }
@@ -32,7 +35,9 @@ public final class MusicDetailComponent: Component<MusicDetailDependency>, Music
             reactor: reactor,
             lyricHighlightingFactory: dependency.lyricHighlightingFactory,
             songCreditFactory: dependency.songCreditFactory,
+            signInFactory: dependency.signInFactory,
             containSongsFactory: dependency.containSongsFactory,
+            textPopupFactory: dependency.textPopUpFactory,
             playlistPresenterGlobalState: dependency.playlistPresenterGlobalState
         )
 

--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailReactor.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailReactor.swift
@@ -1,13 +1,17 @@
 import Foundation
 import Kingfisher
 import LikeDomainInterface
+import Localization
 import LogManager
 import LyricHighlightingFeatureInterface
 import ReactorKit
+import RxSwift
 import SongsDomainInterface
 import Utility
 
 final class MusicDetailReactor: Reactor {
+    private typealias Log = MusicDetailAnalyticsLog
+
     enum Action {
         case viewDidLoad
         case prevButtonDidTap
@@ -35,6 +39,8 @@ final class MusicDetailReactor: Reactor {
         case musicPick(id: String)
         case playlist
         case dismiss
+        case textPopup(text: String, completion: () -> Void)
+        case signin
     }
 
     struct State {
@@ -51,7 +57,7 @@ final class MusicDetailReactor: Reactor {
         var navigateType: NavigateType?
     }
 
-    private typealias Log = MusicDetailAnalyticsLog
+    private let signInIsRequiredSubject = PublishSubject<Void>()
 
     var initialState: State
     private let youtubeURLGenerator = YoutubeURLGenerator()
@@ -126,6 +132,13 @@ final class MusicDetailReactor: Reactor {
             newState.songDictionary[key] = value
         }
         return newState
+    }
+
+    func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
+        let signInIsRequired = signInIsRequiredSubject
+            .map { _ in Mutation.navigate(.signin) }
+
+        return Observable.merge(mutation, signInIsRequired)
     }
 }
 
@@ -227,8 +240,19 @@ private extension MusicDetailReactor {
     }
 
     func likeButtonDidTap() -> Observable<Mutation> {
-        let isLike = currentState.selectedSong?.isLiked ?? false
+        guard PreferenceManager.userInfo != nil else {
+            return navigateMutation(
+                navigate: NavigateType.textPopup(
+                    text: LocalizationStrings.needLoginWarning,
+                    completion: { [signInIsRequiredSubject] in
+                        signInIsRequiredSubject.onNext(())
+                    }
+                )
+            )
+        }
+
         guard let song = currentState.selectedSong else { return .empty() }
+        let isLike = currentState.selectedSong?.isLiked ?? false
         let log = Log.clickLikeMusicButton(
             id: song.videoID,
             like: isLike
@@ -260,6 +284,16 @@ private extension MusicDetailReactor {
     }
 
     func musicPickButtonDidTap() -> Observable<Mutation> {
+        guard PreferenceManager.userInfo != nil else {
+            return navigateMutation(
+                navigate: NavigateType.textPopup(
+                    text: LocalizationStrings.needLoginWarning,
+                    completion: { [signInIsRequiredSubject] in
+                        signInIsRequiredSubject.onNext(())
+                    }
+                )
+            )
+        }
         guard let song = currentState.selectedSong else { return .empty() }
         let log = Log.clickMusicPickButton(id: song.videoID)
         LogManager.analytics(log)

--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailReactor.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailReactor.swift
@@ -136,7 +136,10 @@ final class MusicDetailReactor: Reactor {
 
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
         let signInIsRequired = signInIsRequiredSubject
-            .map { _ in Mutation.navigate(.signin) }
+            .withUnretained(self)
+            .flatMap { owner, _ in
+                owner.navigateMutation(navigate: .signin)
+            }
 
         return Observable.merge(mutation, signInIsRequired)
     }

--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailViewController.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailViewController.swift
@@ -4,6 +4,7 @@ import DesignSystem
 import LogManager
 import LyricHighlightingFeatureInterface
 import RxSwift
+import SignInFeatureInterface
 import SnapKit
 import SongCreditFeatureInterface
 import Then
@@ -14,19 +15,25 @@ final class MusicDetailViewController: BaseReactorViewController<MusicDetailReac
     private let musicDetailView = MusicDetailView()
     private let lyricHighlightingFactory: any LyricHighlightingFactory
     private let songCreditFactory: any SongCreditFactory
+    private let signInFactory: any SignInFactory
     private let containSongsFactory: any ContainSongsFactory
+    private let textPopupFactory: any TextPopUpFactory
     private let playlistPresenterGlobalState: any PlayListPresenterGlobalStateProtocol
 
     init(
         reactor: MusicDetailReactor,
         lyricHighlightingFactory: any LyricHighlightingFactory,
         songCreditFactory: any SongCreditFactory,
+        signInFactory: any SignInFactory,
         containSongsFactory: any ContainSongsFactory,
+        textPopupFactory: any TextPopUpFactory,
         playlistPresenterGlobalState: any PlayListPresenterGlobalStateProtocol
     ) {
         self.lyricHighlightingFactory = lyricHighlightingFactory
         self.songCreditFactory = songCreditFactory
+        self.signInFactory = signInFactory
         self.containSongsFactory = containSongsFactory
+        self.textPopupFactory = textPopupFactory
         self.playlistPresenterGlobalState = playlistPresenterGlobalState
         super.init(reactor: reactor)
     }
@@ -128,6 +135,10 @@ final class MusicDetailViewController: BaseReactorViewController<MusicDetailReac
                     owner.presentMusicPick(id: id)
                 case .playlist:
                     owner.presentPlaylist()
+                case let .textPopup(text, completion):
+                    owner.presentTextPopup(text: text, completion: completion)
+                case .signin:
+                    owner.presentSignIn()
                 case .dismiss:
                     owner.dismiss()
                 }
@@ -223,6 +234,24 @@ private extension MusicDetailViewController {
         self.dismiss(animated: true) { [playlistPresenterGlobalState] in
             playlistPresenterGlobalState.presentPlayList()
         }
+    }
+
+    func presentTextPopup(text: String, completion: @escaping () -> Void) {
+        let viewController = textPopupFactory.makeView(
+            text: text,
+            cancelButtonIsHidden: false,
+            confirmButtonText: "확인",
+            cancelButtonText: "취소",
+            completion: completion,
+            cancelCompletion: nil
+        )
+        self.showBottomSheet(content: viewController)
+    }
+
+    func presentSignIn() {
+        let viewController = signInFactory.makeView()
+        viewController.modalPresentationStyle = .overFullScreen
+        self.present(viewController, animated: true)
     }
 
     func dismiss() {

--- a/Projects/Modules/Utility/Sources/GoogleOAuth/GoogleLoginManager.swift
+++ b/Projects/Modules/Utility/Sources/GoogleOAuth/GoogleLoginManager.swift
@@ -55,11 +55,7 @@ public class GoogleLoginManager {
         if let url = components?.url, UIApplication.shared.canOpenURL(url) {
             LogManager.printDebug(url)
             let safari = SFSafariViewController(url: url)
-            let root = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?
-                .windows
-                .first?
-                .rootViewController
-            (root as? UINavigationController)?.presentedViewController?.present(safari, animated: true)
+            UIApplication.topVisibleViewController()?.present(safari, animated: true)
         }
     }
 


### PR DESCRIPTION
## 💡 배경 및 개요
- 음악 상세 좋아요, 노래 담기 비로그인 처리

Resolves: #932

## 📃 작업내용

- 음악 상세 페이지에서 좋아요와 노래 담기를 행동할 때 비로그인을 처리했어요
- Google 로그인을 위한 웹뷰를 present할 때 최상단의 viewController가 아닌 최상단에 보여지는 viewController에 present하도록 변경했어요.

## 🙋‍♂️ 리뷰노트
- 스읍 UIApplication.topVisibleViewController() 이 친구 너무 많이 쓰면 계층 구조가 복잡해질 수 있어 자제하고는 싶지만 계속 써야되게 되네요 present위에 present위에 present 🤔 

- 보일러 플레이트가 굉장히 많지만,, 이후 개선 여지는 보이지만 당장은 건드리지 않을거에요.
- 사실 아이디어도 잘 떠오르지는 않아요 🤔🤔🤔🤔🤔🤔🤔🤔

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
