### PR TITLE
🔀 :: (#986)  재생목록 편집 상태 동기화

### DIFF
--- a/Projects/Features/PlaylistFeature/Sources/Components/PlaylistComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/PlaylistComponent.swift
@@ -2,11 +2,14 @@ import BaseFeature
 import BaseFeatureInterface
 import NeedleFoundation
 import PlaylistFeatureInterface
+import SignInFeatureInterface
 import UIKit
 
 public protocol PlaylistDependency: Dependency {
     var containSongsFactory: any ContainSongsFactory { get }
     var songDetailPresenter: any SongDetailPresentable { get }
+    var textPopUpFactory: any TextPopUpFactory { get }
+    var signInFactory: any SignInFactory { get }
 }
 
 public final class PlaylistComponent: Component<PlaylistDependency>, PlaylistFactory {
@@ -15,7 +18,9 @@ public final class PlaylistComponent: Component<PlaylistDependency>, PlaylistFac
         let viewController = PlaylistViewController(
             viewModel: viewModel,
             containSongsFactory: dependency.containSongsFactory,
-            songDetailPresenter: dependency.songDetailPresenter
+            songDetailPresenter: dependency.songDetailPresenter,
+            textPopUpFactory: dependency.textPopUpFactory,
+            signInFactory: dependency.signInFactory
         )
         return viewController
     }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistViewController+Delegate.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistViewController+Delegate.swift
@@ -1,8 +1,8 @@
 import BaseFeature
 import DesignSystem
+import Localization
 import UIKit
 import Utility
-import Localization
 
 extension PlaylistViewController: SongCartViewDelegate {
     public func buttonTapped(type: SongCartSelectType) {
@@ -14,11 +14,10 @@ extension PlaylistViewController: SongCartViewDelegate {
             guard let viewController = containSongsFactory.makeView(songs: songs) as? ContainSongsViewController else {
                 return
             }
-            
+
             let count = songs.count
-            
+
             if PreferenceManager.userInfo == nil {
-                
                 let textPopvc = TextPopupViewController.viewController(
                     text: LocalizationStrings.needLoginWarning,
                     cancelButtonIsHidden: false,

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistViewController+Delegate.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistViewController+Delegate.swift
@@ -2,6 +2,7 @@ import BaseFeature
 import DesignSystem
 import UIKit
 import Utility
+import Localization
 
 extension PlaylistViewController: SongCartViewDelegate {
     public func buttonTapped(type: SongCartSelectType) {
@@ -9,16 +10,34 @@ extension PlaylistViewController: SongCartViewDelegate {
         case let .allSelect(flag):
             self.isSelectedAllSongs.onNext(flag)
         case .addSong:
-            let songs: [String] = []
+            let songs: [String] = Array(output.selectedSongIds.value)
             guard let viewController = containSongsFactory.makeView(songs: songs) as? ContainSongsViewController else {
                 return
             }
-
+            
+            let count = songs.count
+            
+            if PreferenceManager.userInfo == nil {
+                
+                let textPopvc = TextPopupViewController.viewController(
+                    text: LocalizationStrings.needLoginWarning,
+                    cancelButtonIsHidden: false,
+                    completion: { [weak self] in
+                        guard let self else { return }
+                        let vc = self.signInFactory.makeView()
+                        vc.modalPresentationStyle = .fullScreen
+                        self.present(vc, animated: true) {
+                            self.tappedAddPlaylist.onNext(())
+                        }
+                    }
+                )
+                self.showBottomSheet(content: textPopvc)
+                return
+            }
             viewController.modalPresentationStyle = .overFullScreen
 
             self.present(viewController, animated: true) {
                 self.tappedAddPlaylist.onNext(())
-                self.hideSongCart()
             }
 
         case .remove:

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -7,10 +7,10 @@ import Kingfisher
 import RxDataSources
 import RxRelay
 import RxSwift
+import SignInFeatureInterface
 import SnapKit
 import UIKit
 import Utility
-import SignInFeatureInterface
 
 public final class PlaylistViewController: UIViewController, SongCartViewType {
     var viewModel: PlaylistViewModel!

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -10,6 +10,7 @@ import RxSwift
 import SnapKit
 import UIKit
 import Utility
+import SignInFeatureInterface
 
 public final class PlaylistViewController: UIViewController, SongCartViewType {
     var viewModel: PlaylistViewModel!
@@ -25,6 +26,8 @@ public final class PlaylistViewController: UIViewController, SongCartViewType {
 
     private(set) var containSongsFactory: any ContainSongsFactory
     private(set) var songDetailPresenter: any SongDetailPresentable
+    private(set) var textPopUpFactory: any TextPopUpFactory
+    private(set) var signInFactory: any SignInFactory
 
     public var songCartView: BaseFeature.SongCartView!
     public var bottomSheetView: BaseFeature.BottomSheetView!
@@ -51,10 +54,14 @@ public final class PlaylistViewController: UIViewController, SongCartViewType {
     init(
         viewModel: PlaylistViewModel,
         containSongsFactory: ContainSongsFactory,
-        songDetailPresenter: any SongDetailPresentable
+        songDetailPresenter: any SongDetailPresentable,
+        textPopUpFactory: any TextPopUpFactory,
+        signInFactory: any SignInFactory
     ) {
         self.containSongsFactory = containSongsFactory
         self.songDetailPresenter = songDetailPresenter
+        self.signInFactory = signInFactory
+        self.textPopUpFactory = textPopUpFactory
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }

--- a/Projects/Features/PlaylistFeature/Sources/ViewModels/PlayListViewModel.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewModels/PlayListViewModel.swift
@@ -1,11 +1,3 @@
-//
-//  PlaylistViewModel.swift
-//  PlayerFeature
-//
-//  Created by YoungK on 2023/02/28.
-//  Copyright © 2023 yongbeomkwak. All rights reserved.
-//
-
 import BaseFeature
 import Combine
 import Foundation
@@ -13,6 +5,7 @@ import RxDataSources
 import RxRelay
 import RxSwift
 import Utility
+
 
 internal typealias PlayListSectionModel = SectionModel<Int, PlaylistItemModel>
 
@@ -116,18 +109,21 @@ final class PlaylistViewModel: ViewModelType {
             .disposed(by: disposeBag)
 
         input.addPlaylistButtonDidTapEvent
-            .subscribe { _ in
+            .withUnretained(self)
+            .subscribe(onNext: { (owner, _) in
                 output.selectedSongIds.accept([])
                 output.editState.send(false)
-            }.disposed(by: disposeBag)
+                owner.isEditing = false
+            })
+            .disposed(by: disposeBag)
 
         input.removeSongsButtonDidTapEvent
             .withLatestFrom(output.selectedSongIds)
-            .subscribe(onNext: { selectedIds in
+            .withUnretained(self)
+            .subscribe(onNext: { owner, selectedIds in
                 if selectedIds.count == output.playlists.value.count {
                     output.playlists.accept([])
                     output.selectedSongIds.accept([])
-                    output.editState.send(false)
                     output.shouldClosePlaylist.send()
                 } else {
                     let removedPlaylists = output.playlists.value
@@ -135,6 +131,7 @@ final class PlaylistViewModel: ViewModelType {
                     output.playlists.accept(removedPlaylists)
                     output.selectedSongIds.accept([])
                 }
+                owner.isEditing = false
                 output.countOfSongs.send(output.playlists.value.count)
             }).disposed(by: disposeBag)
 

--- a/Projects/Features/PlaylistFeature/Sources/ViewModels/PlayListViewModel.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewModels/PlayListViewModel.swift
@@ -6,7 +6,6 @@ import RxRelay
 import RxSwift
 import Utility
 
-
 internal typealias PlayListSectionModel = SectionModel<Int, PlaylistItemModel>
 
 final class PlaylistViewModel: ViewModelType {
@@ -110,7 +109,7 @@ final class PlaylistViewModel: ViewModelType {
 
         input.addPlaylistButtonDidTapEvent
             .withUnretained(self)
-            .subscribe(onNext: { (owner, _) in
+            .subscribe(onNext: { owner, _ in
                 output.selectedSongIds.accept([])
                 output.editState.send(false)
                 owner.isEditing = false


### PR DESCRIPTION
## 💡 배경 및 개요

재생목록 곡 담기 시 편집상태 동기화 깨짐 문제발견

Resolves: #986

## 📃 작업내용

- 비로그인 시 로그인 로직 추가
- 노래담기 시 편집상태 동기화

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
