### PR TITLE
🔀 :: (#1063) 재생목록에 곡이 없을 시 FAB 버튼 숨김 처리

### DIFF
--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainContainerViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainContainerViewController.swift
@@ -1,5 +1,6 @@
 import ArtistFeature
 import BaseFeature
+import Combine
 import DesignSystem
 import PlaylistFeatureInterface
 import RxSwift
@@ -20,6 +21,7 @@ open class MainContainerViewController: BaseViewController, ViewControllerFromSt
 
     var isDarkContentBackground: Bool = false
     private let disposeBag = DisposeBag()
+    private var subscription = Set<AnyCancellable>()
 
     override open func viewDidLoad() {
         super.viewDidLoad()
@@ -109,6 +111,7 @@ private extension MainContainerViewController {
             playlistViewController.modalPresentationStyle = .overFullScreen
             navigationController?.topViewController?.present(playlistViewController, animated: true)
         }
+        playlistFloatingActionButton.isHidden = PlayState.shared.isEmpty
         playlistFloatingActionButton.addAction(
             playlistButtonAction,
             for: .primaryActionTriggered
@@ -122,6 +125,11 @@ private extension MainContainerViewController {
                 navigationController?.topViewController?.present(playlistViewController, animated: true)
             }
             .disposed(by: disposeBag)
+
+        PlayState.shared.listChangedPublisher
+            .map(\.isEmpty)
+            .assign(to: \.isHidden, on: playlistFloatingActionButton)
+            .store(in: &subscription)
     }
 
     func bindNotification() {

--- a/Projects/Features/PlaylistFeature/Sources/ViewModels/PlayListViewModel.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewModels/PlayListViewModel.swift
@@ -123,6 +123,7 @@ final class PlaylistViewModel: ViewModelType {
                 if selectedIds.count == output.playlists.value.count {
                     output.playlists.accept([])
                     output.selectedSongIds.accept([])
+                    output.editState.send(false)
                     output.shouldClosePlaylist.send()
                 } else {
                     let removedPlaylists = output.playlists.value


### PR DESCRIPTION
## 💡 배경 및 개요
재생목록에 곡이 없을 시 FAB 버튼 숨김 처리

Resolves: #1063

## 📃 작업내용

- 재생목록에 곡이 없을 시 FAB 버튼 숨김 처리
- 재생목록의 전체 삭제가 동작하지 않는 이슈 해결

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
