### PR TITLE
🔀 :: [#1007] 로그인 이중 팝업 UX 수정

### DIFF
--- a/Projects/Features/MyInfoFeature/Sources/Reactors/SettingReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/SettingReactor.swift
@@ -77,7 +77,7 @@ final class SettingReactor: Reactor {
             userInfo: Utility.PreferenceManager.userInfo,
             isHiddenLogoutButton: true,
             isHiddenWithDrawButton: true,
-            notificationAuthorizationStatus: PreferenceManager.pushNotificationAuthorizationStatus ?? false, 
+            notificationAuthorizationStatus: PreferenceManager.pushNotificationAuthorizationStatus ?? false,
             isShowActivityIndicator: false
         )
         self.withDrawUserInfoUseCase = withDrawUserInfoUseCase
@@ -140,7 +140,7 @@ final class SettingReactor: Reactor {
         }
         return newState
     }
-    
+
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
         let updateIsLoggedInMutation = PreferenceManager.$userInfo.map { $0?.ID }
             .distinctUntilChanged()
@@ -152,7 +152,7 @@ final class SettingReactor: Reactor {
                     owner.updateIsHiddenWithDrawButton(isLoggedIn)
                 )
             }
-        
+
         let updatepushNotificationAuthorizationStatusMutation = PreferenceManager.$pushNotificationAuthorizationStatus
             .skip(1)
             .distinctUntilChanged()
