### PR TITLE
🔀 :: (#970) 노티피케이션 이름 정리

### DIFF
--- a/Projects/Features/BaseFeature/Sources/Protocols/EditSheetViewType.swift
+++ b/Projects/Features/BaseFeature/Sources/Protocols/EditSheetViewType.swift
@@ -51,7 +51,7 @@ public extension EditSheetViewType where Self: UIViewController {
         bottomSheetView.present(in: view)
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 숨깁니다.
-        NotificationCenter.default.post(name: .showSongCart, object: nil)
+        NotificationCenter.default.post(name: .willShowSongCart, object: nil)
     }
 
     /// 편집하기 팝업을 제거합니다.
@@ -66,6 +66,6 @@ public extension EditSheetViewType where Self: UIViewController {
         self.bottomSheetView = nil
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 다시 보여줍니다.
-        NotificationCenter.default.post(name: .hideSongCart, object: nil)
+        NotificationCenter.default.post(name: .willHideSongCart, object: nil)
     }
 }

--- a/Projects/Features/BaseFeature/Sources/Protocols/PlaylistEditSheetViewType.swift
+++ b/Projects/Features/BaseFeature/Sources/Protocols/PlaylistEditSheetViewType.swift
@@ -42,7 +42,7 @@ public extension PlaylistEditSheetViewType where Self: UIViewController {
         bottomSheetView.present(in: view)
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 숨깁니다.
-        NotificationCenter.default.post(name: .showSongCart, object: nil)
+        NotificationCenter.default.post(name: .willShowSongCart, object: nil)
     }
 
     /// 편집하기 팝업을 제거합니다.
@@ -57,6 +57,6 @@ public extension PlaylistEditSheetViewType where Self: UIViewController {
         self.bottomSheetView = nil
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 다시 보여줍니다.
-        NotificationCenter.default.post(name: .hideSongCart, object: nil)
+        NotificationCenter.default.post(name: .willHideSongCart, object: nil)
     }
 }

--- a/Projects/Features/BaseFeature/Sources/Protocols/SongCartViewType.swift
+++ b/Projects/Features/BaseFeature/Sources/Protocols/SongCartViewType.swift
@@ -77,7 +77,7 @@ public extension SongCartViewType where Self: UIViewController {
         bottomSheetView.present(in: view)
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 숨깁니다.
-        NotificationCenter.default.post(name: .showSongCart, object: nil)
+        NotificationCenter.default.post(name: .willShowSongCart, object: nil)
     }
 
     /// 노래 담기 팝업을 제거합니다.
@@ -92,6 +92,6 @@ public extension SongCartViewType where Self: UIViewController {
         self.bottomSheetView = nil
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 다시 보여줍니다.
-        NotificationCenter.default.post(name: .hideSongCart, object: nil)
+        NotificationCenter.default.post(name: .willHideSongCart, object: nil)
     }
 }

--- a/Projects/Features/BaseFeature/Sources/Protocols/WMBottomSheetViewType.swift
+++ b/Projects/Features/BaseFeature/Sources/Protocols/WMBottomSheetViewType.swift
@@ -37,7 +37,7 @@ public extension WMBottomSheetViewType where Self: UIViewController {
         bottomSheetView.present(in: view)
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 숨깁니다.
-        NotificationCenter.default.post(name: .showSongCart, object: nil)
+        NotificationCenter.default.post(name: .willShowSongCart, object: nil)
     }
 
     /// 편집하기 팝업을 제거합니다.
@@ -52,7 +52,7 @@ public extension WMBottomSheetViewType where Self: UIViewController {
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 다시 보여줍니다.
         if postNoti {
-            NotificationCenter.default.post(name: .hideSongCart, object: nil)
+            NotificationCenter.default.post(name: .willHideSongCart, object: nil)
         }
     }
 }

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -73,7 +73,7 @@ extension ContainSongsViewController {
             .bind(to: input.itemDidTap)
             .disposed(by: disposeBag)
 
-        NotificationCenter.default.rx.notification(.playlistRefresh)
+        NotificationCenter.default.rx.notification(.shouldRefreshPlaylist)
             .map { _ in () }
             .bind(to: input.playListLoad)
             .disposed(by: disposeBag)
@@ -113,16 +113,15 @@ extension ContainSongsViewController {
                 self.showToast(text: result.description, options: [.tabBar])
 
                 if result.status == 201 {
-                    NotificationCenter.default.post(name: .playlistRefresh, object: nil) // 플리목록창 이름 변경하기 위함
+                    NotificationCenter.default.post(name: .shouldRefreshPlaylist, object: nil) // 플리목록창 이름 변경하기 위함
                 } else if result.status == 200 {
-                    NotificationCenter.default.post(name: .playlistRefresh, object: nil) // 플리목록창 이름 변경하기 위함
+                    NotificationCenter.default.post(name: .shouldRefreshPlaylist, object: nil) // 플리목록창 이름 변경하기 위함
                     self.dismiss(animated: true)
                 } else if result.status == -1 {
                     return
                 } else {
                     self.dismiss(animated: true)
                 }
-
             })
             .disposed(by: disposeBag)
 
