### PR TITLE
🔀 :: (#976) 열매 소비가 필요한 로직 이후 유저정보를 갱신합니다.

### DIFF
--- a/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
@@ -200,7 +200,7 @@ public final class ContainSongsViewModel: ViewModelType {
             })
             .map { _ in BaseEntity(status: 201, description: "플레이리스트를 성곡적으로 생성했습니다.") }
             .do(onNext: { _ in
-                NotificationCenter.default.post(name: .willRefreshUserInfo,object: nil)
+                NotificationCenter.default.post(name: .willRefreshUserInfo, object: nil)
             })
             .bind(to: output.showToastMessage)
             .disposed(by: disposeBag)

--- a/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
@@ -148,12 +148,6 @@ public final class ContainSongsViewModel: ViewModelType {
                                 description: "이미 내 리스트에 담긴 곡들입니다."
                             ))
 
-                        case .badRequest:
-                            output.showToastMessage.onNext(BaseEntity(
-                                status: 400,
-                                description: "노래는 최대 50개까지 선택 가능합니다."
-                            ))
-
                         default:
                             output.showToastMessage.onNext(BaseEntity(status: 400, description: "잘못된 요청입니다."))
                         }
@@ -205,6 +199,9 @@ public final class ContainSongsViewModel: ViewModelType {
                 output.showToastMessage.onNext(BaseEntity(status: 400, description: wmError.errorDescription!))
             })
             .map { _ in BaseEntity(status: 201, description: "플레이리스트를 성곡적으로 생성했습니다.") }
+            .do(onNext: { _ in
+                NotificationCenter.default.post(name: .willRefreshUserInfo,object: nil)
+            })
             .bind(to: output.showToastMessage)
             .disposed(by: disposeBag)
 

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -68,16 +68,19 @@ final class MyInfoReactor: Reactor {
     private let fetchNoticeIDListUseCase: any FetchNoticeIDListUseCase
     private let setUsernameUseCase: any SetUserNameUseCase
     private let fetchUserInfoUseCase: any FetchUserInfoUseCase
+    private let myInfoCommonService: any MyInfoCommonService
     private let disposeBag = DisposeBag()
 
     init(
         fetchNoticeIDListUseCase: any FetchNoticeIDListUseCase,
         setUserNameUseCase: any SetUserNameUseCase,
-        fetchUserInfoUseCase: any FetchUserInfoUseCase
+        fetchUserInfoUseCase: any FetchUserInfoUseCase,
+        myInfoCommonService: any MyInfoCommonService = DefaultMyInfoCommonService.shared
     ) {
         self.fetchNoticeIDListUseCase = fetchNoticeIDListUseCase
         self.setUsernameUseCase = setUserNameUseCase
         self.fetchUserInfoUseCase = fetchUserInfoUseCase
+        self.myInfoCommonService = myInfoCommonService
         self.initialState = .init(
             isLoggedIn: false,
             profileImage: "",
@@ -168,6 +171,16 @@ final class MyInfoReactor: Reactor {
             newState.dismissEditSheet = true
         }
         return newState
+    }
+    
+    func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
+        
+        let willRefreshUserInfoMutation = myInfoCommonService.willRefreshUserInfoEvent.withUnretained(self)
+            .flatMap { owner, _ -> Observable<Mutation> in
+            return owner.fetchUserInfo()
+        }
+    
+        return Observable.merge(willRefreshUserInfoMutation, mutation)
     }
 }
 

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -172,14 +172,13 @@ final class MyInfoReactor: Reactor {
         }
         return newState
     }
-    
+
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
-        
         let willRefreshUserInfoMutation = myInfoCommonService.willRefreshUserInfoEvent.withUnretained(self)
             .flatMap { owner, _ -> Observable<Mutation> in
-            return owner.fetchUserInfo()
-        }
-    
+                return owner.fetchUserInfo()
+            }
+
         return Observable.merge(willRefreshUserInfoMutation, mutation)
     }
 }

