### PR TITLE
🔀 :: (#978) 내정보화면에서 불필요한 api가 호출되던 문제 수정

### DIFF
--- a/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
+++ b/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
@@ -18,7 +18,7 @@ final class DefaultStorageCommonService: StorageCommonService {
     init() {
         let notificationCenter = NotificationCenter.default
         isEditingState = .init(value: false)
-        loginStateDidChangedEvent = PreferenceManager.$userInfo.map(\.?.ID).skip(1).distinctUntilChanged()
+        loginStateDidChangedEvent = PreferenceManager.$userInfo.map(\.?.ID).distinctUntilChanged().skip(1)
         playlistRefreshEvent = notificationCenter.rx.notification(.playlistRefresh)
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요

![2024-08-05_6 28 18](https://github.com/user-attachments/assets/d3a054ab-0e9c-44d0-982f-cef476405679)

로그인 상태로 앱을 켰을 때, 내정보화면에서 시작했고 보관함 탭으로 이동한 상황

Resolves: #978

## 📃 작업내용

보관함 탭은 userinfo.id를 옵저빙하고 있음.

앱이 시작되면 userinfo.id와 바인딩이 시작되고, 첫번째 옵저버블이 방출
내정보 탭이 viewDidLoad 되면 fetchUserInfo를 호출하고 userinfo를 덮어쓰면서, 두번째 옵저버블이 방출됨

### 문제는 아래 코드 였습니다.
```swift
PreferenceManager.$userInfo.map(.?.ID).skip(1).distinctUntilChanged()
```
문제 상황을 재현해보면 userInfo.id = 123 이 들어있는 상태이고, fetch를 땡겨도 123이 넘어오는 상황이라고 가정.
skip(1).distinctUntilChanged() 이면
1. 바인딩될때 123 옵저버블이 skip에 의해 사라짐
2. fetch하면 id가 덮어씌워지고 123 옵저버블이 방출되는데, skip은 이미 썼고 disChanged()는 직전에 방출한 값이 없기 때문에 그대로 123이 방출됨

### 해결 코드
```swift
PreferenceManager.$userInfo.map(.?.ID).distinctUntilChanged().skip(1)
```

disChanged().skip(1) 이면
1. 바인딩될때 123 옵저버블이 distinctUntilChanged()를 거쳐 방출됨
2. skip에서 123이 사라짐
3. fetch하면 id가 123이 넘어오는데, disChanged가 직전에 방출했던 123이랑 똑같기 때문에 방출하지 않음

distinctUntilChanged()는 직전에 '방출' 했던 옵저버블과 비교한다.. 이게 핵심이었네요


## 🙋‍♂️ 리뷰노트


## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