@@ -160,7 +160,7 @@ final class SettingReactor: Reactor {
             .flatMap { granted -> Observable<Mutation> in
                 return .just(.changedNotificationAuthorizationStatus(granted))
             }
-        
+
         return Observable.merge(
             mutation,
             updateIsLoggedInMutation,

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/Setting/SettingViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/Setting/SettingViewController.swift
@@ -4,13 +4,13 @@ import DesignSystem
 import Foundation
 import LogManager
 import MyInfoFeatureInterface
+import NVActivityIndicatorView
 import RxSwift
 import SignInFeatureInterface
 import SnapKit
 import Then
 import UIKit
 import Utility
-import NVActivityIndicatorView
 
 final class SettingViewController: BaseReactorViewController<SettingReactor> {
     private var textPopUpFactory: TextPopUpFactory!
@@ -56,7 +56,7 @@ final class SettingViewController: BaseReactorViewController<SettingReactor> {
                 owner.settingView.updateActivityIndicatorState(isPlaying: isShow)
             }
             .disposed(by: disposeBag)
-        
+
         reactor.state.map(\.isHiddenWithDrawButton)
             .distinctUntilChanged()
             .bind(with: self) { owner, isHidden in

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/Setting/SettingViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/Setting/SettingViewController.swift
@@ -10,6 +10,7 @@ import SnapKit
 import Then
 import UIKit
 import Utility
+import NVActivityIndicatorView
 
 final class SettingViewController: BaseReactorViewController<SettingReactor> {
     private var textPopUpFactory: TextPopUpFactory!
@@ -49,6 +50,13 @@ final class SettingViewController: BaseReactorViewController<SettingReactor> {
     }
 
     override func bindState(reactor: SettingReactor) {
+        reactor.state.map(\.isShowActivityIndicator)
+            .distinctUntilChanged()
+            .bind(with: self) { owner, isShow in
+                owner.settingView.updateActivityIndicatorState(isPlaying: isShow)
+            }
+            .disposed(by: disposeBag)
+        
         reactor.state.map(\.isHiddenWithDrawButton)
             .distinctUntilChanged()
             .bind(with: self) { owner, isHidden in

--- a/Projects/Features/MyInfoFeature/Sources/Views/SettingView.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/SettingView.swift
@@ -7,10 +7,12 @@ import Then
 import UIKit
 import UserDomainInterface
 import Utility
+import NVActivityIndicatorView
 
 private protocol SettingStateProtocol {
     func updateIsHiddenWithDrawButton(isHidden: Bool)
     func updateIsHiddenLogoutButton(isHidden: Bool)
+    func updateActivityIndicatorState(isPlaying: Bool)
 }
 
 private protocol SettingActionProtocol {
@@ -50,11 +52,18 @@ final class SettingView: UIView {
     fileprivate let withDrawLabel = WithDrawLabel().then {
         $0.preferredMaxLayoutWidth = APP_WIDTH() - 56
     }
+    
+    private let activityIndicator = NVActivityIndicatorView(
+        frame: .zero,
+        type: .circleStrokeSpin,
+        color: DesignSystemAsset.PrimaryColor.point.color
+    )
 
     init() {
         super.init(frame: .zero)
         addView()
         setLayout()
+        configureUI()
     }
 
     @available(*, unavailable)
@@ -68,7 +77,8 @@ private extension SettingView {
         self.addSubviews(
             wmNavigationbarView,
             titleLabel,
-            settingItemTableView
+            settingItemTableView,
+            activityIndicator
         )
         withDrawContentView.addSubviews(dotImageView, withDrawLabel)
         settingItemTableView.tableFooterView = withDrawContentView
@@ -103,10 +113,28 @@ private extension SettingView {
             $0.left.equalTo(dotImageView.snp.right)
             $0.height.equalTo(18)
         }
+        
+        activityIndicator.snp.makeConstraints {
+            $0.width.height.equalTo(30)
+            $0.center.equalToSuperview()
+        }
+    }
+    
+    func configureUI() {
+        activityIndicator.isHidden = true
+        activityIndicator.stopAnimating()
     }
 }
 
 extension SettingView: SettingStateProtocol {
+    func updateActivityIndicatorState(isPlaying: Bool) {
+        if isPlaying {
+            self.activityIndicator.startAnimating()
+        } else {
+            self.activityIndicator.stopAnimating()
+        }
+    }
+    
     func updateIsHiddenWithDrawButton(isHidden: Bool) {
         self.dotImageView.isHidden = isHidden
         self.withDrawLabel.isHidden = isHidden

--- a/Projects/Features/MyInfoFeature/Sources/Views/SettingView.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/SettingView.swift
@@ -1,4 +1,5 @@
 import DesignSystem
+import NVActivityIndicatorView
 import RxCocoa
 import RxSwift
 import SignInFeatureInterface
@@ -7,7 +8,6 @@ import Then
 import UIKit
 import UserDomainInterface
 import Utility
-import NVActivityIndicatorView
 
 private protocol SettingStateProtocol {
     func updateIsHiddenWithDrawButton(isHidden: Bool)
@@ -52,7 +52,7 @@ final class SettingView: UIView {
     fileprivate let withDrawLabel = WithDrawLabel().then {
         $0.preferredMaxLayoutWidth = APP_WIDTH() - 56
     }
-    
+
     private let activityIndicator = NVActivityIndicatorView(
         frame: .zero,
         type: .circleStrokeSpin,
@@ -113,13 +113,13 @@ private extension SettingView {
             $0.left.equalTo(dotImageView.snp.right)
             $0.height.equalTo(18)
         }
-        
+
         activityIndicator.snp.makeConstraints {
             $0.width.height.equalTo(30)
             $0.center.equalToSuperview()
         }
     }
-    
+
     func configureUI() {
         activityIndicator.isHidden = true
         activityIndicator.stopAnimating()
@@ -134,7 +134,7 @@ extension SettingView: SettingStateProtocol {
             self.activityIndicator.stopAnimating()
         }
     }
-    
+
     func updateIsHiddenWithDrawButton(isHidden: Bool) {
         self.dotImageView.isHidden = isHidden
         self.withDrawLabel.isHidden = isHidden

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
@@ -168,21 +168,9 @@ final class ListStorageViewController: BaseReactorViewController<ListStorageReac
         reactor.pulse(\.$showLoginAlert)
             .compactMap { $0 }
             .bind(with: self, onNext: { owner, _ in
-                guard let vc = owner.textPopUpFactory.makeView(
-                    text: LocalizationStrings.needLoginWarning,
-                    cancelButtonIsHidden: false,
-                    confirmButtonText: nil,
-                    cancelButtonText: nil,
-                    completion: {
-                        let loginVC = owner.signInFactory.makeView()
-                        loginVC.modalPresentationStyle = .fullScreen
-                        owner.present(loginVC, animated: true)
-                    },
-                    cancelCompletion: {}
-                ) as? TextPopupViewController else {
-                    return
-                }
-                owner.showBottomSheet(content: vc)
+                let loginVC = owner.signInFactory.makeView()
+                loginVC.modalPresentationStyle = .fullScreen
+                owner.present(loginVC, animated: true)
             })
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 💡 배경 및 개요

https://github.com/user-attachments/assets/fcb5a059-dea0-4686-8f2a-443511909865

로그인 팝업 서순이 바텀시트 -> 풀스크린 으로 되어있음.

두번 뜨는게 UX적으로 좋아보이진 않음.

바로 풀스크린 로그인 팝업이 뜨도록 수정

Resolves: #{이슈번호}

## 📃 작업내용

- 로그인 팝업 바로 풀스크린으로 수정

- 로그아웃 진행 시 인디케이터 추가

- settingReactor 작은 코드 리팩토링

## 🙋‍♂️ 리뷰노트


## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
