### PR TITLE
🔀 :: (#1047) 음악 상세에서 좋아요 클릭 시 보관함 좋아요 페이지 리스트 갱신

### DIFF
--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailViewController.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailViewController.swift
@@ -152,6 +152,11 @@ final class MusicDetailViewController: BaseReactorViewController<MusicDetailReac
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
+        self.rx.methodInvoked(#selector(viewDidDisappear))
+            .map { _ in Reactor.Action.viewWillDisappear }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
         musicDetailView.rx.prevMusicButtonDidTap
             .throttle(.milliseconds(500), latest: false, scheduler: MainScheduler.asyncInstance)
             .map { Reactor.Action.prevButtonDidTap }

--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailViewController.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailViewController.swift
@@ -152,7 +152,7 @@ final class MusicDetailViewController: BaseReactorViewController<MusicDetailReac
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
-        self.rx.methodInvoked(#selector(viewDidDisappear))
+        self.rx.methodInvoked(#selector(viewWillDisappear))
             .map { _ in Reactor.Action.viewWillDisappear }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)

--- a/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
+++ b/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
@@ -6,6 +6,7 @@ protocol StorageCommonService {
     var isEditingState: BehaviorSubject<Bool> { get }
     var loginStateDidChangedEvent: Observable<String?> { get }
     var playlistRefreshEvent: Observable<Notification> { get }
+    var likeListRefreshEvent: Observable<Void> { get }
 }
 
 final class DefaultStorageCommonService: StorageCommonService {
@@ -14,11 +15,13 @@ final class DefaultStorageCommonService: StorageCommonService {
     let isEditingState: BehaviorSubject<Bool>
     let loginStateDidChangedEvent: Observable<String?>
     let playlistRefreshEvent: Observable<Notification>
+    let likeListRefreshEvent: Observable<Void>
 
     init() {
         let notificationCenter = NotificationCenter.default
         isEditingState = .init(value: false)
         loginStateDidChangedEvent = PreferenceManager.$userInfo.map(\.?.ID).distinctUntilChanged().skip(1)
         playlistRefreshEvent = notificationCenter.rx.notification(.playlistRefresh)
+        likeListRefreshEvent = notificationCenter.rx.notification(.likeListRefresh).map { _ in () }
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요

음악 상세에서 좋아요 클릭 시 보관함 좋아요 페이지 리스트 갱신

Resolves: #1047

## 📃 작업내용

- 음악 상세에서 좋아요 클릭 시 보관함 좋아요 페이지 리스트 갱신

## 🙋‍♂️ 리뷰노트

- shouldRefreshLikeList를 만든 이유는 좋아요 클릭할때마다 갱신 요청하면 좀 엄일거같아서 화면 닫힐때 판단해서 리프레시 요청 보내게 해놨어요.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
