### PR TITLE
🔀 :: (#981) 인트로(스플래쉬) > 유저정보 api 호출 제거

### DIFF
--- a/Projects/Domains/AuthDomain/Interface/Repository/AuthRepository.swift
+++ b/Projects/Domains/AuthDomain/Interface/Repository/AuthRepository.swift
@@ -4,6 +4,6 @@ import RxSwift
 public protocol AuthRepository {
     func fetchToken(providerType: ProviderType, token: String) -> Single<AuthLoginEntity>
     func reGenerateAccessToken() -> Single<AuthLoginEntity>
-    func logout() -> Completable
+    func logout(localOnly: Bool) -> Completable
     func checkIsExistAccessToken() -> Single<Bool>
 }

--- a/Projects/Domains/AuthDomain/Interface/UseCase/LogoutUseCase.swift
+++ b/Projects/Domains/AuthDomain/Interface/UseCase/LogoutUseCase.swift
@@ -1,5 +1,5 @@
 import RxSwift
 
 public protocol LogoutUseCase {
-    func execute() -> Completable
+    func execute(localOnly: Bool) -> Completable
 }

--- a/Projects/Domains/AuthDomain/Sources/Repository/AuthRepositoryImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/Repository/AuthRepositoryImpl.swift
@@ -30,14 +30,20 @@ public final class AuthRepositoryImpl: AuthRepository {
         remoteAuthDataSource.reGenerateAccessToken()
     }
 
-    public func logout() -> Completable {
+    public func logout(localOnly: Bool) -> Completable {
         let localLogoutCompletable = Completable.create { [localAuthDataSource] observer in
             localAuthDataSource.logout()
             observer(.completed)
             return Disposables.create()
         }
-        return remoteAuthDataSource.logout()
-            .andThen(localLogoutCompletable)
+
+        if localOnly {
+            return localLogoutCompletable
+
+        } else {
+            return remoteAuthDataSource.logout()
+                .andThen(localLogoutCompletable)
+        }
     }
 
     public func checkIsExistAccessToken() -> Single<Bool> {

--- a/Projects/Domains/AuthDomain/Sources/UseCase/LogoutUseCaseImpl.swift
+++ b/Projects/Domains/AuthDomain/Sources/UseCase/LogoutUseCaseImpl.swift
@@ -11,7 +11,7 @@ public struct LogoutUseCaseImpl: LogoutUseCase {
         self.authRepository = authRepository
     }
 
-    public func execute() -> Completable {
-        authRepository.logout()
+    public func execute(localOnly: Bool) -> Completable {
+        authRepository.logout(localOnly: localOnly)
     }
 }

--- a/Projects/Domains/AuthDomain/Testing/LogoutUseCaseSpy.swift
+++ b/Projects/Domains/AuthDomain/Testing/LogoutUseCaseSpy.swift
@@ -2,7 +2,7 @@ import AuthDomainInterface
 import RxSwift
 
 public struct LogoutUseCaseSpy: LogoutUseCase {
-    public func execute() -> Completable {
+    public func execute(localOnly: Bool) -> Completable {
         Completable.create { observer in
             observer(.completed)
             return Disposables.create()

--- a/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
@@ -88,7 +88,7 @@ public final class ContainSongsViewModel: ViewModelType {
                         let wmError = error.asWMError
                         if wmError == .tokenExpired {
                             logoutRelay.accept(wmError)
-                            return logoutUseCase.execute()
+                            return logoutUseCase.execute(localOnly: false)
                                 .andThen(Observable.error(wmError))
                         } else {
                             return Observable.error(wmError)
@@ -193,7 +193,7 @@ public final class ContainSongsViewModel: ViewModelType {
                         let wmError = error.asWMError
                         if wmError == .tokenExpired {
                             logoutRelay.accept(wmError)
-                            return owner.logoutUseCase.execute()
+                            return owner.logoutUseCase.execute(localOnly: false)
                                 .andThen(Observable.error(wmError))
                         } else {
                             return Observable.error(wmError)

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/SettingReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/SettingReactor.swift
@@ -165,7 +165,7 @@ private extension SettingReactor {
     }
 
     func confirmLogoutButtonDidTap() -> Observable<Mutation> {
-        return logoutUseCase.execute()
+        return logoutUseCase.execute(localOnly: false)
             .andThen(
                 .concat(
                     .just(.updateIsHiddenLogoutButton(true)),

--- a/Projects/Features/RootFeature/Sources/ViewControllers/IntroViewController.swift
+++ b/Projects/Features/RootFeature/Sources/ViewControllers/IntroViewController.swift
@@ -52,15 +52,15 @@ private extension IntroViewController {
     }
 
     func outputBind() {
-        permissionResult()
-        appInfoResult()
-        userInfoAndLottieEnded()
+        permissionBind()
+        appInfoBind()
+        userInfoAndLottieEndedBind()
     }
 }
 
 private extension IntroViewController {
-    func permissionResult() {
-        output.permissionResult
+    func permissionBind() {
+        output.confirmedPermission
             .do(onNext: { [weak self] permission in
                 guard let self = self else { return }
                 let show: Bool = !(permission ?? false)
@@ -76,8 +76,8 @@ private extension IntroViewController {
             .disposed(by: disposeBag)
     }
 
-    func appInfoResult() {
-        output.appInfoResult
+    func appInfoBind() {
+        output.confirmedAppInfo
             .withUnretained(self)
             .subscribe(onNext: { owner, result in
                 switch result {
@@ -90,7 +90,7 @@ private extension IntroViewController {
 
                     switch entity.flag {
                     case .normal:
-                        owner.input.fetchUserInfoCheck.onNext(())
+                        owner.input.checkUserInfoPreference.onNext(())
                         return
 
                     case .offline:
@@ -131,7 +131,7 @@ private extension IntroViewController {
                                 owner.goAppStore()
                             },
                             cancelCompletion: {
-                                owner.input.fetchUserInfoCheck.onNext(())
+                                owner.input.checkUserInfoPreference.onNext(())
                             }
                         )
 
@@ -173,11 +173,11 @@ private extension IntroViewController {
             .disposed(by: disposeBag)
     }
 
-    func userInfoAndLottieEnded() {
+    func userInfoAndLottieEndedBind() {
         Observable.zip(
-            output.userInfoResult,
+            output.confirmedUserInfoPreference,
             output.endedLottieAnimation
-        ) { result, _ -> Result<String, Error> in
+        ) { result, _ -> Result<Void, Error> in
             return result
         }
         .withUnretained(self)
@@ -251,7 +251,7 @@ private extension IntroViewController {
         }
 
         animationView.play { _ in
-            self.input.endedLottieAnimation.onNext(())
+            self.output.endedLottieAnimation.onNext(())
         }
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요
- 인트로에서 유저정보 api 호출이 불필요하다는 결론

Resolves: #981 

## 📃 작업내용
- 유저정보 api 호출 제거
- 로그인 상태로 앱을 삭제한 유저의 앱 재설치 상황에서 엑세스토큰을 날려주는데, logoutUsecase는 remote와 local 로그아웃이 둘다 이뤄지기 때문에 localOnly 플래그를 추가하였음.
- 기타 네이밍 수정

## 🙋‍♂️ 리뷰노트
x

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
