### PR TITLE
🔀 :: (#993) 열매 갯수 변동 시 내 정보에 바로 반영되지 않는 문제 수정

### DIFF
--- a/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
@@ -198,7 +198,7 @@ public final class ContainSongsViewModel: ViewModelType {
                 let wmError: WMError = error.asWMError
                 output.showToastMessage.onNext(BaseEntity(status: 400, description: wmError.errorDescription!))
             })
-            .map { _ in BaseEntity(status: 201, description: "플레이리스트를 성곡적으로 생성했습니다.") }
+            .map { _ in BaseEntity(status: 201, description: "플레이리스트를 성공적으로 생성했습니다.") }
             .do(onNext: { _ in
                 NotificationCenter.default.post(name: .willRefreshUserInfo, object: nil)
             })

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -222,7 +222,7 @@ private extension MyInfoReactor {
     }
 
     func updateFruitCount(_ userInfo: UserInfo?) -> Observable<Mutation> {
-        print("🚀 updateFruitCount 호출됨:",userInfo)
+        print("🚀 updateFruitCount 호출됨:", userInfo)
         guard let count = userInfo?.itemCount else {
             return .just(.updateFruitCount(-1))
         }

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -163,8 +163,10 @@ final class MyInfoReactor: Reactor {
     }
 
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
-        let willRefreshUserInfoMutation = myInfoCommonService.willRefreshUserInfoEvent.withUnretained(self)
+        let willRefreshUserInfoMutation = myInfoCommonService.willRefreshUserInfoEvent
+            .withUnretained(self)
             .flatMap { owner, _ -> Observable<Mutation> in
+                print("🚀 willRefreshUserInfoEvent 수신")
                 return owner.mutateFetchUserInfo()
             }
 
@@ -220,6 +222,7 @@ private extension MyInfoReactor {
     }
 
     func updateFruitCount(_ userInfo: UserInfo?) -> Observable<Mutation> {
+        print("🚀 updateFruitCount 호출됨:",userInfo)
         guard let count = userInfo?.itemCount else {
             return .just(.updateFruitCount(-1))
         }

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -166,7 +166,6 @@ final class MyInfoReactor: Reactor {
         let willRefreshUserInfoMutation = myInfoCommonService.willRefreshUserInfoEvent
             .withUnretained(self)
             .flatMap { owner, _ -> Observable<Mutation> in
-                print("🚀 willRefreshUserInfoEvent 수신")
                 return owner.mutateFetchUserInfo()
             }
 
@@ -222,7 +221,6 @@ private extension MyInfoReactor {
     }
 
     func updateFruitCount(_ userInfo: UserInfo?) -> Observable<Mutation> {
-        print("🚀 updateFruitCount 호출됨:", userInfo)
         guard let count = userInfo?.itemCount else {
             return .just(.updateFruitCount(-1))
         }

--- a/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
@@ -145,7 +145,7 @@ final class ListStorageReactor: Reactor {
         case .drawFruitButtonDidTap:
             let isLoggedIn = currentState.isLoggedIn
             return isLoggedIn ? .just(.showDrawFruitPopup) : .just(.showLoginAlert)
-        
+
         case .completedFruitDraw:
             return completedFruitDraw()
         }
@@ -278,7 +278,7 @@ extension ListStorageReactor {
     func clearDataSource() -> Observable<Mutation> {
         return .just(.clearDataSource)
     }
-    
+
     func completedFruitDraw() -> Observable<Mutation> {
         NotificationCenter.default.post(name: .willRefreshUserInfo, object: nil)
         return .empty()

--- a/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
@@ -26,6 +26,7 @@ final class ListStorageReactor: Reactor {
         case deleteButtonDidTap
         case confirmDeleteButtonDidTap
         case drawFruitButtonDidTap
+        case completedFruitDraw
     }
 
     enum Mutation {
@@ -144,6 +145,9 @@ final class ListStorageReactor: Reactor {
         case .drawFruitButtonDidTap:
             let isLoggedIn = currentState.isLoggedIn
             return isLoggedIn ? .just(.showDrawFruitPopup) : .just(.showLoginAlert)
+        
+        case .completedFruitDraw:
+            return completedFruitDraw()
         }
     }
 
@@ -273,6 +277,11 @@ extension ListStorageReactor {
 
     func clearDataSource() -> Observable<Mutation> {
         return .just(.clearDataSource)
+    }
+    
+    func completedFruitDraw() -> Observable<Mutation> {
+        NotificationCenter.default.post(name: .willRefreshUserInfo, object: nil)
+        return .empty()
     }
 
     func updateIsLoggedIn(_ isLoggedIn: Bool) -> Observable<Mutation> {

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
@@ -330,7 +330,6 @@ extension ListStorageViewController {
 
 extension ListStorageViewController: FruitDrawViewControllerDelegate {
     func completedFruitDraw(itemCount: Int) {
-        #warning("획득한 열매 갯수입니다. 다음 처리 진행해주세요.")
-        LogManager.printDebug("itemCount: \(itemCount)")
+        reactor?.action.onNext(.completedFruitDraw)
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요

Resolves: #993

## 📃 작업내용

- 플리 생성 시 열매 차감 안됨 -> 서버에서 차감 로직이 적용안된걸로 확인 -> 서버에서 로직 추가하면 정상적으로 동작할거에요 아마?
- 보관함 탭에서 열매 뽑기시 바로 반영 안됨 -> 열매를 뽑은 다음 노티를 발송해서 갱신하도록 수정

## 🙋‍♂️ 리뷰노트

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
