### PR TITLE
🔀 :: (#965) Preference.useInfo 저장 로직 레파지토리로 이동

### DIFF
--- a/Projects/Domains/UserDomain/Sources/Repository/UserRepositoryImpl.swift
+++ b/Projects/Domains/UserDomain/Sources/Repository/UserRepositoryImpl.swift
@@ -3,6 +3,7 @@ import ErrorModule
 import LikeDomainInterface
 import RxSwift
 import UserDomainInterface
+import Utility
 
 public final class UserRepositoryImpl: UserRepository {
     private let remoteUserDataSource: any RemoteUserDataSource
@@ -13,6 +14,15 @@ public final class UserRepositoryImpl: UserRepository {
 
     public func fetchUserInfo() -> Single<UserInfoEntity> {
         remoteUserDataSource.fetchUserInfo()
+            .do(onSuccess: { entity in
+                PreferenceManager.shared.setUserInfo(
+                    ID: entity.id,
+                    platform: entity.platform,
+                    profile: entity.profile,
+                    name: entity.name,
+                    itemCount: entity.itemCount
+                )
+            })
     }
 
     public func setProfile(image: String) -> Completable {

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -192,6 +192,7 @@ private extension MyInfoReactor {
     func fetchUserInfo() -> Observable<Mutation> {
         return fetchUserInfoUseCase.execute()
             .asObservable()
+            .flatMap { _ in Observable.empty() }
             .catch { error in
                 let error = error.asWMError
                 return Observable.just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
@@ -224,7 +225,7 @@ private extension MyInfoReactor {
             .andThen(
                 fetchUserInfoUseCase.execute()
                     .asObservable()
-                    .flatMap { entity -> Observable<Mutation> in
+                    .flatMap { _ -> Observable<Mutation> in
                         return .concat(
                             .just(.showToast("닉네임이 변경되었습니다.")),
                             .just(.dismissEditSheet)

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -192,16 +192,6 @@ private extension MyInfoReactor {
     func fetchUserInfo() -> Observable<Mutation> {
         return fetchUserInfoUseCase.execute()
             .asObservable()
-            .flatMap { entity -> Observable<Mutation> in
-                PreferenceManager.shared.setUserInfo(
-                    ID: entity.id,
-                    platform: entity.platform,
-                    profile: entity.profile,
-                    name: entity.name,
-                    itemCount: entity.itemCount
-                )
-                return .empty()
-            }
             .catch { error in
                 let error = error.asWMError
                 return Observable.just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
@@ -235,13 +225,6 @@ private extension MyInfoReactor {
                 fetchUserInfoUseCase.execute()
                     .asObservable()
                     .flatMap { entity -> Observable<Mutation> in
-                        PreferenceManager.shared.setUserInfo(
-                            ID: entity.id,
-                            platform: entity.platform,
-                            profile: entity.profile,
-                            name: entity.name,
-                            itemCount: entity.itemCount
-                        )
                         return .concat(
                             .just(.showToast("닉네임이 변경되었습니다.")),
                             .just(.dismissEditSheet)

--- a/Projects/Features/RootFeature/Sources/ViewModels/IntroViewModel.swift
+++ b/Projects/Features/RootFeature/Sources/ViewModels/IntroViewModel.swift
@@ -129,13 +129,6 @@ public final class IntroViewModel: ViewModelType {
             .debug("✅ Intro > fetchUserInfoUseCase")
             .subscribe(
                 onNext: { entity in
-                    PreferenceManager.shared.setUserInfo(
-                        ID: entity.id,
-                        platform: entity.platform,
-                        profile: entity.profile,
-                        name: entity.name,
-                        itemCount: entity.itemCount
-                    )
                     output.userInfoResult.onNext(.success(""))
                 },
                 onError: { error in

--- a/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
@@ -88,13 +88,6 @@ private extension LoginViewModel {
             }
             .subscribe(onNext: { [input, output] entity in
                 LogManager.setUserID(userID: entity.id)
-                PreferenceManager.shared.setUserInfo(
-                    ID: entity.id,
-                    platform: entity.platform,
-                    profile: entity.profile,
-                    name: entity.name,
-                    itemCount: entity.itemCount
-                )
                 output.dismissLoginScene.accept(input.arrivedTokenFromThirdParty.value.0)
                 output.showLoading.accept(false)
 


### PR DESCRIPTION
## 💡 배경 및 개요
- 피쳐별로 사용하던 로직을 한 군데로 모음.

Resolves: #965 

## 📃 작업내용
- 레파지토리로 로직 이동
- 각 피쳐에서 사용하던 로직 제거

## 🙋‍♂️ 리뷰노트
x

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
