### PR TITLE
🔀 :: (#1057) 플로팅 버튼 탭에 따른 위치 조절

### DIFF
--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainContainerViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainContainerViewController.swift
@@ -163,7 +163,6 @@ private extension MainContainerViewController {
         ) { startPage, storagePage -> (Int, Int) in
             return (startPage, storagePage)
         }
-        .debug("testtest")
         .bind(with: self, onNext: { owner, params in
             let (startPage, storagePage) = params
             let bottomOffset: Int = (startPage == 3) ? ((storagePage == 0) ? -80 : -20) : -20

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainContainerViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainContainerViewController.swift
@@ -52,9 +52,11 @@ private extension MainContainerViewController {
     func setLayout() {
         view.addSubview(playlistFloatingActionButton)
 
+        let startPage: Int = PreferenceManager.startPage ?? 0
+        let bottomOffset: Int = startPage == 3 ? -80 : -20
         playlistFloatingActionButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(20)
-            $0.bottom.equalTo(bottomContainerView.snp.top).offset(-20)
+            $0.bottom.equalTo(bottomContainerView.snp.top).offset(bottomOffset)
             $0.size.equalTo(56)
         }
     }
@@ -154,6 +156,24 @@ private extension MainContainerViewController {
                 }
             })
             .disposed(by: disposeBag)
+
+        Observable.combineLatest(
+            PreferenceManager.$startPage.map { $0 ?? 0 },
+            NotificationCenter.default.rx.notification(.didChangeTabInStorage).map { $0.object as? Int ?? 0 }
+        ) { startPage, storagePage -> (Int, Int) in
+            return (startPage, storagePage)
+        }
+        .debug("testtest")
+        .bind(with: self, onNext: { owner, params in
+            let (startPage, storagePage) = params
+            let bottomOffset: Int = (startPage == 3) ? ((storagePage == 0) ? -80 : -20) : -20
+            owner.playlistFloatingActionButton.snp.updateConstraints {
+                $0.trailing.equalToSuperview().inset(20)
+                $0.bottom.equalTo(owner.bottomContainerView.snp.top).offset(bottomOffset)
+                $0.size.equalTo(56)
+            }
+        })
+        .disposed(by: disposeBag)
     }
 }
 

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
@@ -82,6 +82,7 @@ final class StorageViewController: TabmanViewController, View {
         animated: Bool
     ) {
         self.reactor?.action.onNext(.switchTab(index))
+        NotificationCenter.default.post(name: .didChangeTabInStorage, object: index)
     }
 }
 

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
@@ -11,4 +11,5 @@ public extension Notification.Name {
     static let hideSongCart = Notification.Name("hideSongCart")
     static let movedTab = Notification.Name("movedTab")
     static let updateCurrentSongLikeState = Notification.Name("updateCurrentSongLikeState")
+    static let didChangeTabInStorage = Notification.Name("didChangeTabInStorage")
 }


### PR DESCRIPTION
## 💡 배경 및 개요
- 플로팅 버튼 탭에 따른 위치 조절

Resolves: #1057 

## 📃 작업내용
- 플로팅 버튼 탭에 따른 위치 조절

## 🙋‍♂️ 리뷰노트
x

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
