### PR TITLE
🔀 :: (#1054)  비 로그인 시 무한로딩 버그 해결

### DIFF
--- a/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
@@ -37,7 +37,6 @@ final class PlaylistDetailContainerReactor: Reactor {
             return updateOwnerID()
         case .clearOwnerID:
             return clearOwnerID()
-            
         }
     }
 
@@ -82,7 +81,7 @@ extension PlaylistDetailContainerReactor {
     func updateLoadingState(flag: Bool) -> Observable<Mutation> {
         return .just(.updateLoadingState(flag))
     }
-    
+
     func clearOwnerID() -> Observable<Mutation> {
         return .concat([
             Observable.just(Mutation.updateOwnerID(nil)),

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
@@ -36,7 +36,8 @@ final class PlaylistDetailContainerReactor: Reactor {
         case .requestOwnerID:
             return updateOwnerID()
         case .clearOwnerID:
-            return .just(.updateOwnerID(nil))
+            return clearOwnerID()
+            
         }
     }
 
@@ -80,5 +81,12 @@ extension PlaylistDetailContainerReactor {
 
     func updateLoadingState(flag: Bool) -> Observable<Mutation> {
         return .just(.updateLoadingState(flag))
+    }
+    
+    func clearOwnerID() -> Observable<Mutation> {
+        return .concat([
+            Observable.just(Mutation.updateOwnerID(nil)),
+            Observable.just(.updateLoadingState(false))
+        ])
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
@@ -78,8 +78,8 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
                 owner.remove(asChildViewController: owner.children.first)
 
                 if userInfo == nil {
-                    owner.add(asChildViewController: owner.unknownPlaylistVC)
                     reactor.action.onNext(.clearOwnerID)
+                    owner.add(asChildViewController: owner.unknownPlaylistVC)
                 } else {
                     reactor.action.onNext(.requestOwnerID)
                 }


### PR DESCRIPTION
## 💡 배경 및 개요

비로그인 시 플레이리스트 디테일 화면의 indicator가 꺼지지 않는 버그가 있습니다.

Resolves: #1054

## 📃 작업내용

- 비로그인 시 인디케이터 처리를 해줬씁니다.

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
