### PR TITLE
🔀 :: (#1046) 플레이리시트 컨테이너 로딩 중 처리

### DIFF
--- a/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
@@ -58,14 +58,13 @@ final class PlaylistDetailContainerReactor: Reactor {
 
 extension PlaylistDetailContainerReactor {
     func updateOwnerID() -> Observable<Mutation> {
-        
         return .concat([
             updateLoadingState(flag: true),
             updateOwnerIDMutation(),
             updateLoadingState(flag: false)
         ])
     }
-    
+
     func updateOwnerIDMutation() -> Observable<Mutation> {
         return requestPlaylistOwnerIDUsecase
             .execute(key: key)
@@ -73,15 +72,13 @@ extension PlaylistDetailContainerReactor {
             .flatMap { entitiy -> Observable<Mutation> in
                 return .just(Mutation.updateOwnerID(entitiy.ownerID))
             }
-            .catch { error  in
+            .catch { error in
                 let wmError = error.asWMError
                 return .just(Mutation.showToastMessagae(wmError.localizedDescription))
             }
     }
-    
 
     func updateLoadingState(flag: Bool) -> Observable<Mutation> {
         return .just(.updateLoadingState(flag))
     }
-    
 }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
@@ -6,10 +6,11 @@ import RxSwift
 final class PlaylistDetailContainerReactor: Reactor {
     enum Action {
         case requestOwnerID
+        case clearOwnerID
     }
 
     enum Mutation {
-        case updateOwnerID(String)
+        case updateOwnerID(String?)
         case updateLoadingState(Bool)
         case showToastMessagae(String)
     }
@@ -34,6 +35,8 @@ final class PlaylistDetailContainerReactor: Reactor {
         switch action {
         case .requestOwnerID:
             return updateOwnerID()
+        case .clearOwnerID:
+            return .just(.updateOwnerID(nil))
         }
     }
 
@@ -55,16 +58,30 @@ final class PlaylistDetailContainerReactor: Reactor {
 
 extension PlaylistDetailContainerReactor {
     func updateOwnerID() -> Observable<Mutation> {
+        
+        return .concat([
+            updateLoadingState(flag: true),
+            updateOwnerIDMutation(),
+            updateLoadingState(flag: false)
+        ])
+    }
+    
+    func updateOwnerIDMutation() -> Observable<Mutation> {
         return requestPlaylistOwnerIDUsecase
             .execute(key: key)
             .asObservable()
-            .catchAndReturn(PlaylistOwnerIDEntity(ownerID: "__"))
             .flatMap { entitiy -> Observable<Mutation> in
                 return .just(Mutation.updateOwnerID(entitiy.ownerID))
             }
+            .catch { error  in
+                let wmError = error.asWMError
+                return .just(Mutation.showToastMessagae(wmError.localizedDescription))
+            }
     }
+    
 
     func updateLoadingState(flag: Bool) -> Observable<Mutation> {
         return .just(.updateLoadingState(flag))
     }
+    
 }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
@@ -12,7 +12,7 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
     var contentView: UIView! = UIView().then {
         $0.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
     }
-    
+
     private var wmNavigationbarView: WMNavigationBarView = WMNavigationBarView()
     private let dismissButton = UIButton().then {
         let dismissImage = DesignSystemAsset.Navigation.back.image
@@ -59,7 +59,7 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
         contentView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
-        
+
         wmNavigationbarView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.horizontalEdges.equalToSuperview()
@@ -86,6 +86,7 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
             }
             .disposed(by: disposeBag)
     }
+
     override func bindAction(reactor: PlaylistDetailContainerReactor) {
         super.bindAction(reactor: reactor)
         dismissButton.rx
@@ -100,7 +101,7 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
         super.bindState(reactor: reactor)
 
         let sharedState = reactor.state.share()
-        
+
         sharedState.map(\.isLoading)
             .distinctUntilChanged()
             .bind(with: self) { owner, isLoading in
@@ -112,10 +113,10 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
                     owner.wmNavigationbarView.isHidden = true
                 }
             }.disposed(by: disposeBag)
-        
+
         sharedState.map(\.ownerID)
             .distinctUntilChanged()
-            .compactMap({ $0 })
+            .compactMap { $0 }
             .withLatestFrom(PreferenceManager.$userInfo) { ($0, $1) }
             .bind(with: self) { owner, info in
 

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
@@ -12,6 +12,13 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
     var contentView: UIView! = UIView().then {
         $0.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
     }
+    
+    private var wmNavigationbarView: WMNavigationBarView = WMNavigationBarView()
+    private let dismissButton = UIButton().then {
+        let dismissImage = DesignSystemAsset.Navigation.back.image
+            .withTintColor(DesignSystemAsset.BlueGrayColor.blueGray900.color, renderingMode: .alwaysOriginal)
+        $0.setImage(dismissImage, for: .normal)
+    }
 
     private let unknownPlaylistDetailFactory: any UnknownPlaylistDetailFactory
     private let myPlaylistDetailFactory: any MyPlaylistDetailFactory
@@ -43,13 +50,20 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
 
     override func addView() {
         super.addView()
-        self.view.addSubviews(contentView)
+        self.view.addSubviews(contentView, wmNavigationbarView)
+        wmNavigationbarView.setLeftViews([dismissButton])
     }
 
     override func setLayout() {
         super.setLayout()
         contentView.snp.makeConstraints {
             $0.edges.equalToSuperview()
+        }
+        
+        wmNavigationbarView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(48)
         }
     }
 
@@ -65,9 +79,19 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
 
                 if userInfo == nil {
                     owner.add(asChildViewController: owner.unknownPlaylistVC)
+                    reactor.action.onNext(.clearOwnerID)
                 } else {
                     reactor.action.onNext(.requestOwnerID)
                 }
+            }
+            .disposed(by: disposeBag)
+    }
+    override func bindAction(reactor: PlaylistDetailContainerReactor) {
+        super.bindAction(reactor: reactor)
+        dismissButton.rx
+            .tap
+            .bind(with: self) { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
             }
             .disposed(by: disposeBag)
     }
@@ -76,9 +100,22 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
         super.bindState(reactor: reactor)
 
         let sharedState = reactor.state.share()
-
+        
+        sharedState.map(\.isLoading)
+            .distinctUntilChanged()
+            .bind(with: self) { owner, isLoading in
+                if isLoading {
+                    owner.indicator.startAnimating()
+                    owner.wmNavigationbarView.isHidden = false
+                } else {
+                    owner.indicator.stopAnimating()
+                    owner.wmNavigationbarView.isHidden = true
+                }
+            }.disposed(by: disposeBag)
+        
         sharedState.map(\.ownerID)
-            .compactMap { $0 }
+            .distinctUntilChanged()
+            .compactMap({ $0 })
             .withLatestFrom(PreferenceManager.$userInfo) { ($0, $1) }
             .bind(with: self) { owner, info in
 


### PR DESCRIPTION
## 💡 배경 및 개요

이전에는 container 내용 불러오기 전 까지 비어있는 화면이 깁니다.

Resolves: #1046

## 📃 작업내용

- 눈속임 네비게이션 처리
- ownerId 처리 방식 변경

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
