### PR TITLE
🔀 :: (#983) 재생목록 저장 최대 50개로 제한

### DIFF
--- a/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlayState+Playlist.swift
+++ b/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlayState+Playlist.swift
@@ -12,6 +12,10 @@ import SongsDomainInterface
 import Utility
 
 final class Playlist {
+    private enum Const {
+        static let maximumListCount = 50
+    }
+
     @Published private(set) var list: [PlaylistItem] = []
 
     init(list: [PlaylistItem] = []) {
@@ -27,18 +31,26 @@ final class Playlist {
 
     func append(_ item: PlaylistItem) {
         list.append(item)
+
+        processListMaximumCount()
     }
 
     func append(_ items: [PlaylistItem]) {
         list.append(contentsOf: items)
+
+        processListMaximumCount()
     }
 
     func insert(_ newElement: PlaylistItem, at: Int) {
         list.insert(newElement, at: at)
+
+        processListMaximumCount()
     }
 
     func update(contentsOf items: [PlaylistItem]) {
         list = items
+
+        processListMaximumCount()
     }
 
     func remove(at index: Int) {
@@ -79,5 +91,13 @@ final class Playlist {
     /// 해당 곡이 이미 재생목록에 있으면 재생목록 속 해당 곡의 index, 없으면 nil 리턴
     func uniqueIndex(of item: PlaylistItem) -> Int? {
         return list.firstIndex(of: item)
+    }
+}
+
+private extension Playlist {
+    func processListMaximumCount() {
+        if list.count > Const.maximumListCount {
+            list = Array(list.suffix(Const.maximumListCount))
+        }
     }
 }

--- a/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlayState+Playlist.swift
+++ b/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlayState+Playlist.swift
@@ -52,8 +52,18 @@ final class Playlist {
         }
     }
 
+    func remove(id: String) {
+        if let index = list.firstIndex(where: { $0.id == id }) {
+            remove(at: index)
+        }
+    }
+
     func removeAll() {
         list.removeAll()
+    }
+
+    func removeAll(where shouldBeRemoved: (PlaylistItem) -> Bool) {
+        list.removeAll(where: shouldBeRemoved)
     }
 
     func contains(_ item: PlaylistItem) -> Bool {

--- a/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlayState.swift
+++ b/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlayState.swift
@@ -92,6 +92,14 @@ public final class PlayState {
         playlist.update(contentsOf: contentsOf)
     }
 
+    public func remove(id: String) {
+        playlist.remove(id: id)
+    }
+
+    public func remove(ids: [String]) {
+        ids.forEach { playlist.remove(id: $0) }
+    }
+
     public func remove(at index: Int) {
         playlist.remove(at: index)
     }
@@ -102,6 +110,10 @@ public final class PlayState {
 
     public func removeAll() {
         playlist.removeAll()
+    }
+
+    func removeAll(where shouldBeRemoved: (PlaylistItem) -> Bool) {
+        playlist.removeAll(where: shouldBeRemoved)
     }
 
     public func contains(item: PlaylistItem) -> Bool {

--- a/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlayState.swift
+++ b/Projects/Features/BaseFeature/Sources/Etc/PlayState/PlayState.swift
@@ -38,6 +38,8 @@ public final class PlayState {
     /// 플레이리스트에 변경사항이 생겼을 때, 로컬 DB를 덮어씁니다.
     private func subscribePlayListChanges() {
         playlist.subscribeListChanges()
+            .map { $0.suffix(50) }
+            .map { Array($0) }
             .sink { [weak self] playlistItems in
                 self?.updatePlaylistChangesToLocalDB(playList: playlistItems)
             }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlayListViewController.swift
@@ -214,7 +214,7 @@ private extension PlaylistViewController {
     }
 
     private func bindCloseButton(output: PlaylistViewModel.Output) {
-        output.willClosePlaylist.sink { [weak self] _ in
+        output.shouldClosePlaylist.sink { [weak self] _ in
             self?.dismiss(animated: true)
         }.store(in: &subscription)
     }


### PR DESCRIPTION
## 💡 배경 및 개요
- 재생목록에 노래를 최대 50개만 제한할 수 있게 했어요.
- 노래를 저장할 시 50개 이상이면 오래된순으로 잘라서 저장되게 해요.

Resolves: #983 

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
