### PR TITLE
🔀 :: (#990) 내 정보 viewDidLoad 시 서버로부터 유저정보 fetch

### DIFF
--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -8,6 +8,7 @@ import Utility
 
 final class MyInfoReactor: Reactor {
     enum Action {
+        case viewDidLoad
         case loginButtonDidTap
         case profileImageDidTap
         case drawButtonDidTap
@@ -20,8 +21,6 @@ final class MyInfoReactor: Reactor {
         case completedFruitDraw
         case completedSetProfile
         case changeNicknameButtonDidTap(String)
-        case changedUserInfo(UserInfo?)
-        case changedReadNoticeIDs([Int])
         case requiredLogin
     }
 
@@ -89,12 +88,12 @@ final class MyInfoReactor: Reactor {
             fruitCount: 0,
             isAllNoticesRead: false
         )
-        observeUserInfoChanges()
-        observeReadNoticeIdChanges()
     }
 
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
+        case .viewDidLoad:
+            return viewDidLoad()
         case .loginButtonDidTap:
             return loginButtonDidTap()
         case .profileImageDidTap:
@@ -113,24 +112,14 @@ final class MyInfoReactor: Reactor {
             return teamNavigationDidTap()
         case .settingNavigationDidTap:
             return settingNavigationDidTap()
-        case let .changedUserInfo(userInfo):
-            return .concat(
-                updateIsLoggedIn(userInfo),
-                updateProfileImage(userInfo),
-                updateNickname(userInfo),
-                updatePlatform(userInfo),
-                updateFruitCount(userInfo)
-            )
-        case let .changedReadNoticeIDs(readIDs):
-            return updateIsAllNoticesRead(readIDs)
         case .requiredLogin:
             return navigateLogin()
         case .completedFruitDraw:
-            return fetchUserInfo()
+            return mutateFetchUserInfoUseCase()
         case .completedSetProfile:
-            return fetchUserInfo()
+            return mutateFetchUserInfoUseCase()
         case let .changeNicknameButtonDidTap(newNickname):
-            return updateRemoteNickname(newNickname)
+            return mutateSetRemoteUserNameUseCase(newNickname)
         }
     }
 
@@ -176,51 +165,39 @@ final class MyInfoReactor: Reactor {
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
         let willRefreshUserInfoMutation = myInfoCommonService.willRefreshUserInfoEvent.withUnretained(self)
             .flatMap { owner, _ -> Observable<Mutation> in
-                return owner.fetchUserInfo()
+                return owner.mutateFetchUserInfoUseCase()
             }
-
-        return Observable.merge(willRefreshUserInfoMutation, mutation)
+        
+        let didChangedUserInfoMutation = myInfoCommonService.didChangedUserInfoEvent
+            .withUnretained(self)
+            .flatMap { owner, userInfo -> Observable<Mutation> in
+                return .concat(
+                    owner.updateNickname(userInfo),
+                    owner.updatePlatform(userInfo),
+                    owner.updateFruitCount(userInfo),
+                    owner.updateIsLoggedIn(userInfo),
+                    owner.updateProfileImage(userInfo)
+                )
+            }
+        
+        let didChangedReadNoticeIDsMutation = myInfoCommonService.didChangedReadNoticeIDsEvent
+            .withUnretained(self)
+            .flatMap { owner, readIDs -> Observable<Mutation> in
+                return owner.mutateFetchNoticeIDListUseCase(readIDs ?? [])
+            }
+        
+        return Observable.merge(
+            mutation,
+            willRefreshUserInfoMutation,
+            didChangedUserInfoMutation,
+            didChangedReadNoticeIDsMutation
+        )
     }
 }
 
 private extension MyInfoReactor {
-    func observeUserInfoChanges() {
-        PreferenceManager.$userInfo
-            .bind(with: self) { owner, userInfo in
-                owner.action.onNext(.changedUserInfo(userInfo))
-            }
-            .disposed(by: disposeBag)
-    }
-
-    func observeReadNoticeIdChanges() {
-        PreferenceManager.$readNoticeIDs
-            .map { $0 ?? [] }
-            .bind(with: self) { owner, readIDs in
-                owner.action.onNext(.changedReadNoticeIDs(readIDs))
-            }
-            .disposed(by: disposeBag)
-    }
-
-    func fetchUserInfo() -> Observable<Mutation> {
-        return fetchUserInfoUseCase.execute()
-            .asObservable()
-            .flatMap { _ in Observable.empty() }
-            .catch { error in
-                let error = error.asWMError
-                return Observable.just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
-            }
-    }
-
-    func updateIsAllNoticesRead(_ readIDs: [Int]) -> Observable<Mutation> {
-        return fetchNoticeIDListUseCase.execute()
-            .catchAndReturn(FetchNoticeIDListEntity(status: "404", data: []))
-            .asObservable()
-            .map {
-                let readIDsSet = Set(readIDs)
-                let allNoticeIDsSet = Set($0.data)
-                return allNoticeIDsSet.isSubset(of: readIDsSet)
-            }
-            .map { Mutation.updateIsAllNoticesRead($0) }
+    func viewDidLoad() -> Observable<Mutation> {
+        return mutateFetchUserInfoUseCase()
     }
 
     func updateIsLoggedIn(_ userInfo: UserInfo?) -> Observable<Mutation> {
@@ -230,27 +207,6 @@ private extension MyInfoReactor {
     func updateProfileImage(_ userInfo: UserInfo?) -> Observable<Mutation> {
         guard let profile = userInfo?.profile else { return .empty() }
         return .just(.updateProfileImage(profile))
-    }
-
-    func updateRemoteNickname(_ newNickname: String) -> Observable<Mutation> {
-        setUsernameUseCase.execute(name: newNickname)
-            .andThen(
-                fetchUserInfoUseCase.execute()
-                    .asObservable()
-                    .flatMap { _ -> Observable<Mutation> in
-                        return .concat(
-                            .just(.showToast("닉네임이 변경되었습니다.")),
-                            .just(.dismissEditSheet)
-                        )
-                    }
-            )
-            .catch { error in
-                let error = error.asWMError
-                return .concat(
-                    .just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")),
-                    .just(.dismissEditSheet)
-                )
-            }
     }
 
     func updateNickname(_ userInfo: UserInfo?) -> Observable<Mutation> {
@@ -308,5 +264,50 @@ private extension MyInfoReactor {
 
     func navigateLogin() -> Observable<Mutation> {
         return .just(.navigate(.login))
+    }
+}
+
+private extension MyInfoReactor {
+    func mutateFetchUserInfoUseCase() -> Observable<Mutation> {
+        return fetchUserInfoUseCase.execute()
+            .asObservable()
+            .flatMap { _ in Observable.empty() }
+            .catch { error in
+                let error = error.asWMError
+                return Observable.just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
+            }
+    }
+    
+    func mutateSetRemoteUserNameUseCase(_ newNickname: String) -> Observable<Mutation> {
+        setUsernameUseCase.execute(name: newNickname)
+            .andThen(
+                fetchUserInfoUseCase.execute()
+                    .asObservable()
+                    .flatMap { _ -> Observable<Mutation> in
+                        return .concat(
+                            .just(.showToast("닉네임이 변경되었습니다.")),
+                            .just(.dismissEditSheet)
+                        )
+                    }
+            )
+            .catch { error in
+                let error = error.asWMError
+                return .concat(
+                    .just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")),
+                    .just(.dismissEditSheet)
+                )
+            }
+    }
+    
+    func mutateFetchNoticeIDListUseCase(_ readIDs: [Int]) -> Observable<Mutation> {
+        return fetchNoticeIDListUseCase.execute()
+            .catchAndReturn(FetchNoticeIDListEntity(status: "404", data: []))
+            .asObservable()
+            .map {
+                let readIDsSet = Set(readIDs)
+                let allNoticeIDsSet = Set($0.data)
+                return allNoticeIDsSet.isSubset(of: readIDsSet)
+            }
+            .map { Mutation.updateIsAllNoticesRead($0) }
     }
 }

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -115,11 +115,11 @@ final class MyInfoReactor: Reactor {
         case .requiredLogin:
             return navigateLogin()
         case .completedFruitDraw:
-            return mutateFetchUserInfoUseCase()
+            return mutateFetchUserInfo()
         case .completedSetProfile:
-            return mutateFetchUserInfoUseCase()
+            return mutateFetchUserInfo()
         case let .changeNicknameButtonDidTap(newNickname):
-            return mutateSetRemoteUserNameUseCase(newNickname)
+            return mutateSetRemoteUserName(newNickname)
         }
     }
 
@@ -165,7 +165,7 @@ final class MyInfoReactor: Reactor {
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
         let willRefreshUserInfoMutation = myInfoCommonService.willRefreshUserInfoEvent.withUnretained(self)
             .flatMap { owner, _ -> Observable<Mutation> in
-                return owner.mutateFetchUserInfoUseCase()
+                return owner.mutateFetchUserInfo()
             }
 
         let didChangedUserInfoMutation = myInfoCommonService.didChangedUserInfoEvent
@@ -183,7 +183,7 @@ final class MyInfoReactor: Reactor {
         let didChangedReadNoticeIDsMutation = myInfoCommonService.didChangedReadNoticeIDsEvent
             .withUnretained(self)
             .flatMap { owner, readIDs -> Observable<Mutation> in
-                return owner.mutateFetchNoticeIDListUseCase(readIDs ?? [])
+                return owner.mutateFetchNoticeIDList(readIDs ?? [])
             }
 
         return Observable.merge(
@@ -197,7 +197,7 @@ final class MyInfoReactor: Reactor {
 
 private extension MyInfoReactor {
     func viewDidLoad() -> Observable<Mutation> {
-        return mutateFetchUserInfoUseCase()
+        return mutateFetchUserInfo()
     }
 
     func updateIsLoggedIn(_ userInfo: UserInfo?) -> Observable<Mutation> {
@@ -268,7 +268,7 @@ private extension MyInfoReactor {
 }
 
 private extension MyInfoReactor {
-    func mutateFetchUserInfoUseCase() -> Observable<Mutation> {
+    func mutateFetchUserInfo() -> Observable<Mutation> {
         return fetchUserInfoUseCase.execute()
             .asObservable()
             .flatMap { _ in Observable.empty() }
@@ -278,7 +278,7 @@ private extension MyInfoReactor {
             }
     }
 
-    func mutateSetRemoteUserNameUseCase(_ newNickname: String) -> Observable<Mutation> {
+    func mutateSetRemoteUserName(_ newNickname: String) -> Observable<Mutation> {
         setUsernameUseCase.execute(name: newNickname)
             .andThen(
                 fetchUserInfoUseCase.execute()
@@ -299,7 +299,7 @@ private extension MyInfoReactor {
             }
     }
 
-    func mutateFetchNoticeIDListUseCase(_ readIDs: [Int]) -> Observable<Mutation> {
+    func mutateFetchNoticeIDList(_ readIDs: [Int]) -> Observable<Mutation> {
         return fetchNoticeIDListUseCase.execute()
             .catchAndReturn(FetchNoticeIDListEntity(status: "404", data: []))
             .asObservable()

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -167,7 +167,7 @@ final class MyInfoReactor: Reactor {
             .flatMap { owner, _ -> Observable<Mutation> in
                 return owner.mutateFetchUserInfoUseCase()
             }
-        
+
         let didChangedUserInfoMutation = myInfoCommonService.didChangedUserInfoEvent
             .withUnretained(self)
             .flatMap { owner, userInfo -> Observable<Mutation> in
@@ -179,13 +179,13 @@ final class MyInfoReactor: Reactor {
                     owner.updateProfileImage(userInfo)
                 )
             }
-        
+
         let didChangedReadNoticeIDsMutation = myInfoCommonService.didChangedReadNoticeIDsEvent
             .withUnretained(self)
             .flatMap { owner, readIDs -> Observable<Mutation> in
                 return owner.mutateFetchNoticeIDListUseCase(readIDs ?? [])
             }
-        
+
         return Observable.merge(
             mutation,
             willRefreshUserInfoMutation,
@@ -277,7 +277,7 @@ private extension MyInfoReactor {
                 return Observable.just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
             }
     }
-    
+
     func mutateSetRemoteUserNameUseCase(_ newNickname: String) -> Observable<Mutation> {
         setUsernameUseCase.execute(name: newNickname)
             .andThen(
@@ -298,7 +298,7 @@ private extension MyInfoReactor {
                 )
             }
     }
-    
+
     func mutateFetchNoticeIDListUseCase(_ readIDs: [Int]) -> Observable<Mutation> {
         return fetchNoticeIDListUseCase.execute()
             .catchAndReturn(FetchNoticeIDListEntity(status: "404", data: []))

--- a/Projects/Features/MyInfoFeature/Sources/Service/MyInfoCommonService.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Service/MyInfoCommonService.swift
@@ -4,14 +4,21 @@ import Utility
 
 protocol MyInfoCommonService {
     var willRefreshUserInfoEvent: Observable<Notification> { get }
+    var didChangedUserInfoEvent: Observable<UserInfo?> { get }
+    var didChangedReadNoticeIDsEvent: Observable<[Int]?> { get }
 }
 
 final class DefaultMyInfoCommonService: MyInfoCommonService {
     let willRefreshUserInfoEvent: Observable<Notification>
+    let didChangedUserInfoEvent: Observable<UserInfo?>
+    let didChangedReadNoticeIDsEvent: Observable<[Int]?>
+    
     static let shared = DefaultMyInfoCommonService()
 
     init() {
         let notificationCenter = NotificationCenter.default
         willRefreshUserInfoEvent = notificationCenter.rx.notification(.willRefreshUserInfo)
+        didChangedUserInfoEvent = PreferenceManager.$userInfo
+        didChangedReadNoticeIDsEvent = PreferenceManager.$readNoticeIDs
     }
 }

--- a/Projects/Features/MyInfoFeature/Sources/Service/MyInfoCommonService.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Service/MyInfoCommonService.swift
@@ -12,7 +12,7 @@ final class DefaultMyInfoCommonService: MyInfoCommonService {
     let willRefreshUserInfoEvent: Observable<Notification>
     let didChangedUserInfoEvent: Observable<UserInfo?>
     let didChangedReadNoticeIDsEvent: Observable<[Int]?>
-    
+
     static let shared = DefaultMyInfoCommonService()
 
     init() {

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -43,7 +43,7 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
         super.viewDidAppear(animated)
         navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         reactor?.action.onNext(.viewDidLoad)

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -43,6 +43,11 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
         super.viewDidAppear(animated)
         navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        reactor?.action.onNext(.viewDidLoad)
+    }
 
     override public func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)


### PR DESCRIPTION
## 💡 배경 및 개요

기존엔 내 정보 리액터가 생성되면 PreferenceManager.userInfo 와 바인딩을 맺어 유저정보를 fetch 해오는 방식이었습니다.
PreferenceManager.userInfo 는 어디까지나 로컬 정보이기에 가져오는 타이밍에 따라 서버와 다른 값을 가지고 있을 수 있다는 위험성이 존재했습니다.
따라서 버그 방지 및 동작 일관성을 위해 viewDidLoad시 api를 호출해 유저정보를 갱신하도록 변경합니다.

Resolves: #990

## 📃 작업내용
- viewDidLoad 시 서버로부터 유저정보 fetch
- 리액터에서 직접 옵저빙하던 코드들 transform 으로 리팩토링
- 변수명, extension 등 코드 가독성 개선

## 🙋‍♂️ 리뷰노트

```swift
private extension MyInfoReactor {
    func mutateFetchUserInfoUseCase() -> Observable<Mutation> {
        return fetchUserInfoUseCase.execute()
            .asObservable()
            .flatMap { _ in Observable.empty() }
            .catch { error in
                let error = error.asWMError
                return Observable.just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
            }
    }
    
    func mutateSetRemoteUserNameUseCase(_ newNickname: String) -> Observable<Mutation> {
        setUsernameUseCase.execute(name: newNickname)
            .andThen(
                fetchUserInfoUseCase.execute()
                    .asObservable()
                    .flatMap { _ -> Observable<Mutation> in
                        return .concat(
                            .just(.showToast("닉네임이 변경되었습니다.")),
                            .just(.dismissEditSheet)
                        )
                    }
            )
            .catch { error in
                let error = error.asWMError
                return .concat(
                    .just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")),
                    .just(.dismissEditSheet)
                )
            }
    }
    
   // 위 메소드들은 동작과 메소드명이 일치하는데 얘는 메소드명이 동작과 어울리지 않다는 느낌이 들어요 
   // api를 통해 공지ID들을 전부 읽어오고, map을 통해 전부 다 읽은 공지들인지 판별해서 mutation으로 바꿔주는 동작입니다.
  // 다음과 같이 메소드명을 지은 이유는 "해당 useCase를 실행하고 mutate로 변환시켜주는 코드다." 
  // 라는 의미로 메소드명을 단순하게 지어봤어요. 
  // 더 좋은 메소드명 있다면 조언 부탁드립니다 
    func mutateFetchNoticeIDListUseCase(_ readIDs: [Int]) -> Observable<Mutation> {
        return fetchNoticeIDListUseCase.execute()
            .catchAndReturn(FetchNoticeIDListEntity(status: "404", data: []))
            .asObservable()
            .map {
                let readIDsSet = Set(readIDs)
                let allNoticeIDsSet = Set($0.data)
                return allNoticeIDsSet.isSubset(of: readIDsSet)
            }
            .map { Mutation.updateIsAllNoticesRead($0) }
    }
}
```

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
