### PR TITLE
🔀 :: (#1021) 음악 상세에서 노래 재생 시 플리에 추가

### DIFF
--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailReactor.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailReactor.swift
@@ -1,3 +1,4 @@
+import BaseFeature
 import Foundation
 import Kingfisher
 import LikeDomainInterface
@@ -195,6 +196,7 @@ private extension MusicDetailReactor {
             )
             LogManager.analytics(log)
         }
+        PlayState.shared.append(item: PlaylistItem(id: song.videoID, title: song.title, artist: song.artistString))
         return navigateMutation(navigate: .youtube(id: song.videoID))
     }
 


### PR DESCRIPTION
## 💡 배경 및 개요
음악 상세에서 노래 재생 시 플리에 추가

Resolves: #1021

## 📃 작업내용

- 음악 상세에서 노래 재생 시 플리에 추가

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