--- a/Projects/Features/MyInfoFeature/Sources/Service/MyInfoCommonService.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Service/MyInfoCommonService.swift
@@ -7,7 +7,6 @@ protocol MyInfoCommonService {
 }
 
 final class DefaultMyInfoCommonService: MyInfoCommonService {
-
     let willRefreshUserInfoEvent: Observable<Notification>
     static let shared = DefaultMyInfoCommonService()
 

--- a/Projects/Features/MyInfoFeature/Sources/Service/MyInfoCommonService.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Service/MyInfoCommonService.swift
@@ -1,0 +1,18 @@
+import Foundation
+import RxSwift
+import Utility
+
+protocol MyInfoCommonService {
+    var willRefreshUserInfoEvent: Observable<Notification> { get }
+}
+
+final class DefaultMyInfoCommonService: MyInfoCommonService {
+
+    let willRefreshUserInfoEvent: Observable<Notification>
+    static let shared = DefaultMyInfoCommonService()
+
+    init() {
+        let notificationCenter = NotificationCenter.default
+        willRefreshUserInfoEvent = notificationCenter.rx.notification(.willRefreshUserInfo)
+    }
+}

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
@@ -7,6 +7,7 @@ import SongsDomainInterface
 import Utility
 
 final class MyPlaylistDetailReactor: Reactor {
+    
     enum Action {
         case viewDidLoad
         case itemDidTap(Int)
@@ -35,7 +36,7 @@ final class MyPlaylistDetailReactor: Reactor {
         case updateImageData(PlaylistImageKind?)
         case showToast(String)
         case showShareLink(String)
-        case updateRefresh
+        case updateNotiName(Notification.Name)
     }
 
     struct State {
@@ -48,7 +49,7 @@ final class MyPlaylistDetailReactor: Reactor {
         var imageData: PlaylistImageKind?
         @Pulse var toastMessage: String?
         @Pulse var shareLink: String?
-        @Pulse var refresh: Void?
+        @Pulse var notiName: Notification.Name?
     }
 
     internal let key: String
@@ -97,7 +98,7 @@ final class MyPlaylistDetailReactor: Reactor {
             backupPlaylistModels: [],
             isLoading: true,
             selectedCount: 0,
-            refresh: nil
+            notiName: nil
         )
     }
 
@@ -174,8 +175,8 @@ final class MyPlaylistDetailReactor: Reactor {
 
         case let .showShareLink(link):
             newState.shareLink = link
-        case .updateRefresh:
-            newState.refresh = ()
+        case let .updateNotiName(notiName):
+            newState.notiName = notiName
         }
 
         return newState
@@ -263,7 +264,10 @@ private extension MyPlaylistDetailReactor {
             case let .custom(data):
                 mutations.append(
                     requestCustomImageURLUseCase.execute(key: self.key, data: data)
-                        .andThen(.empty())
+                        .andThen(.concat([ 
+                            updateNotiName(notiName: .playlistRefresh), // 플리 이미지 갱신
+                            updateNotiName(notiName: .willRefreshUserInfo) // 열매 갱신
+                        ]))
                         .catch { error in
                             let wmErorr = error.asWMError
                             return Observable.just(
@@ -339,7 +343,7 @@ private extension MyPlaylistDetailReactor {
         return .concat([
             .just(.updateHeader(prev)),
             updateTitleAndPrivateUseCase.execute(key: key, title: text, isPrivate: nil)
-                .andThen(updateSendRefreshNoti())
+                .andThen(updateNotiName(notiName: .playlistRefresh))
         ])
     }
 }
@@ -446,7 +450,7 @@ private extension MyPlaylistDetailReactor {
                 .just(.updateSelectedCount(0)),
                 .just(.updateHeader(prevHeader)),
                 .just(.showToast("\(remainSongs.count)개의 곡을 삭제했습니다.")),
-                updateSendRefreshNoti()
+                updateNotiName(notiName: .playlistRefresh)
 
             ]))
             .catch { error in
@@ -461,7 +465,8 @@ private extension MyPlaylistDetailReactor {
         return .just(.updateImageData(imageData))
     }
 
-    func updateSendRefreshNoti() -> Observable<Mutation> {
-        .just(.updateRefresh)
+    func updateNotiName(notiName: Notification.Name) -> Observable<Mutation> {
+        .just(.updateNotiName(notiName))
     }
+    
 }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
@@ -7,7 +7,6 @@ import SongsDomainInterface
 import Utility
 
 final class MyPlaylistDetailReactor: Reactor {
-    
     enum Action {
         case viewDidLoad
         case itemDidTap(Int)
@@ -264,7 +263,7 @@ private extension MyPlaylistDetailReactor {
             case let .custom(data):
                 mutations.append(
                     requestCustomImageURLUseCase.execute(key: self.key, data: data)
-                        .andThen(.concat([ 
+                        .andThen(.concat([
                             updateNotiName(notiName: .playlistRefresh), // 플리 이미지 갱신
                             updateNotiName(notiName: .willRefreshUserInfo) // 열매 갱신
                         ]))
@@ -468,5 +467,4 @@ private extension MyPlaylistDetailReactor {
     func updateNotiName(notiName: Notification.Name) -> Observable<Mutation> {
         .just(.updateNotiName(notiName))
     }
-    
 }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
@@ -35,7 +35,7 @@ final class MyPlaylistDetailReactor: Reactor {
         case updateImageData(PlaylistImageKind?)
         case showToast(String)
         case showShareLink(String)
-        case updateNotiName(Notification.Name)
+        case postNotification(Notification.Name)
     }
 
     struct State {
@@ -174,7 +174,7 @@ final class MyPlaylistDetailReactor: Reactor {
 
         case let .showShareLink(link):
             newState.shareLink = link
-        case let .updateNotiName(notiName):
+        case let .postNotification(notiName):
             newState.notiName = notiName
         }
 
@@ -264,8 +264,8 @@ private extension MyPlaylistDetailReactor {
                 mutations.append(
                     requestCustomImageURLUseCase.execute(key: self.key, data: data)
                         .andThen(.concat([
-                            updateNotiName(notiName: .playlistRefresh), // 플리 이미지 갱신
-                            updateNotiName(notiName: .willRefreshUserInfo) // 열매 갱신
+                            postNotification(notiName: .playlistRefresh), // 플리 이미지 갱신
+                            postNotification(notiName: .willRefreshUserInfo) // 열매 갱신
                         ]))
                         .catch { error in
                             let wmErorr = error.asWMError
@@ -342,7 +342,7 @@ private extension MyPlaylistDetailReactor {
         return .concat([
             .just(.updateHeader(prev)),
             updateTitleAndPrivateUseCase.execute(key: key, title: text, isPrivate: nil)
-                .andThen(updateNotiName(notiName: .playlistRefresh))
+                .andThen(postNotification(notiName: .playlistRefresh))
         ])
     }
 }
@@ -449,7 +449,7 @@ private extension MyPlaylistDetailReactor {
                 .just(.updateSelectedCount(0)),
                 .just(.updateHeader(prevHeader)),
                 .just(.showToast("\(remainSongs.count)개의 곡을 삭제했습니다.")),
-                updateNotiName(notiName: .playlistRefresh)
+                postNotification(notiName: .playlistRefresh)
 
             ]))
             .catch { error in
@@ -464,7 +464,7 @@ private extension MyPlaylistDetailReactor {
         return .just(.updateImageData(imageData))
     }
 
-    func updateNotiName(notiName: Notification.Name) -> Observable<Mutation> {
-        .just(.updateNotiName(notiName))
+    func postNotification(notiName: Notification.Name) -> Observable<Mutation> {
+        .just(.postNotification(notiName))
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -282,7 +282,6 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
             .compactMap { $0 }
             .bind(with: self) { owner, name in
                 NotificationCenter.default.post(name: name, object: nil)
-               
             }
             .disposed(by: disposeBag)
 

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -278,10 +278,11 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
             }
             .disposed(by: disposeBag)
 
-        reactor.pulse(\.$refresh)
+        reactor.pulse(\.$notiName)
             .compactMap { $0 }
-            .bind(with: self) { owner, _ in
-                NotificationCenter.default.post(name: .playlistRefresh, object: nil)
+            .bind(with: self) { owner, name in
+                NotificationCenter.default.post(name: name, object: nil)
+               
             }
             .disposed(by: disposeBag)
 

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
@@ -4,6 +4,7 @@ public extension Notification.Name {
     static let playlistRefresh = Notification.Name("playlistRefresh") // 플레이리스트 목록 갱신(보관함 같은) (노래목록 아님)
     static let likeListRefresh = Notification.Name("likeListRefresh")
     static let subscriptionPlaylistDidRemoved = Notification.Name("subscriptionPlaylistDidRemoved") // 보관함에서 구독플리 제거
+    static let willRefreshUserInfo = Notification.Name("willRefreshUserInfo") // 유저 정보 갱신
     static let statusBarEnterDarkBackground = Notification.Name("statusBarEnterDarkBackground")
     static let statusBarEnterLightBackground = Notification.Name("statusBarEnterLightBackground")
     static let showSongCart = Notification.Name("showSongCart")


### PR DESCRIPTION
## 💡 배경 및 개요

음표 열매 사용 후 동기화처리가 없었습니다.

Resolves: #976

## 📃 작업내용

- NotificationCenter를 이용하여 플리 생성 및 커스텀 이미지 제작 시 음표열매를 사용 후 갱신합니다.

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
