### PR TITLE
🔀 :: (#769) 보관함 플레이리스트를 현재 재생목록에 추가하는 기능들 구현

### DIFF
--- a/Projects/App/Sources/Application/AppComponent+Playlist.swift
+++ b/Projects/App/Sources/Application/AppComponent+Playlist.swift
@@ -67,7 +67,7 @@ public extension AppComponent {
             FetchRecommendPlaylistUseCaseImpl(playlistRepository: playlistRepository)
         }
     }
-    
+
     var fetchPlaylistSongsUseCase: any FetchPlaylistSongsUseCase {
         shared {
             FetchPlaylistSongsUseCaseImpl(playlistRepository: playlistRepository)

--- a/Projects/App/Sources/Application/AppComponent+Playlist.swift
+++ b/Projects/App/Sources/Application/AppComponent+Playlist.swift
@@ -67,6 +67,12 @@ public extension AppComponent {
             FetchRecommendPlaylistUseCaseImpl(playlistRepository: playlistRepository)
         }
     }
+    
+    var fetchPlaylistSongsUseCase: any FetchPlaylistSongsUseCase {
+        shared {
+            FetchPlaylistSongsUseCaseImpl(playlistRepository: playlistRepository)
+        }
+    }
 
     var fetchPlaylistDetailUseCase: any FetchPlaylistDetailUseCase {
         shared {

--- a/Projects/Domains/PlaylistDomain/Interface/DataSource/RemotePlaylistDataSource.swift
+++ b/Projects/Domains/PlaylistDomain/Interface/DataSource/RemotePlaylistDataSource.swift
@@ -8,7 +8,7 @@ public protocol RemotePlaylistDataSource {
     func fetchPlaylistDetail(id: String, type: PlaylistType) -> Single<PlaylistDetailEntity>
     func updateTitleAndPrivate(key: String, title: String?, isPrivate: Bool?) -> Completable
     func createPlaylist(title: String) -> Single<PlaylistBaseEntity>
-    func fetchPlaylistSongs(id: String) -> Single<[SongEntity]>
+    func fetchPlaylistSongs(key: String) -> Single<[SongEntity]>
     func updatePlaylist(key: String, songs: [String]) -> Completable
     func addSongIntoPlaylist(key: String, songs: [String]) -> Single<AddSongEntity>
     func removeSongs(key: String, songs: [String]) -> Completable

--- a/Projects/Domains/PlaylistDomain/Interface/Repository/PlaylistRepository.swift
+++ b/Projects/Domains/PlaylistDomain/Interface/Repository/PlaylistRepository.swift
@@ -8,7 +8,7 @@ public protocol PlaylistRepository {
     func fetchPlaylistDetail(id: String, type: PlaylistType) -> Single<PlaylistDetailEntity>
     func updateTitleAndPrivate(key: String, title: String?, isPrivate: Bool?) -> Completable
     func createPlaylist(title: String) -> Single<PlaylistBaseEntity>
-    func fetchPlaylistSongs(id: String) -> Single<[SongEntity]>
+    func fetchPlaylistSongs(key: String) -> Single<[SongEntity]>
     func updatePlaylist(key: String, songs: [String]) -> Completable
     func addSongIntoPlaylist(key: String, songs: [String]) -> Single<AddSongEntity>
     func removeSongs(key: String, songs: [String]) -> Completable

--- a/Projects/Domains/PlaylistDomain/Sources/DataSource/RemotePlaylistDataSourceImpl.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/DataSource/RemotePlaylistDataSourceImpl.swift
@@ -33,8 +33,8 @@ public final class RemotePlaylistDataSourceImpl: BaseRemoteDataSource<PlaylistAP
             .map { $0.toDomain() }
     }
 
-    public func fetchPlaylistSongs(id: String) -> Single<[SongEntity]> {
-        request(.fetchPlaylistSongs(key: id))
+    public func fetchPlaylistSongs(key: String) -> Single<[SongEntity]> {
+        request(.fetchPlaylistSongs(key: key))
             .map([SingleSongResponseDTO].self)
             .map { $0.map { $0.toDomain() } }
     }

--- a/Projects/Domains/PlaylistDomain/Sources/Repository/PlaylistRepositoryImpl.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/Repository/PlaylistRepositoryImpl.swift
@@ -29,8 +29,8 @@ public final class PlaylistRepositoryImpl: PlaylistRepository {
         remotePlaylistDataSource.createPlaylist(title: title)
     }
 
-    public func fetchPlaylistSongs(id: String) -> Single<[SongEntity]> {
-        remotePlaylistDataSource.fetchPlaylistSongs(id: id)
+    public func fetchPlaylistSongs(key: String) -> Single<[SongEntity]> {
+        remotePlaylistDataSource.fetchPlaylistSongs(key: key)
     }
 
     public func updatePlaylist(key: String, songs: [String]) -> Completable {

--- a/Projects/Domains/PlaylistDomain/Sources/UseCase/FetchPlaylistSongsUseCaseImpl.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/UseCase/FetchPlaylistSongsUseCaseImpl.swift
@@ -1,8 +1,8 @@
 import BaseDomainInterface
 import Foundation
+import PlaylistDomainInterface
 import RxSwift
 import SongsDomainInterface
-import PlaylistDomainInterface
 
 public struct FetchPlaylistSongsUseCaseImpl: FetchPlaylistSongsUseCase {
     private let playlistRepository: any PlaylistRepository
@@ -12,7 +12,7 @@ public struct FetchPlaylistSongsUseCaseImpl: FetchPlaylistSongsUseCase {
     ) {
         self.playlistRepository = playlistRepository
     }
-    
+
     public func execute(key: String) -> Single<[SongEntity]> {
         return playlistRepository.fetchPlaylistSongs(key: key)
     }

--- a/Projects/Domains/PlaylistDomain/Sources/UseCase/FetchPlaylistSongsUseCaseImpl.swift
+++ b/Projects/Domains/PlaylistDomain/Sources/UseCase/FetchPlaylistSongsUseCaseImpl.swift
@@ -1,0 +1,19 @@
+import BaseDomainInterface
+import Foundation
+import RxSwift
+import SongsDomainInterface
+import PlaylistDomainInterface
+
+public struct FetchPlaylistSongsUseCaseImpl: FetchPlaylistSongsUseCase {
+    private let playlistRepository: any PlaylistRepository
+
+    public init(
+        playlistRepository: PlaylistRepository
+    ) {
+        self.playlistRepository = playlistRepository
+    }
+    
+    public func execute(key: String) -> Single<[SongEntity]> {
+        return playlistRepository.fetchPlaylistSongs(key: key)
+    }
+}

--- a/Projects/Features/StorageFeature/Sources/Components/LikeStorageComponent.swift
+++ b/Projects/Features/StorageFeature/Sources/Components/LikeStorageComponent.swift
@@ -22,7 +22,7 @@ public final class LikeStorageComponent: Component<LikeStorageDependency> {
     public func makeView() -> UIViewController {
         return LikeStorageViewController.viewController(
             reactor: LikeStorageReactor(
-                storageCommonService: DefaultStorageCommonService(),
+                storageCommonService: DefaultStorageCommonService.shared,
                 fetchFavoriteSongsUseCase: dependency.fetchFavoriteSongsUseCase,
                 deleteFavoriteListUseCase: dependency.deleteFavoriteListUseCase,
                 editFavoriteSongsOrderUseCase: dependency.editFavoriteSongsOrderUseCase

--- a/Projects/Features/StorageFeature/Sources/Components/ListStorageComponent.swift
+++ b/Projects/Features/StorageFeature/Sources/Components/ListStorageComponent.swift
@@ -33,7 +33,7 @@ public final class ListStorageComponent: Component<ListStorageDependency> {
                 fetchPlayListUseCase: dependency.fetchPlayListUseCase,
                 editPlayListOrderUseCase: dependency.editPlayListOrderUseCase,
                 deletePlayListUseCase: dependency.deletePlayListUseCase,
-                fetchPlaylistSongsUseCase:  dependency.fetchPlaylistSongsUseCase
+                fetchPlaylistSongsUseCase: dependency.fetchPlaylistSongsUseCase
             ),
             multiPurposePopUpFactory: dependency.multiPurposePopUpFactory,
             textPopUpFactory: dependency.textPopUpFactory,

--- a/Projects/Features/StorageFeature/Sources/Components/ListStorageComponent.swift
+++ b/Projects/Features/StorageFeature/Sources/Components/ListStorageComponent.swift
@@ -17,6 +17,7 @@ public protocol ListStorageDependency: Dependency {
     var editPlayListOrderUseCase: any EditPlaylistOrderUseCase { get }
     var fetchPlayListUseCase: any FetchPlaylistUseCase { get }
     var deletePlayListUseCase: any DeletePlaylistUseCase { get }
+    var fetchPlaylistSongsUseCase: any FetchPlaylistSongsUseCase { get }
     var logoutUseCase: any LogoutUseCase { get }
     var textPopUpFactory: any TextPopUpFactory { get }
     var signInFactory: any SignInFactory { get }
@@ -27,11 +28,12 @@ public final class ListStorageComponent: Component<ListStorageDependency> {
     public func makeView() -> UIViewController {
         return ListStorageViewController(
             reactor: ListStorageReactor(
-                storageCommonService: DefaultStorageCommonService(),
+                storageCommonService: DefaultStorageCommonService.shared,
                 createPlaylistUseCase: dependency.createPlaylistUseCase,
                 fetchPlayListUseCase: dependency.fetchPlayListUseCase,
                 editPlayListOrderUseCase: dependency.editPlayListOrderUseCase,
-                deletePlayListUseCase: dependency.deletePlayListUseCase
+                deletePlayListUseCase: dependency.deletePlayListUseCase,
+                fetchPlaylistSongsUseCase:  dependency.fetchPlaylistSongsUseCase
             ),
             multiPurposePopUpFactory: dependency.multiPurposePopUpFactory,
             textPopUpFactory: dependency.textPopUpFactory,

--- a/Projects/Features/StorageFeature/Sources/Components/StorageComponent.swift
+++ b/Projects/Features/StorageFeature/Sources/Components/StorageComponent.swift
@@ -19,7 +19,7 @@ public final class StorageComponent: Component<StorageDependency>, StorageFactor
     public func makeView() -> UIViewController {
         return StorageViewController.viewController(
             reactor: StorageReactor(
-                storageCommonService: DefaultStorageCommonService()
+                storageCommonService: DefaultStorageCommonService.shared
             ),
             listStorageComponent: dependency.listStorageComponent,
             multiPurposePopUpFactory: dependency.multiPurposePopUpFactory,

--- a/Projects/Features/StorageFeature/Sources/Reactors/LikeStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/LikeStorageReactor.swift
@@ -357,7 +357,8 @@ private extension LikeStorageReactor {
         deleteFavoriteListUseCase.execute(ids: ids)
             .andThen(
                 .concat(
-                    fetchDataSource()
+                    fetchDataSource(),
+                    .just(.showToast("\(ids.count)개의 리스트를 삭제했습니다."))
                 )
             )
             .catch { error in

--- a/Projects/Features/StorageFeature/Sources/Reactors/LikeStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/LikeStorageReactor.swift
@@ -284,9 +284,18 @@ extension LikeStorageReactor {
     }
 
     func addToCurrentPlaylist() -> Observable<Mutation> {
+        let limit = 50
+        
         let appendingPlaylisItems = currentState.dataSource
             .flatMap { $0.items.filter { $0.isSelected == true } }
             .map { PlaylistItem(id: $0.songID, title: $0.title, artist: $0.artist) }
+        
+        if appendingPlaylisItems.count > limit {
+            let overFlowQuantity = appendingPlaylisItems.count - limit
+            let overFlowMessage = LocalizationStrings.overFlowAddPlaylistWarning(overFlowQuantity)
+            return .just(.showToast(overFlowMessage))
+        }
+        
         PlayState.shared.append(contentsOf: appendingPlaylisItems)
         return .just(.showToast(LocalizationStrings.addList))
     }

--- a/Projects/Features/StorageFeature/Sources/Reactors/LikeStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/LikeStorageReactor.swift
@@ -285,17 +285,17 @@ extension LikeStorageReactor {
 
     func addToCurrentPlaylist() -> Observable<Mutation> {
         let limit = 50
-        
+
         let appendingPlaylisItems = currentState.dataSource
             .flatMap { $0.items.filter { $0.isSelected == true } }
             .map { PlaylistItem(id: $0.songID, title: $0.title, artist: $0.artist) }
-        
+
         if appendingPlaylisItems.count > limit {
             let overFlowQuantity = appendingPlaylisItems.count - limit
             let overFlowMessage = LocalizationStrings.overFlowAddPlaylistWarning(overFlowQuantity)
             return .just(.showToast(overFlowMessage))
         }
-        
+
         PlayState.shared.append(contentsOf: appendingPlaylisItems)
         return .just(.showToast(LocalizationStrings.addList))
     }

--- a/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
@@ -6,9 +6,9 @@ import PlaylistDomainInterface
 import ReactorKit
 import RxCocoa
 import RxSwift
+import SongsDomainInterface
 import UserDomainInterface
 import Utility
-import SongsDomainInterface
 
 final class ListStorageReactor: Reactor {
     enum Action {
@@ -314,11 +314,11 @@ extension ListStorageReactor {
             .flatMap { $0.items.filter { $0.isSelected == true } }
 
         let selectedSongCount = selectedPlaylists.map { $0.songCount }.reduce(0, +)
-        
+
         if selectedSongCount == 0 {
             return .just(.showToast("플레이리스트가 비어있습니다."))
         }
-        
+
         if selectedSongCount > limit {
             let overFlowQuantity = selectedSongCount - limit
             let overFlowMessage = LocalizationStrings.overFlowAddPlaylistWarning(overFlowQuantity)
@@ -363,17 +363,17 @@ extension ListStorageReactor {
         guard let selectedPlaylist = currentState.dataSource.first?.items[safe: index] else {
             return .just(.showToast("알 수 없는 오류가 발생하였습니다."))
         }
-        
+
         if selectedPlaylist.songCount == 0 {
             return .just(.showToast("플레이리스트가 비어있습니다."))
         }
-        
+
         if selectedPlaylist.songCount > limit {
             let overFlowQuantity = selectedPlaylist.songCount - limit
             let overFlowMessage = LocalizationStrings.overFlowAddPlaylistWarning(overFlowQuantity)
             return .just(.showToast(overFlowMessage))
         }
-        
+
         return Observable.concat(
             .just(.updateIsShowActivityIndicator(true)),
             fetchPlaylistSongsUseCase.execute(key: selectedPlaylist.key)
@@ -464,7 +464,8 @@ private extension ListStorageReactor {
 
     func mutateDeletePlaylistUseCase(_ playlists: [PlaylistEntity]) -> Observable<Mutation> {
         let noti = NotificationCenter.default
-        let subscribedPlaylistKeys = playlists.filter { $0.userId != PreferenceManager.userInfo?.decryptedID }.map { $0.key }
+        let subscribedPlaylistKeys = playlists.filter { $0.userId != PreferenceManager.userInfo?.decryptedID }
+            .map { $0.key }
         let ids = playlists.map { $0.key }
         return deletePlayListUseCase.execute(ids: ids)
             .do(onCompleted: {

--- a/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
@@ -324,13 +324,13 @@ extension ListStorageReactor {
             let overFlowMessage = LocalizationStrings.overFlowAddPlaylistWarning(overFlowQuantity)
             return .just(.showToast(overFlowMessage))
         }
-        
+
         let keys = selectedPlaylists.map { $0.key }
-        
+
         let observables = keys.map { key in
             fetchPlaylistSongsUseCase.execute(key: key).asObservable()
         }
-        
+
         return Observable.concat(
             .just(.updateIsShowActivityIndicator(true)),
             Observable.zip(observables)

--- a/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
@@ -1,4 +1,6 @@
+import BaseFeature
 import Foundation
+import Localization
 import LogManager
 import PlaylistDomainInterface
 import ReactorKit
@@ -66,13 +68,15 @@ final class ListStorageReactor: Reactor {
     private let fetchPlayListUseCase: any FetchPlaylistUseCase
     private let editPlayListOrderUseCase: any EditPlaylistOrderUseCase
     private let deletePlayListUseCase: any DeletePlaylistUseCase
+    private let fetchPlaylistSongsUseCase: any FetchPlaylistSongsUseCase
 
     init(
         storageCommonService: any StorageCommonService,
         createPlaylistUseCase: any CreatePlaylistUseCase,
         fetchPlayListUseCase: any FetchPlaylistUseCase,
         editPlayListOrderUseCase: any EditPlaylistOrderUseCase,
-        deletePlayListUseCase: any DeletePlaylistUseCase
+        deletePlayListUseCase: any DeletePlaylistUseCase,
+        fetchPlaylistSongsUseCase: any FetchPlaylistSongsUseCase
     ) {
         self.initialState = State(
             isLoggedIn: false,
@@ -309,13 +313,43 @@ extension ListStorageReactor {
 
     func addToCurrentPlaylist() -> Observable<Mutation> {
         #warning("PlayState 리팩토링 끝나면 수정 예정")
-        return .just(.showToast("개발이 필요해요"))
+        let limit = 50
+        let selectedPlaylists = currentState.dataSource
+            .flatMap { $0.items.filter { $0.isSelected == true } }
+
+        let selectedSongCount = selectedPlaylists.map { $0.songCount }.reduce(0, +)
+
+        if selectedSongCount > limit {
+            let overFlowQuantity = selectedSongCount - limit
+            let overFlowMessage = LocalizationStrings.overFlowAddPlaylistWarning(overFlowQuantity)
+            return .just(.showToast(overFlowMessage))
+        }
+
+        // let appendingPlaylistItems = selectedPlaylists.map { PlaylistItem(id: , title: , artist: ) }
+        // PlayState.shared.append(contentsOf: appendingPlaylisItems)
+
+        return .just(.showToast(LocalizationStrings.addList))
     }
 
     func playWithAddToCurrentPlaylist() -> Observable<Mutation> {
         #warning("PlayState 리팩토링 끝나면 수정 예정")
-        return .just(.showToast("개발이 필요해요"))
+        return .just(.showToast("playWithAddToCurrentPlaylist 개발이 필요해요"))
     }
+
+//    func addToCurrentPlaylist() -> Observable<Mutation> {
+//        let appendingPlaylisItems = currentState.dataSource
+//            .flatMap { $0.items.filter { $0.isSelected == true } }
+//            .map { PlaylistItem(id: $0.songID, title: $0.title, artist: $0.artist) }
+//        PlayState.shared.append(contentsOf: appendingPlaylisItems)
+//        return .just(.showToast(LocalizationStrings.addList))
+//    }
+//
+//    func playWithAddToCurrentPlaylist(song: FavoriteSongEntity) -> Observable<Mutation> {
+//        let appendingPlaylisItem = PlaylistItem(id: song.songID, title: song.title, artist: song.artist)
+//        PlayState.shared.append(item: appendingPlaylisItem)
+//        WakmusicYoutubePlayer(id: song.songID).play()
+//        return .empty()
+//    }
 
     /// 순서 변경
     func updateOrder(src: Int, dest: Int) -> Observable<Mutation> {

--- a/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
+++ b/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
@@ -9,6 +9,8 @@ protocol StorageCommonService {
 }
 
 final class DefaultStorageCommonService: StorageCommonService {
+    static let shared = DefaultStorageCommonService()
+    
     let isEditingState: BehaviorSubject<Bool>
     let loginStateDidChangedEvent: Observable<String?>
     let playlistRefreshEvent: Observable<Notification>

--- a/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
+++ b/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
@@ -10,7 +10,7 @@ protocol StorageCommonService {
 
 final class DefaultStorageCommonService: StorageCommonService {
     static let shared = DefaultStorageCommonService()
-    
+
     let isEditingState: BehaviorSubject<Bool>
     let loginStateDidChangedEvent: Observable<String?>
     let playlistRefreshEvent: Observable<Notification>

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/LikeStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/LikeStorageViewController.swift
@@ -89,7 +89,11 @@ final class LikeStorageViewController: BaseReactorViewController<LikeStorageReac
         reactor.pulse(\.$showToast)
             .compactMap { $0 }
             .bind(with: self, onNext: { owner, message in
-                owner.showToast(text: message, font: DesignSystemFontFamily.Pretendard.light.font(size: 14), options: [.tabBar, .songCart])
+                owner.showToast(
+                    text: message,
+                    font: DesignSystemFontFamily.Pretendard.light.font(size: 14),
+                    options: [.tabBar, .songCart]
+                )
             })
             .disposed(by: disposeBag)
 

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/LikeStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/LikeStorageViewController.swift
@@ -89,7 +89,7 @@ final class LikeStorageViewController: BaseReactorViewController<LikeStorageReac
         reactor.pulse(\.$showToast)
             .compactMap { $0 }
             .bind(with: self, onNext: { owner, message in
-                owner.showToast(text: message, font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
+                owner.showToast(text: message, font: DesignSystemFontFamily.Pretendard.light.font(size: 14), options: [.tabBar, .songCart])
             })
             .disposed(by: disposeBag)
 

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
@@ -103,7 +103,11 @@ final class ListStorageViewController: BaseReactorViewController<ListStorageReac
         reactor.pulse(\.$showToast)
             .compactMap { $0 }
             .bind(with: self, onNext: { owner, message in
-                owner.showToast(text: message, font: DesignSystemFontFamily.Pretendard.light.font(size: 14), options: [.tabBar, .songCart])
+                owner.showToast(
+                    text: message,
+                    font: DesignSystemFontFamily.Pretendard.light.font(size: 14),
+                    options: [.tabBar, .songCart]
+                )
             })
             .disposed(by: disposeBag)
 

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
@@ -103,7 +103,7 @@ final class ListStorageViewController: BaseReactorViewController<ListStorageReac
         reactor.pulse(\.$showToast)
             .compactMap { $0 }
             .bind(with: self, onNext: { owner, message in
-                owner.showToast(text: message, font: DesignSystemFontFamily.Pretendard.light.font(size: 14))
+                owner.showToast(text: message, font: DesignSystemFontFamily.Pretendard.light.font(size: 14), options: [.tabBar, .songCart])
             })
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 💡 배경 및 개요
재생목록에 추가하는 기능들 빨리 구현해야겠다 해서 처리했슴다
Resolves: #769

## 📃 작업내용
- DefaultStorageCommonService 싱글톤 복구
> 편집 상태 공유 등 storage, list, like 셋이서 같은 상태를 공유하기 위함이었는데, 각각 인스턴스를 생성하면 상태를 공유하지 못함..
- 플레이리스트 key값을 통해 곡들 가져오는 UseCase 추가
- 플레이리스트를 재생목록에 추가 기능 구현
- 플레이리스트를 재생목록에 추가 및 재생 기능 구현
- 구독중인 리스트 삭제 시 노티 전송
- 좋아요한 곡 재생목록에 추가 시 50곡 제한 코드 추가

## 🙋‍♂️ 리뷰노트

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
