### PR TITLE
🔀 :: (#1034) Firebase Crashlytics 통합

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ install:
 test:
 	TUIST_ENV=CI TUIST_ROOT_DIR=${PWD} tuist test --platform ios
 
+deploy:
+	make install
+	TUIST_ENV=CD TUIST_ROOT_DIR=${PWD} tuist generate
+
 clean:
 	rm -rf **/*.xcodeproj
 	rm -rf *.xcworkspace

--- a/Projects/App/Resources/GoogleService-Info-QA.plist
+++ b/Projects/App/Resources/GoogleService-Info-QA.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyAgnrvQkVHTDrGimRAP1LRdP-clo6X45Ek</string>
+	<key>GCM_SENDER_ID</key>
+	<string>121910868968</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>yongbeomkwak.Billboardoo</string>
+	<key>PROJECT_ID</key>
+	<string>wakmusic-for-qa</string>
+	<key>STORAGE_BUCKET</key>
+	<string>wakmusic-for-qa.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:121910868968:ios:5b3676f5a70ba6535a025d</string>
+</dict>
+</plist>

--- a/Scripts/FirebaseCrashlyticsScript.sh
+++ b/Scripts/FirebaseCrashlyticsScript.sh
@@ -1,5 +1,5 @@
 #if [ "${CONFIGURATION}" != "Debug" ]; then
-"../Tuist/Dependencies/SwiftPackageManager/.build/checkouts/firebase-ios-sdk/Crashlytics/run"
-"../Tuist/Dependencies/SwiftPackageManager/.build/checkouts/firebase-ios-sdk/Crashlytics/run" -gsp ../Projects/App/Resources/GoogleService-Info.plist
-"../Tuist/Dependencies/SwiftPackageManager/.build/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols" -gsp ../Projects/App/Resources/GoogleService-Info.plist -p ios ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}
+"../.build/checkouts/firebase-ios-sdk/Crashlytics/run"
+"../.build/checkouts/firebase-ios-sdk/Crashlytics/run" -gsp ../Projects/App/Resources/GoogleService-Info.plist
+"../.build/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols" -gsp ../Projects/App/Resources/GoogleService-Info.plist -p ios ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}
 #fi

--- a/Tuist/ProjectDescriptionHelpers/Action+Template.swift
+++ b/Tuist/ProjectDescriptionHelpers/Action+Template.swift
@@ -13,12 +13,28 @@ public extension TargetScript {
         name: "Needle",
         basedOnDependencyAnalysis: false
     )
+
+    static let firebaseInfoByConfiguration = TargetScript.post(
+        script: """
+            case "${CONFIGURATION}" in
+              "Release" )
+                cp -r "$SRCROOT/Resources/GoogleService-Info.plist" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist"
+                ;;
+              *)
+                cp -r "$SRCROOT/Resources/GoogleService-Info-QA.plist" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist"
+                ;;
+            esac
+
+            """,
+        name: "Firebase Info copy by Configuration",
+        basedOnDependencyAnalysis: false
+    )
     
     static let firebaseCrashlytics = TargetScript.post(
         script:
             """
             ROOT_DIR=\(ProcessInfo.processInfo.environment["TUIST_ROOT_DIR"] ?? "")
-            "${ROOT_DIR}/Tuist/Dependencies/SwiftPackageManager/.build/checkouts/firebase-ios-sdk/Crashlytics/run"
+            "${ROOT_DIR}/.build/checkouts/firebase-ios-sdk/Crashlytics/run"
             """
         ,
         name: "FirebaseCrashlytics",

--- a/Tuist/ProjectDescriptionHelpers/GenerateEnvironment.swift
+++ b/Tuist/ProjectDescriptionHelpers/GenerateEnvironment.swift
@@ -18,7 +18,7 @@ public extension GenerateEnvironment {
             return []
             
         case .cd:
-            return [.firebaseCrashlytics]
+            return [.firebaseInfoByConfiguration, .firebaseCrashlytics]
 
         case .dev:
             return [.swiftLint, .needle]


### PR DESCRIPTION
## 💡 배경 및 개요
- 파베 QA 버전을 추가했어요.
- Release빌드라면 GoogleService-Info.plist 파일을 대상으로 파베가 구성되고,
- Release빌드가 아니라면 GoogleService-Info-QA.plist 파일을 대상으로 파베가 구성돼요.
- 배포 시에는 make deploy 명령어로 프로젝트 구성 후에 archive해주세요 @yongbeomkwak 
  - 이점은 배포 자동화가 있다면 저희가 신경을 안써도 되긴하지만.. 지금은 아쉽게도 수동이기에

Resolves: #1034 

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