@@ -130,8 +129,6 @@ extension ContainSongsViewController {
             .bind(with: self) { owner, error in
                 let toastFont = DesignSystemFontFamily.Pretendard.light.font(size: 14)
                 owner.showToast(text: error.localizedDescription, font: toastFont)
-                NotificationCenter.default.post(name: .movedTab, object: 4)
-
                 owner.dismiss(animated: true)
             }
             .disposed(by: disposeBag)

--- a/Projects/Features/BaseFeature/Sources/Views/WMBottomSheetView.swift
+++ b/Projects/Features/BaseFeature/Sources/Views/WMBottomSheetView.swift
@@ -68,7 +68,7 @@ public extension UIViewController {
         )
 
         bottomSheetView.present(in: self.view)
-        NotificationCenter.default.post(name: .showSongCart, object: nil)
+        NotificationCenter.default.post(name: .willShowSongCart, object: nil)
     }
 
     func hideInlineBottomSheet() {
@@ -77,6 +77,6 @@ public extension UIViewController {
             .last as? BottomSheetView else { return }
 
         bottomSheetView.dismiss()
-        NotificationCenter.default.post(name: .hideSongCart, object: nil)
+        NotificationCenter.default.post(name: .willHideSongCart, object: nil)
     }
 }

--- a/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitStorageViewController.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitStorageViewController.swift
@@ -82,12 +82,12 @@ public final class FruitStorageViewController: UIViewController {
     override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         LogManager.analytics(FruitDrawAnalyticsLog.viewPage(pageName: "fruit_storage"))
-        NotificationCenter.default.post(name: .statusBarEnterDarkBackground, object: nil)
+        NotificationCenter.default.post(name: .willStatusBarEnterDarkBackground, object: nil)
     }
 
     override public func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        NotificationCenter.default.post(name: .statusBarEnterLightBackground, object: nil)
