### PR TITLE
🔀 :: (#1048) 아티스트:: Retry UI 추가

### DIFF
--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistViewController.swift
@@ -2,6 +2,7 @@ import ArtistFeatureInterface
 import BaseFeature
 import DesignSystem
 import KeychainModule
+import Localization
 import LogManager
 import NeedleFoundation
 import NVActivityIndicatorView
@@ -10,7 +11,6 @@ import RxCocoa
 import RxSwift
 import UIKit
 import Utility
-import Localization
 
 public final class ArtistViewController:
     BaseViewController,

--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistViewController.swift
@@ -10,6 +10,7 @@ import RxCocoa
 import RxSwift
 import UIKit
 import Utility
+import Localization
 
 public final class ArtistViewController:
     BaseViewController,
@@ -20,12 +21,18 @@ public final class ArtistViewController:
 
     @IBOutlet weak var collectionView: UICollectionView!
     @IBOutlet weak var activityIndicator: NVActivityIndicatorView!
+    private let retryWarningView = WMRetryWarningView(
+        description: LocalizationStrings.unknownErrorWarning,
+        retryButtonTitle: LocalizationStrings.titleRetry
+    )
 
     var artistDetailFactory: ArtistDetailFactory!
     public var disposeBag: DisposeBag = DisposeBag()
 
     override public func viewDidLoad() {
         super.viewDidLoad()
+        addSubviews()
+        setLayout()
         configureUI()
     }
 
@@ -82,7 +89,9 @@ public final class ArtistViewController:
         let sharedState = reactor.state.share(replay: 1)
 
         sharedState.map(\.artistList)
-            .do(onNext: { [activityIndicator] _ in
+            .skip(1)
+            .do(onNext: { [activityIndicator, retryWarningView] entities in
+                retryWarningView.isHidden = !entities.isEmpty
                 activityIndicator?.stopAnimating()
             })
             .bind(to: collectionView.rx.items) { collectionView, index, artist in
@@ -110,8 +119,20 @@ public final class ArtistViewController:
     }
 }
 
-extension ArtistViewController {
-    private func configureUI() {
+private extension ArtistViewController {
+    func addSubviews() {
+        view.addSubview(retryWarningView)
+    }
+
+    func setLayout() {
+        let topOffset = (APP_HEIGHT() - SAFEAREA_BOTTOM_HEIGHT() - PLAYER_HEIGHT() - 160) / 3.0
+        retryWarningView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalToSuperview().offset(topOffset + STATUS_BAR_HEGHIT())
+        }
+    }
+
+    func configureUI() {
         view.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
         activityIndicator.color = DesignSystemAsset.PrimaryColor.point.color
         activityIndicator.type = .circleStrokeSpin
@@ -128,6 +149,17 @@ extension ArtistViewController {
 
         collectionView.setCollectionViewLayout(layout, animated: false)
         collectionView.showsVerticalScrollIndicator = false
+
+        retryWarningView.isHidden = true
+        retryWarningView.delegate = self
+    }
+}
+
+extension ArtistViewController: WMRetryWarningViewDelegate {
+    public func tappedRetryButton() {
+        retryWarningView.isHidden = true
+        activityIndicator.startAnimating()
+        reactor?.action.onNext(Reactor.Action.viewDidLoad)
     }
 }
 

--- a/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewModels/ContainSongsViewModel.swift
@@ -99,7 +99,7 @@ public final class ContainSongsViewModel: ViewModelType {
                 let wmError = error.asWMError
                 output.showToastMessage.onNext(BaseEntity(
                     status: 401,
-                    description: wmError.errorDescription ?? "알 수 없는 오류가 발생하였습니다."
+                    description: wmError.errorDescription ?? LocalizationStrings.unknownErrorWarning
                 ))
             })
             .catchAndReturn([])

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -1,7 +1,7 @@
 import BaseFeature
 import Foundation
-import LogManager
 import Localization
+import LogManager
 import NoticeDomainInterface
 import ReactorKit
 import UserDomainInterface

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -1,6 +1,7 @@
 import BaseFeature
 import Foundation
 import LogManager
+import Localization
 import NoticeDomainInterface
 import ReactorKit
 import UserDomainInterface
@@ -276,7 +277,7 @@ private extension MyInfoReactor {
             .flatMap { _ in Observable.empty() }
             .catch { error in
                 let error = error.asWMError
-                return Observable.just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
+                return Observable.just(.showToast(error.errorDescription ?? LocalizationStrings.unknownErrorWarning))
             }
     }
 
@@ -295,7 +296,7 @@ private extension MyInfoReactor {
             .catch { error in
                 let error = error.asWMError
                 return .concat(
-                    .just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")),
+                    .just(.showToast(error.errorDescription ?? LocalizationStrings.unknownErrorWarning)),
                     .just(.dismissEditSheet)
                 )
             }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
@@ -1,11 +1,11 @@
 import AuthDomainInterface
 import Foundation
+import Localization
 import PlaylistDomainInterface
 import ReactorKit
 import RxSwift
 import SongsDomainInterface
 import Utility
-import Localization
 
 final class MyPlaylistDetailReactor: Reactor {
     enum Action {

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
@@ -5,6 +5,7 @@ import ReactorKit
 import RxSwift
 import SongsDomainInterface
 import Utility
+import Localization
 
 final class MyPlaylistDetailReactor: Reactor {
     enum Action {
@@ -229,7 +230,7 @@ private extension MyPlaylistDetailReactor {
                 .catch { error in
                     let wmErorr = error.asWMError
                     return Observable.just(
-                        Mutation.showToast(wmErorr.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")
+                        Mutation.showToast(wmErorr.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                     )
                 },
             .just(.updateLoadingState(false))
@@ -255,7 +256,7 @@ private extension MyPlaylistDetailReactor {
                         .catch { error in
                             let wmErorr = error.asWMError
                             return Observable.just(
-                                Mutation.showToast(wmErorr.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")
+                                Mutation.showToast(wmErorr.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                             )
                         }
                 )
@@ -270,7 +271,7 @@ private extension MyPlaylistDetailReactor {
                         .catch { error in
                             let wmErorr = error.asWMError
                             return Observable.just(
-                                Mutation.showToast(wmErorr.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")
+                                Mutation.showToast(wmErorr.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                             )
                         }
                 )
@@ -285,7 +286,7 @@ private extension MyPlaylistDetailReactor {
                     .catch { error in
                         let wmErorr = error.asWMError
                         return Observable.just(
-                            Mutation.showToast(wmErorr.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")
+                            Mutation.showToast(wmErorr.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                         )
                     }
             )
@@ -328,7 +329,7 @@ private extension MyPlaylistDetailReactor {
             .catch { error in
                 let wmErorr = error.asWMError
                 return Observable.just(
-                    Mutation.showToast(wmErorr.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")
+                    Mutation.showToast(wmErorr.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                 )
             }
     }
@@ -455,7 +456,7 @@ private extension MyPlaylistDetailReactor {
             .catch { error in
                 let wmErorr = error.asWMError
                 return Observable.just(
-                    Mutation.showToast(wmErorr.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")
+                    Mutation.showToast(wmErorr.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                 )
             }
     }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/UnknownPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/UnknownPlaylistDetailReactor.swift
@@ -1,11 +1,11 @@
 import AuthDomainInterface
 import Foundation
+import Localization
 import PlaylistDomainInterface
 import ReactorKit
 import RxSwift
 import SongsDomainInterface
 import Utility
-import Localization
 
 final class UnknownPlaylistDetailReactor: Reactor {
     let key: String

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/UnknownPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/UnknownPlaylistDetailReactor.swift
@@ -5,6 +5,7 @@ import ReactorKit
 import RxSwift
 import SongsDomainInterface
 import Utility
+import Localization
 
 final class UnknownPlaylistDetailReactor: Reactor {
     let key: String
@@ -190,7 +191,7 @@ private extension UnknownPlaylistDetailReactor {
                         return self.updateDetectedNotFound()
                     }
                     return Observable.just(
-                        Mutation.showToast(wmErorr.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")
+                        Mutation.showToast(wmErorr.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                     )
                 },
             .just(.updateLoadingState(false))
@@ -206,7 +207,7 @@ private extension UnknownPlaylistDetailReactor {
             .catch { error in
                 let wmErorr = error.asWMError
                 return Observable.just(
-                    Mutation.showToast(wmErorr.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")
+                    Mutation.showToast(wmErorr.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                 )
             }
     }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/WakmusicPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/WakmusicPlaylistDetailReactor.swift
@@ -1,11 +1,11 @@
 import AuthDomainInterface
 import Foundation
+import Localization
 import PlaylistDomainInterface
 import ReactorKit
 import RxSwift
 import SongsDomainInterface
 import Utility
-import Localization
 
 final class WakmusicPlaylistDetailReactor: Reactor {
     let key: String

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/WakmusicPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/WakmusicPlaylistDetailReactor.swift
@@ -5,6 +5,7 @@ import ReactorKit
 import RxSwift
 import SongsDomainInterface
 import Utility
+import Localization
 
 final class WakmusicPlaylistDetailReactor: Reactor {
     let key: String
@@ -135,7 +136,7 @@ private extension WakmusicPlaylistDetailReactor {
                 .catch { error in
                     let wmErorr = error.asWMError
                     return Observable.just(
-                        Mutation.showToast(wmErorr.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")
+                        Mutation.showToast(wmErorr.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                     )
                 },
             .just(.updateLoadingState(false))

--- a/Projects/Features/SearchFeature/Sources/After/Reactors/ListSearchResultReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/After/Reactors/ListSearchResultReactor.swift
@@ -1,7 +1,7 @@
+import Localization
 import LogManager
 import ReactorKit
 import SearchDomainInterface
-import Localization
 
 final class ListSearchResultReactor: Reactor {
     enum Action {

--- a/Projects/Features/SearchFeature/Sources/After/Reactors/ListSearchResultReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/After/Reactors/ListSearchResultReactor.swift
@@ -1,6 +1,7 @@
 import LogManager
 import ReactorKit
 import SearchDomainInterface
+import Localization
 
 final class ListSearchResultReactor: Reactor {
     enum Action {
@@ -114,7 +115,7 @@ extension ListSearchResultReactor {
                 .catch { error in
                     let wmErorr = error.asWMError
                     return Observable.just(
-                        Mutation.showToast(wmErorr.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")
+                        Mutation.showToast(wmErorr.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                     )
                 },
             .just(Mutation.updateScrollPage(scrollPage + 1)),

--- a/Projects/Features/SearchFeature/Sources/After/Reactors/SongSearchResultReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/After/Reactors/SongSearchResultReactor.swift
@@ -1,8 +1,8 @@
+import Localization
 import LogManager
 import ReactorKit
 import SearchDomainInterface
 import SongsDomainInterface
-import Localization
 
 final class SongSearchResultReactor: Reactor {
     enum Action {

--- a/Projects/Features/SearchFeature/Sources/After/Reactors/SongSearchResultReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/After/Reactors/SongSearchResultReactor.swift
@@ -2,6 +2,7 @@ import LogManager
 import ReactorKit
 import SearchDomainInterface
 import SongsDomainInterface
+import Localization
 
 final class SongSearchResultReactor: Reactor {
     enum Action {
@@ -165,7 +166,7 @@ extension SongSearchResultReactor {
                 .catch { error in
                     let wmErorr = error.asWMError
                     return Observable.just(
-                        Mutation.showToast(wmErorr.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")
+                        Mutation.showToast(wmErorr.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                     )
                 },
             .just(Mutation.updateScrollPage(scrollPage + 1)), // 스크롤 페이지 증가

--- a/Projects/Features/SearchFeature/Sources/Before/Reactors/BeforeSearchReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/Before/Reactors/BeforeSearchReactor.swift
@@ -1,10 +1,10 @@
 import ChartDomainInterface
 import Foundation
+import Localization
 import PlaylistDomainInterface
 import ReactorKit
 import RxSwift
 import Utility
-import Localization
 
 public struct WrapperDataSourceModel {
     let currentVideo: CurrentVideoEntity

--- a/Projects/Features/SearchFeature/Sources/Before/Reactors/BeforeSearchReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/Before/Reactors/BeforeSearchReactor.swift
@@ -4,6 +4,7 @@ import PlaylistDomainInterface
 import ReactorKit
 import RxSwift
 import Utility
+import Localization
 
 public struct WrapperDataSourceModel {
     let currentVideo: CurrentVideoEntity
@@ -107,7 +108,7 @@ extension BeforeSearchReactor {
                 .catch { error in
                     let wmErorr = error.asWMError
                     return Observable.just(
-                        Mutation.showToast(wmErorr.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")
+                        Mutation.showToast(wmErorr.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                     )
                 },
             .just(.updateLoadingState(false))

--- a/Projects/Features/SearchFeature/Sources/Before/Reactors/WakmusicRecommendReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/Before/Reactors/WakmusicRecommendReactor.swift
@@ -1,6 +1,6 @@
 import Foundation
-import LogManager
 import Localization
+import LogManager
 import PlaylistDomainInterface
 import ReactorKit
 import RxSwift

--- a/Projects/Features/SearchFeature/Sources/Before/Reactors/WakmusicRecommendReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/Before/Reactors/WakmusicRecommendReactor.swift
@@ -1,5 +1,6 @@
 import Foundation
 import LogManager
+import Localization
 import PlaylistDomainInterface
 import ReactorKit
 import RxSwift
@@ -74,7 +75,7 @@ extension WakmusicRecommendReactor {
                 .catch { error in
                     let wmErorr = error.asWMError
                     return Observable.just(
-                        Mutation.showToast(wmErorr.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")
+                        Mutation.showToast(wmErorr.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                     )
                 },
             .just(.updateLodingState(false))

--- a/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
@@ -8,6 +8,7 @@ import RxRelay
 import RxSwift
 import UserDomainInterface
 import Utility
+import Localization
 
 public final class LoginViewModel: NSObject { // 네이버 델리게이트를 받기위한 NSObject 상속
     private let fetchTokenUseCase: FetchTokenUseCase
@@ -93,7 +94,7 @@ private extension LoginViewModel {
 
             }, onError: { [input, output] error in
                 let error = error.asWMError
-                output.showToast.accept(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다.")
+                output.showToast.accept(error.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                 output.dismissLoginScene.accept(input.arrivedTokenFromThirdParty.value.0)
                 output.showLoading.accept(false)
             })

--- a/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
+++ b/Projects/Features/SignInFeature/Sources/ViewModels/LoginViewModel.swift
@@ -2,13 +2,13 @@ import AuthDomainInterface
 import AuthenticationServices
 import BaseFeature
 import CryptoSwift
+import Localization
 import LogManager
 import NaverThirdPartyLogin
 import RxRelay
 import RxSwift
 import UserDomainInterface
 import Utility
-import Localization
 
 public final class LoginViewModel: NSObject { // 네이버 델리게이트를 받기위한 NSObject 상속
     private let fetchTokenUseCase: FetchTokenUseCase

--- a/Projects/Features/StorageFeature/Sources/Reactors/LikeStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/LikeStorageReactor.swift
@@ -374,7 +374,7 @@ private extension LikeStorageReactor {
                 let error = error.asWMError
                 return .concat(
                     .just(.undoDataSource),
-                    .just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
+                    .just(.showToast(error.errorDescription ?? LocalizationStrings.unknownErrorWarning))
                 )
             }
     }
@@ -392,7 +392,7 @@ private extension LikeStorageReactor {
                 let error = error.asWMError
                 return Observable.concat([
                     .just(.undoDataSource),
-                    .just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
+                    .just(.showToast(error.errorDescription ?? LocalizationStrings.unknownErrorWarning))
                 ])
             }
     }

--- a/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
@@ -374,7 +374,7 @@ extension ListStorageReactor {
             let error = error.asWMError
             return Observable.concat([
                 .just(.updateIsShowActivityIndicator(false)),
-                .just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
+                .just(.showToast(error.errorDescription ?? LocalizationStrings.unknownErrorWarning))
             ])
         }
     }
@@ -382,7 +382,7 @@ extension ListStorageReactor {
     func playWithAddToCurrentPlaylist(_ index: Int) -> Observable<Mutation> {
         let limit = 50
         guard let selectedPlaylist = currentState.dataSource.first?.items[safe: index] else {
-            return .just(.showToast("알 수 없는 오류가 발생하였습니다."))
+            return .just(.showToast(LocalizationStrings.unknownErrorWarning))
         }
 
         if selectedPlaylist.songCount == 0 {
@@ -414,7 +414,7 @@ extension ListStorageReactor {
             let error = error.asWMError
             return Observable.concat([
                 .just(.updateIsShowActivityIndicator(false)),
-                .just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
+                .just(.showToast(error.errorDescription ?? LocalizationStrings.unknownErrorWarning))
             ])
         }
     }
@@ -485,7 +485,7 @@ private extension ListStorageReactor {
                 }
                 .catch { error in
                     let error = error.asWMError
-                    return .just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
+                    return .just(.showToast(error.errorDescription ?? LocalizationStrings.unknownErrorWarning))
                 },
             .just(.updateIsShowActivityIndicator(false))
         )
@@ -510,7 +510,7 @@ private extension ListStorageReactor {
                 let error = error.asWMError
                 return .concat(
                     .just(.undoDataSource),
-                    .just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
+                    .just(.showToast(error.errorDescription ?? LocalizationStrings.unknownErrorWarning))
                 )
             }
     }
@@ -528,7 +528,7 @@ private extension ListStorageReactor {
                 let error = error.asWMError
                 return Observable.concat([
                     .just(.undoDataSource),
-                    .just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
+                    .just(.showToast(error.errorDescription ?? LocalizationStrings.unknownErrorWarning))
                 ])
             }
     }
@@ -541,7 +541,7 @@ private extension ListStorageReactor {
                 .map { $0.price }
                 .flatMap { price -> Observable<Mutation> in
                     guard let userItemCount = PreferenceManager.userInfo?.itemCount else {
-                        return .just(.showToast("알 수 없는 오류가 발생하였습니다."))
+                        return .just(.showToast(LocalizationStrings.unknownErrorWarning))
                     }
                     if userItemCount < price {
                         return .just(.showToast(LocalizationStrings.lackOfMoney(price - userItemCount)))
@@ -550,7 +550,7 @@ private extension ListStorageReactor {
                 }
                 .catch { error in
                     let error = error.asWMError
-                    return .just(.showToast(error.errorDescription ?? "알 수 없는 오류가 발생하였습니다."))
+                    return .just(.showToast(error.errorDescription ?? LocalizationStrings.unknownErrorWarning))
                 },
             .just(.updateIsShowActivityIndicator(false))
         )

--- a/Projects/Modules/Localization/Resources/en.lproj/Localizable.strings
+++ b/Projects/Modules/Localization/Resources/en.lproj/Localizable.strings
@@ -7,3 +7,5 @@
 "TITLE_50_RANDOM_PLAY" = "50곡 랜덤재생";
 "NEED_LOGIN_WARNING" = "로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?";
 "LACK_OF_MONEY" = "음표 열매가 %@개가 부족합니다.";
+"UNKNOWN_ERROR_WARNING" = "알 수 없는 오류가 발생하였습니다.";
+"TITLE_RETRY" = "재시도";

--- a/Projects/Modules/Localization/Resources/ko.lproj/Localizable.strings
+++ b/Projects/Modules/Localization/Resources/ko.lproj/Localizable.strings
@@ -7,3 +7,5 @@
 "TITLE_50_RANDOM_PLAY" = "50곡 랜덤재생";
 "NEED_LOGIN_WARNING" = "로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?";
 "LACK_OF_MONEY" = "음표 열매가 %@개가 부족합니다.";
+"UNKNOWN_ERROR_WARNING" = "알 수 없는 오류가 발생하였습니다.";
+"TITLE_RETRY" = "재시도";

--- a/Projects/UsertInterfaces/DesignSystem/Sources/WMRetryWarningView.swift
+++ b/Projects/UsertInterfaces/DesignSystem/Sources/WMRetryWarningView.swift
@@ -1,0 +1,104 @@
+import RxSwift
+import SnapKit
+import Then
+import UIKit
+
+public protocol WMRetryWarningViewDelegate: AnyObject {
+    func tappedRetryButton()
+}
+
+public final class WMRetryWarningView: UIView {
+    private let warningImageView: UIImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.image = DesignSystemAsset.Search.warning.image
+    }
+
+    private let descriptionLabel: WMLabel = WMLabel(
+        text: "",
+        textColor: DesignSystemAsset.BlueGrayColor.blueGray900.color,
+        font: .t6(weight: .light),
+        alignment: .center,
+        kernValue: -0.5
+    ).then {
+        $0.numberOfLines = 0
+        let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+        let screenWidth = windowScene?.screen.bounds.size.width ?? .zero
+        $0.preferredMaxLayoutWidth = screenWidth - 40
+    }
+
+    private let retryButton: UIButton = UIButton(
+        type: .system
+    ).then {
+        $0.titleLabel?.font = UIFont.WMFontSystem.t6(weight: .medium).font
+        $0.titleLabel?.setTextWithAttributes(
+            lineHeight: UIFont.WMFontSystem.t6(weight: .medium).font.lineHeight,
+            alignment: .center
+        )
+        $0.setTitleColor(DesignSystemAsset.BlueGrayColor.blueGray600.color, for: .normal)
+        $0.layer.cornerRadius = 8
+        $0.layer.borderColor = DesignSystemAsset.BlueGrayColor.blueGray400.color.withAlphaComponent(0.4).cgColor
+        $0.layer.borderWidth = 1
+        $0.clipsToBounds = true
+    }
+
+    public weak var delegate: WMRetryWarningViewDelegate?
+
+    public init(
+        description: String,
+        retryButtonTitle: String
+    ) {
+        super.init(frame: .zero)
+        addSubviews()
+        setLayout()
+        configureUI(
+            description: description,
+            retryButtonTitle: retryButtonTitle
+        )
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension WMRetryWarningView {
+    func addSubviews() {
+        addSubview(warningImageView)
+        addSubview(descriptionLabel)
+        addSubview(retryButton)
+    }
+
+    func setLayout() {
+        warningImageView.snp.makeConstraints {
+            $0.top.centerX.equalToSuperview()
+            $0.size.equalTo(80)
+        }
+
+        descriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(warningImageView.snp.bottom).offset(-2)
+            $0.horizontalEdges.greaterThanOrEqualTo(0)
+            $0.centerX.equalTo(warningImageView.snp.centerX)
+        }
+
+        retryButton.snp.makeConstraints {
+            $0.width.equalTo(164)
+            $0.height.equalTo(44)
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(16)
+            $0.centerX.bottom.equalToSuperview()
+        }
+    }
+
+    func configureUI(
+        description: String,
+        retryButtonTitle: String
+    ) {
+        descriptionLabel.text = description
+        retryButton.setTitle(retryButtonTitle, for: .normal)
+        retryButton.addTarget(self, action: #selector(retryButtonAction), for: .touchUpInside)
+    }
+
+    @objc func retryButtonAction() {
+        delegate?.tappedRetryButton()
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요
- 네트워크 통신 실패 시 빈 UI가 나타남

Resolves: #1048 

## 📃 작업내용
- Retry UI 추가
- 로컬라이징에 공통 문구 추가(알 수 없는 오류), 하드코딩 사용처 모두 변경

## 🙋‍♂️ 리뷰노트
x

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
