### PR TITLE
🔀 :: (#971) 플레이리스트 디테일 컨테이너에 로그인 갱신 로직을 변경해요

### DIFF
--- a/Projects/Domains/AuthDomain/Sources/UseCase/FetchTokenUseCaseImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/UseCase/FetchTokenUseCaseImpl.swift
@@ -15,6 +15,5 @@ public struct FetchTokenUseCaseImpl: FetchTokenUseCase {
             .do(onSuccess: { _ in
                 NotificationCenter.default.post(name: .loginStateDidChanged, object: true)
             })
-        
     }
 }

--- a/Projects/Domains/AuthDomain/Sources/UseCase/LogoutUseCaseImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/UseCase/LogoutUseCaseImpl.swift
@@ -1,8 +1,8 @@
 import AuthDomainInterface
 import BaseDomainInterface
+import Foundation
 import RxSwift
 import Utility
-import Foundation
 
 public struct LogoutUseCaseImpl: LogoutUseCase {
     private let authRepository: any AuthRepository

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
@@ -57,6 +57,8 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
         super.bind(reactor: reactor)
 
         PreferenceManager.$userInfo
+            .map(\.?.ID)
+            .distinctUntilChanged()
             .bind(with: self) { owner, userInfo in
 
                 owner.remove(asChildViewController: owner.children.first)
@@ -77,7 +79,6 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
 
         sharedState.map(\.ownerID)
             .compactMap { $0 }
-            .distinctUntilChanged()
             .withLatestFrom(PreferenceManager.$userInfo) { ($0, $1) }
             .bind(with: self) { owner, info in
 

--- a/Projects/Features/StorageFeature/Sources/Reactors/LikeStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/LikeStorageReactor.swift
@@ -165,8 +165,8 @@ final class LikeStorageReactor: Reactor {
 
         let updateIsLoggedInMutation = storageCommonService.loginStateDidChangedEvent
             .withUnretained(self)
-            .flatMap { (owner, notification) -> Observable<Mutation> in
-                guard let isLoggedIn = notification.object as? Bool else { return.empty() }
+            .flatMap { owner, notification -> Observable<Mutation> in
+                guard let isLoggedIn = notification.object as? Bool else { return .empty() }
                 return .concat(
                     owner.updateIsLoggedIn(isLoggedIn),
                     owner.fetchDataSource()

--- a/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
@@ -175,14 +175,14 @@ final class ListStorageReactor: Reactor {
 
         let updateIsLoggedInMutation = storageCommonService.loginStateDidChangedEvent
             .withUnretained(self)
-            .flatMap { (owner, notification) -> Observable<Mutation> in
-                guard let isLoggedIn = notification.object as? Bool else { return.empty() }
+            .flatMap { owner, notification -> Observable<Mutation> in
+                guard let isLoggedIn = notification.object as? Bool else { return .empty() }
                 return .concat(
                     owner.updateIsLoggedIn(isLoggedIn),
                     owner.fetchDataSource()
                 )
             }
-        
+
         let playlistRefreshMutation = storageCommonService.playlistRefreshEvent
             .withUnretained(self)
             .flatMap { owner, _ -> Observable<Mutation> in

--- a/Projects/Features/StorageFeature/Sources/Reactors/StorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/StorageReactor.swift
@@ -65,7 +65,7 @@ final class StorageReactor: Reactor {
 
         let updateIsLoggedInMutation = storageCommonService.loginStateDidChangedEvent
             .flatMap { notification -> Observable<Mutation> in
-                guard let isLoggedIn = notification.object as? Bool else { return.empty() }
+                guard let isLoggedIn = notification.object as? Bool else { return .empty() }
                 return .just(.updateIsLoggedIn(isLoggedIn))
             }
 

--- a/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
+++ b/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
@@ -12,7 +12,7 @@ final class DefaultStorageCommonService: StorageCommonService {
     let isEditingState: BehaviorSubject<Bool>
     let loginStateDidChangedEvent: Observable<Notification>
     let playlistRefreshEvent: Observable<Notification>
-    
+
     init() {
         let notificationCenter = NotificationCenter.default
         isEditingState = .init(value: false)


### PR DESCRIPTION
## 💡 배경 및 개요

기존에 `$userInfo`로 옵저빙하여 프로필 변경에도 감지되었습니다.

Resolves: #971

## 📃 작업내용

id값과 중복코드를 통해 쓸데 없는 옵저빙을 방지합니다.

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