+        NotificationCenter.default.post(name: .willStatusBarEnterLightBackground, object: nil)
     }
 
     override public func viewDidLayoutSubviews() {

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/BottomTabBarViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/BottomTabBarViewController.swift
@@ -9,10 +9,10 @@ protocol BottomTabBarViewDelegate: AnyObject {
     func equalHandleTapped(index current: Int)
 }
 
-public class BottomTabBarViewController: UIViewController, ViewControllerFromStoryBoard {
+public final class BottomTabBarViewController: UIViewController, ViewControllerFromStoryBoard {
     @IBOutlet weak var stackView: UIStackView!
 
-    var currentIndex = Utility.PreferenceManager.startPage ?? 0
+    private var currentIndex = Utility.PreferenceManager.startPage ?? 0
     weak var delegate: BottomTabBarViewDelegate?
 
     private lazy var tabs: [TabItemView] = {
@@ -58,12 +58,11 @@ public class BottomTabBarViewController: UIViewController, ViewControllerFromSto
         ]
     }()
 
-    var disposeBag = DisposeBag()
+    private let disposeBag = DisposeBag()
 
     override public func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
-        bindNotification()
     }
 
     public static func viewController() -> BottomTabBarViewController {
@@ -84,21 +83,6 @@ private extension BottomTabBarViewController {
             tabView.delegate = self
             self.stackView.addArrangedSubview(tabView)
         }
-    }
-
-    func bindNotification() {
-        NotificationCenter.default.rx
-            .notification(.movedTab)
-            .subscribe(onNext: { [weak self] notification in
-                guard
-                    let self = self,
-                    let index = notification.object as? Int,
-                    self.tabs.count > index
-                else { return }
-
-                self.handleTap(view: self.tabs[index])
-            })
-            .disposed(by: disposeBag)
     }
 }
 

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainContainerViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainContainerViewController.swift
@@ -126,21 +126,21 @@ private extension MainContainerViewController {
 
     func bindNotification() {
         NotificationCenter.default.rx
-            .notification(.statusBarEnterDarkBackground)
+            .notification(.willStatusBarEnterDarkBackground)
             .subscribe(onNext: { [weak self] _ in
                 self?.statusBarEnterDarkBackground()
             })
             .disposed(by: disposeBag)
 
         NotificationCenter.default.rx
-            .notification(.statusBarEnterLightBackground)
+            .notification(.willStatusBarEnterLightBackground)
             .subscribe(onNext: { [weak self] _ in
                 self?.statusBarEnterLightBackground()
             })
             .disposed(by: disposeBag)
 
         NotificationCenter.default.rx
-            .notification(.showSongCart)
+            .notification(.willShowSongCart)
             .subscribe(onNext: { [playlistFloatingActionButton] _ in
                 UIView.animate(withDuration: 0.2) {
                     playlistFloatingActionButton.alpha = 0
@@ -149,7 +149,7 @@ private extension MainContainerViewController {
             .disposed(by: disposeBag)
 
         NotificationCenter.default.rx
-            .notification(.hideSongCart)
+            .notification(.willHideSongCart)
             .subscribe(onNext: { [playlistFloatingActionButton] _ in
                 UIView.animate(withDuration: 0.2) {
                     playlistFloatingActionButton.alpha = 1

--- a/Projects/Features/MainTabFeature/Sources/Views/TabItemView.swift
+++ b/Projects/Features/MainTabFeature/Sources/Views/TabItemView.swift
@@ -16,7 +16,7 @@ protocol TabItemViewDelegate: AnyObject {
     func handleTap(view: TabItemView)
 }
 
-class TabItemView: UIView {
+final class TabItemView: UIView {
     @IBOutlet weak var defaultTabImageView: UIImageView!
     @IBOutlet weak var lottieContentView: UIView!
     @IBOutlet weak var titleStringLabel: UILabel!
@@ -31,7 +31,7 @@ class TabItemView: UIView {
 
     weak var delegate: TabItemViewDelegate?
 
-    var lottieAnimationView: LottieAnimationView?
+    private var lottieAnimationView: LottieAnimationView?
 
     var isSelected: Bool = false {
         didSet {
@@ -51,8 +51,8 @@ class TabItemView: UIView {
     }
 }
 
-extension TabItemView {
-    private func animateLottie() {
+private extension TabItemView {
+    func animateLottie() {
         guard let item = self.item else { return }
 
         if self.lottieAnimationView == nil {
@@ -81,8 +81,6 @@ extension TabItemView {
 
             lottieAnimationView.stop()
             lottieAnimationView.play { _ in
-//                self.lottieContentView.isHidden = true
-//                self.defaultTabImageView.isHidden = !self.lottieContentView.isHidden
             }
 
         } else {
@@ -92,15 +90,13 @@ extension TabItemView {
 
             lottieAnimationView.stop()
             lottieAnimationView.play { _ in
-//                self.lottieContentView.isHidden = true
-//                self.defaultTabImageView.isHidden = !self.lottieContentView.isHidden
             }
         }
     }
 
-    private func updateUI(isSelected: Bool) {
-        self.titleStringLabel.textColor = isSelected ? DesignSystemAsset.GrayColor.gray900.color : DesignSystemAsset
-            .GrayColor.gray400.color
+    func updateUI(isSelected: Bool) {
+        self.titleStringLabel.textColor = isSelected ?
+            DesignSystemAsset.BlueGrayColor.gray900.color : DesignSystemAsset.BlueGrayColor.gray400.color
         self.defaultTabImageView.image = isSelected ? item?.onImage : item?.offImage
 
         if isSelected {
@@ -112,14 +108,14 @@ extension TabItemView {
         }
     }
 
-    private func configure(_ item: TabItem?) {
+    func configure(_ item: TabItem?) {
         guard let model = item else { return }
 
         let attributedString = NSMutableAttributedString(
             string: model.title,
             attributes: [
                 .font: DesignSystemFontFamily.Pretendard.medium.font(size: 12),
-                .foregroundColor: DesignSystemAsset.GrayColor.gray900.color,
+                .foregroundColor: DesignSystemAsset.BlueGrayColor.gray900.color,
                 .kern: -0.5
             ]
         )
@@ -142,7 +138,7 @@ extension TabItemView {
     }
 }
 
-class TabItem {
+final class TabItem {
     var title: String
     var offImage: UIImage
     var onImage: UIImage

--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailReactor.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailReactor.swift
@@ -179,7 +179,7 @@ private extension MusicDetailReactor {
 
     func viewWillDisappear() -> Observable<Mutation> {
         if shouldRefreshLikeList {
-            NotificationCenter.default.post(name: .likeListRefresh, object: nil)
+            NotificationCenter.default.post(name: .shouldRefreshLikeList, object: nil)
         }
         return .empty()
     }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
@@ -265,7 +265,7 @@ private extension MyPlaylistDetailReactor {
                 mutations.append(
                     requestCustomImageURLUseCase.execute(key: self.key, data: data)
                         .andThen(.concat([
-                            postNotification(notiName: .playlistRefresh), // 플리 이미지 갱신
+                            postNotification(notiName: .shouldRefreshPlaylist), // 플리 이미지 갱신
                             postNotification(notiName: .willRefreshUserInfo) // 열매 갱신
                         ]))
                         .catch { error in
@@ -343,7 +343,7 @@ private extension MyPlaylistDetailReactor {
         return .concat([
             .just(.updateHeader(prev)),
             updateTitleAndPrivateUseCase.execute(key: key, title: text, isPrivate: nil)
-                .andThen(postNotification(notiName: .playlistRefresh))
+                .andThen(postNotification(notiName: .shouldRefreshPlaylist))
         ])
     }
 }
@@ -450,7 +450,7 @@ private extension MyPlaylistDetailReactor {
                 .just(.updateSelectedCount(0)),
                 .just(.updateHeader(prevHeader)),
                 .just(.showToast("\(removeSongs.count)개의 곡을 삭제했습니다.")),
-                postNotification(notiName: .playlistRefresh)
+                postNotification(notiName: .shouldRefreshPlaylist)
 
             ]))
             .catch { error in

--- a/Projects/Features/PlaylistFeature/Sources/Service/PlaylistCommonService.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Service/PlaylistCommonService.swift
@@ -8,7 +8,7 @@ protocol PlaylistCommonService {
 
 final class DefaultPlaylistCommonService: PlaylistCommonService {
     let removeSubscriptionPlaylistEvent: Observable<Notification> = NotificationCenter.default.rx
-        .notification(.subscriptionPlaylistDidRemoved)
+        .notification(.didRemovedSubscriptionPlaylist)
 
     static let shared = DefaultPlaylistCommonService()
 }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistViewController.swift
@@ -204,6 +204,7 @@ private extension PlaylistViewController {
             .subscribe(onNext: { [weak self] songs, dataSourceCount in
                 guard let self = self else { return }
                 self.playlistView.playlistTableView.reloadData()
+                self.playlistView.willShowSongCart(isShow: !songs.isEmpty)
                 switch songs.isEmpty {
                 case true:
                     self.hideSongCart()

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
@@ -190,8 +190,8 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
 
         reactor.pulse(\.$refresh)
             .compactMap { $0 }
-            .bind(with: self) { owner, _ in
-                NotificationCenter.default.post(name: .playlistRefresh, object: nil)
+            .bind { _ in
+                NotificationCenter.default.post(name: .shouldRefreshPlaylist, object: nil)
             }
             .disposed(by: disposeBag)
 

--- a/Projects/Features/PlaylistFeature/Sources/Views/PlayListView.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/PlayListView.swift
@@ -147,3 +147,11 @@ private extension PlaylistView {
         }
     }
 }
+
+extension PlaylistView {
+    func willShowSongCart(isShow: Bool) {
+        let bottom: CGFloat = isShow ? 56 : 0
+        playlistTableView.verticalScrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottom, right: 0)
+        playlistTableView.contentInset = .init(top: 0, left: 0, bottom: bottom, right: 0)
+    }
+}

--- a/Projects/Features/PlaylistFeature/Sources/Views/PlayListView.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Views/PlayListView.swift
@@ -35,7 +35,7 @@ public final class PlaylistView: UIView {
 
     lazy var titleLabel = WMLabel(
         text: "재생목록",
-        textColor: DesignSystemAsset.GrayColor.gray900.color,
+        textColor: DesignSystemAsset.BlueGrayColor.gray900.color,
         font: .t5(weight: .medium),
         alignment: .center,
         lineHeight: UIFont.WMFontSystem.t5().lineHeight,
@@ -140,9 +140,6 @@ private extension PlaylistView {
     }
 
     private func configurePlaylist() {
-        playlistTableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: APP_WIDTH(), height: 56))
-        playlistTableView.verticalScrollIndicatorInsets = UIEdgeInsets(top: 72, left: 0, bottom: 56, right: 0)
-        playlistTableView.contentInset = .init(top: 0, left: 0, bottom: 56, right: 0)
         playlistTableView.snp.makeConstraints {
             $0.top.equalTo(titleBarView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()

--- a/Projects/Features/SearchFeature/Sources/Root/ViewControllers/SearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/Root/ViewControllers/SearchViewController.swift
@@ -230,11 +230,11 @@ final class SearchViewController: BaseStoryboardReactorViewController<SearchReac
             .bind { owner, event in
 
                 if event == .editingDidBegin {
-                    NotificationCenter.default.post(name: .statusBarEnterDarkBackground, object: nil)
+                    NotificationCenter.default.post(name: .willStatusBarEnterDarkBackground, object: nil)
                     reactor.action.onNext(.switchTypingState(.typing))
 
                 } else if event == .editingDidEnd {
-                    NotificationCenter.default.post(name: .statusBarEnterLightBackground, object: nil)
+                    NotificationCenter.default.post(name: .willStatusBarEnterLightBackground, object: nil)
 
                 } else {
                     reactor.action.onNext(.switchTypingState(.search))

--- a/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
+++ b/Projects/Features/StorageFeature/Sources/Reactors/ListStorageReactor.swift
@@ -498,7 +498,7 @@ private extension ListStorageReactor {
         let ids = playlists.map { $0.key }
         return deletePlayListUseCase.execute(ids: ids)
             .do(onCompleted: {
-                noti.post(name: .subscriptionPlaylistDidRemoved, object: subscribedPlaylistKeys, userInfo: nil)
+                noti.post(name: .didRemovedSubscriptionPlaylist, object: subscribedPlaylistKeys, userInfo: nil)
             })
             .andThen(
                 .concat(

--- a/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
+++ b/Projects/Features/StorageFeature/Sources/Service/StorageCommonService.swift
@@ -21,7 +21,7 @@ final class DefaultStorageCommonService: StorageCommonService {
         let notificationCenter = NotificationCenter.default
         isEditingState = .init(value: false)
         loginStateDidChangedEvent = PreferenceManager.$userInfo.map(\.?.ID).distinctUntilChanged().skip(1)
-        playlistRefreshEvent = notificationCenter.rx.notification(.playlistRefresh)
-        likeListRefreshEvent = notificationCenter.rx.notification(.likeListRefresh).map { _ in () }
+        playlistRefreshEvent = notificationCenter.rx.notification(.shouldRefreshPlaylist)
+        likeListRefreshEvent = notificationCenter.rx.notification(.shouldRefreshLikeList).map { _ in () }
     }
 }

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
@@ -1,15 +1,13 @@
 import Foundation
 
 public extension Notification.Name {
-    static let playlistRefresh = Notification.Name("playlistRefresh") // 플레이리스트 목록 갱신(보관함 같은) (노래목록 아님)
-    static let likeListRefresh = Notification.Name("likeListRefresh")
-    static let subscriptionPlaylistDidRemoved = Notification.Name("subscriptionPlaylistDidRemoved") // 보관함에서 구독플리 제거
+    static let shouldRefreshPlaylist = Notification.Name("shouldRefreshPlaylist") // 플레이리스트 목록 갱신(보관함 같은) (노래목록 아님)
+    static let shouldRefreshLikeList = Notification.Name("shouldRefreshLikeList")
+    static let didRemovedSubscriptionPlaylist = Notification.Name("didRemovedSubscriptionPlaylist") // 보관함에서 구독플리 제거
     static let willRefreshUserInfo = Notification.Name("willRefreshUserInfo") // 유저 정보 갱신
-    static let statusBarEnterDarkBackground = Notification.Name("statusBarEnterDarkBackground")
-    static let statusBarEnterLightBackground = Notification.Name("statusBarEnterLightBackground")
-    static let showSongCart = Notification.Name("showSongCart")
-    static let hideSongCart = Notification.Name("hideSongCart")
-    static let movedTab = Notification.Name("movedTab")
-    static let updateCurrentSongLikeState = Notification.Name("updateCurrentSongLikeState")
+    static let willStatusBarEnterDarkBackground = Notification.Name("willStatusBarEnterDarkBackground")
+    static let willStatusBarEnterLightBackground = Notification.Name("willStatusBarEnterLightBackground")
+    static let willShowSongCart = Notification.Name("willShowSongCart")
+    static let willHideSongCart = Notification.Name("willHideSongCart")
     static let didChangeTabInStorage = Notification.Name("didChangeTabInStorage")
 }


### PR DESCRIPTION
## 💡 배경 및 개요
- 노티 이름을 규칙에 맞게 바꿔봄

Resolves: #970 

## 📃 작업내용
- 노티 이름을 규칙에 맞게 바꿔봄
- 미사용 노티 제거 등
- 재생목록 화면:: 하단 쏭카트 show/hide시 UI 조정

## 🙋‍♂️ 리뷰노트
- 개선할 점이 있다? 리뷰좀

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
