### PR TITLE
🔀 :: [#1001] 비로그인 상태에서 토큰이 필요한 api를 요청하면, 토큰을 재발급하려고 시도하는 문제 수정

### DIFF
--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -198,6 +198,7 @@ final class MyInfoReactor: Reactor {
 
 private extension MyInfoReactor {
     func viewDidLoad() -> Observable<Mutation> {
+        guard PreferenceManager.userInfo != nil else { return .empty() }
         return mutateFetchUserInfo()
     }
 


### PR DESCRIPTION
## 💡 배경 및 개요

근본적인 문제는 해결이 안되었다고 생각해서 이슈는 열어두겠습니다.

## 📃 작업내용

- 비로그인시 fetchUserInfo api 요청하지 않도록 guard 처리

## 🙋‍♂️ 리뷰노트


## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
