### PR TITLE
🔀 :: (#998) 음악 상세 UI 제약조건 변경

### DIFF
--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailView.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailView.swift
@@ -140,7 +140,7 @@ private extension MusicDetailView {
         }
 
         wmNavigationbarView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(STATUS_BAR_HEGHIT())
+            $0.top.equalTo(self.safeAreaLayoutGuide.snp.top)
             $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(48)
         }
@@ -156,7 +156,7 @@ private extension MusicDetailView {
 
         musicToolbarView.snp.makeConstraints {
             $0.leading.bottom.trailing.equalToSuperview()
-            $0.height.equalTo(SAFEAREA_BOTTOM_HEIGHT() + 56)
+            $0.top.equalTo(self.safeAreaLayoutGuide.snp.bottom).offset(-56)
         }
 
         dimmedBackgroundView.snp.makeConstraints {

--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/Views/MusicToolbarView.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/Views/MusicToolbarView.swift
@@ -40,6 +40,8 @@ final class MusicToolbarView: UIStackView {
         self.axis = .horizontal
         self.distribution = .fillEqually
         self.alignment = .top
+        self.isLayoutMarginsRelativeArrangement = true
+        self.layoutMargins = .init(top: 4, left: 0, bottom: 0, right: 0)
         self.backgroundColor = DesignSystemAsset.NewGrayColor.gray900.color
     }
 
@@ -64,14 +66,6 @@ extension MusicToolbarView: MusicToolbarStateProtocol {
 
     func updateIsLike(likes: Int, isLike: Bool) {
         heartButton.setTitle("\(likes.toUnitNumber)", for: .normal)
-
-//        let textColor = isLike
-//        ? DesignSystemAsset.PrimaryColorV2.increase.color
-//        : DesignSystemAsset.NewGrayColor.gray400.color
-//        heartButton.setTitleColor(
-//            textColor,
-//            for: .normal
-//        )
         heartButton.setIsLike(isLike: isLike, animated: false)
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요

<img src="https://github.com/user-attachments/assets/2bd2cfae-90e0-4e71-a711-2a93be8e9b10" width="150" />

Resolves: #998

## 📃 작업내용

- 음악 상세 UI 제약조건 변경
  - 유틸리티 전역 함수 사용에서 safeAreaLayoutGuide로 변경
- MusicToolbarView에 layoutMargin 적용

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
