### PR TITLE
🔀 :: (#978) 앱이 실행되자마자 보관함을 갱신하는 문제 수정

### DIFF
--- a/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
+++ b/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
@@ -18,7 +18,7 @@ final class DefaultStorageCommonService: StorageCommonService {
     init() {
         let notificationCenter = NotificationCenter.default
         isEditingState = .init(value: false)
-        loginStateDidChangedEvent = PreferenceManager.$userInfo.map(\.?.ID).distinctUntilChanged()
+        loginStateDidChangedEvent = PreferenceManager.$userInfo.map(\.?.ID).skip(1).distinctUntilChanged()
         playlistRefreshEvent = notificationCenter.rx.notification(.playlistRefresh)
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요
> 내 정보 페이지 접근 후 호출된 api 목록
[GET] ~~/app/check
[GET] ~~/user/profile
[GET] ~~/user/playlists << ?
[GET] ~~/user/likes << ?
[GET] ~~notice/ids
[GET] ~~/notice/popup
그리고 보관함으로 가면
[GET] ~~/user/playlists
[GET] ~~/user/likes
또 호출됨

위와 같은 문제가 발생하고 있었습니다. 확인해본 결과
```swift
loginStateDidChangedEvent = PreferenceManager.$userInfo.map(\.?.ID).distinctUntilChanged()
```
해당 로직에 문제가 있었습니다. 위 이벤트는 api 호출과 바인딩이 되어있는데, 앱이 실행되고 reactor-service간 바인딩이될 때 이벤트를 방출하기 때문에, api가 호출되고 있었습니다.

```swift
loginStateDidChangedEvent = PreferenceManager.$userInfo.map(\.?.ID).skip(1).distinctUntilChanged()
```
그래서 초기 이벤트를 skip 시켜 해결했습니다.

Resolves: #978

## 📃 작업내용

> skip 추가

## 🙋‍♂️ 리뷰노트

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
