### PR TITLE
🔀 :: [#1008] 보관함 리스트 썸네일이 깜빡이는 문제 수정

### DIFF
--- a/Projects/Features/MyInfoFeature/Sources/Reactors/SettingReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/SettingReactor.swift
@@ -272,9 +272,15 @@ private extension SettingReactor {
     }
 
     func confirmRemoveCacheButtonDidTap() -> Observable<Mutation> {
-        ImageCache.default.clearDiskCache()
-        action.onNext(.showToast("캐시 데이터가 삭제되었습니다."))
-        return .just(.confirmRemoveCacheButtonDidTap)
+        return Completable.create { completable in
+            ImageCache.default.clearCache {
+                completable(.completed)
+            }
+            return Disposables.create()
+        }
+        .andThen(
+            Observable.just(Mutation.showToast("캐시 데이터가 삭제되었습니다."))
+        )
     }
 
     func calculateCacheSize() -> Single<String> {

--- a/Projects/Features/StorageFeature/Sources/Views/ListStorageTableViewCell.swift
+++ b/Projects/Features/StorageFeature/Sources/Views/ListStorageTableViewCell.swift
@@ -142,7 +142,7 @@ extension ListStorageTableViewCell {
 
         self.playlistImageView.kf.setImage(
             with: URL(string: model.image),
-            placeholder: DesignSystemAsset.PlayListTheme.theme3.image,
+            placeholder: nil,
             options: [.transition(.fade(0.2))]
         )
 


### PR DESCRIPTION
## 💡 배경 및 개요

플레이스홀더에 이미지를 박아놔서 캐싱되지 않은 이미지를 다운로드 하는 과정에서 보이나봐요.
플레이스홀더를 제거했습니다.

Resolves: #1008

## 📃 작업내용

- 보관함 리스트 썸네일 플레이스홀더 제거
- 캐시 삭제 로직 수정

## 🙋‍♂️ 리뷰노트


## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
