### PR TITLE
🔀 :: (#984) 재생목록 페이지에서 모든 노래를 삭제가 불가능한 이슈 해결

### DIFF
--- a/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlayState+Playlist.swift
+++ b/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlayState+Playlist.swift
@@ -52,8 +52,18 @@ final class Playlist {
         }
     }
 
+    func remove(id: String) {
+        if let index = list.firstIndex(where: { $0.id == id }) {
+            remove(at: index)
+        }
+    }
+
     func removeAll() {
         list.removeAll()
+    }
+
+    func removeAll(where shouldBeRemoved: (PlaylistItem) -> Bool) {
+        list.removeAll(where: shouldBeRemoved)
     }
 
     func contains(_ item: PlaylistItem) -> Bool {

--- a/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlayState.swift
+++ b/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlayState.swift
@@ -92,6 +92,14 @@ public final class PlayState {
         playlist.update(contentsOf: contentsOf)
     }
 
+    public func remove(id: String) {
+        playlist.remove(id: id)
+    }
+
+    public func remove(ids: [String]) {
+        ids.forEach { playlist.remove(id: $0) }
+    }
+
     public func remove(at index: Int) {
         playlist.remove(at: index)
     }
@@ -102,6 +110,10 @@ public final class PlayState {
 
     public func removeAll() {
         playlist.removeAll()
+    }
+
+    func removeAll(where shouldBeRemoved: (PlaylistItem) -> Bool) {
+        playlist.removeAll(where: shouldBeRemoved)
     }
 
     public func contains(item: PlaylistItem) -> Bool {

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController.swift
@@ -214,7 +214,7 @@ private extension PlaylistViewController {
     }
 
     private func bindCloseButton(output: PlaylistViewModel.Output) {
-        output.willClosePlaylist.sink { [weak self] _ in
+        output.shouldClosePlaylist.sink { [weak self] _ in
             self?.dismiss(animated: true)
         }.store(in: &subscription)
     }


### PR DESCRIPTION
## 💡 배경 및 개요
- 재생목록 페이지에서 모든 노래를 삭제가 불가능한 이슈 해결
- 간단하게 말하면 모든 노래를 삭제시키면 화면 dismiss를 시키는데 편집한걸 로컬에 반영하는 트리거를 실행하지 않은채로 dismiss만 시켜서 삭제가 안됐어요

Resolves: #984 

## 📃 작업내용

- 모든 노래 삭제를 할 때 editState를 false로 만들어서 PlayState에 보내는 트리거를 실행함

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
