### PR TITLE
🔀 :: (#1069) 아티스트 상세:: 크레딧에서 접근한 경우 노래 썸네일이 눌리지않는 오류 수정 외 2

### DIFF
--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
@@ -212,7 +212,13 @@ private extension ArtistMusicContentViewController {
 
 extension ArtistMusicContentViewController: ArtistMusicCellDelegate {
     func tappedThumbnail(id: String) {
-        songDetailPresenter.present(id: id)
+        if let presentingViewController = self.presentingViewController {
+            presentingViewController.dismiss(animated: true) { [songDetailPresenter] () in
+                songDetailPresenter?.present(id: id)
+            }
+        } else {
+            songDetailPresenter.present(id: id)
+        }
     }
 }
 

--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
@@ -212,13 +212,7 @@ private extension ArtistMusicContentViewController {
 
 extension ArtistMusicContentViewController: ArtistMusicCellDelegate {
     func tappedThumbnail(id: String) {
-        if let presentingViewController = self.presentingViewController {
-            presentingViewController.dismiss(animated: true) { [songDetailPresenter] () in
-                songDetailPresenter?.present(id: id)
-            }
-        } else {
-            songDetailPresenter.present(id: id)
-        }
+        songDetailPresenter.present(id: id)
     }
 }
 

--- a/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
+++ b/Projects/Features/FruitDrawFeature/Sources/ViewControllers/FruitDrawViewController.swift
@@ -72,7 +72,7 @@ public final class FruitDrawViewController: UIViewController {
     }
 
     private let rewardFruitImageView = UIImageView().then {
-        $0.contentMode = .scaleAspectFill
+        $0.contentMode = .scaleAspectFit
         $0.alpha = 0
     }
 

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
@@ -118,7 +118,14 @@ private extension MainTabBarViewController {
                     selectedID: selection.selectedID
                 )
                 viewController.modalPresentationStyle = .overFullScreen
-                owner.present(viewController, animated: true)
+
+                if let presentedViewController = self.presentedViewController {
+                    presentedViewController.dismiss(animated: true) {
+                        owner.present(viewController, animated: true)
+                    }
+                } else {
+                    owner.present(viewController, animated: true)
+                }
             })
             .disposed(by: disposeBag)
 

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
@@ -118,7 +118,7 @@ private extension MainTabBarViewController {
                     selectedID: selection.selectedID
                 )
                 viewController.modalPresentationStyle = .overFullScreen
-                owner.present(viewController, animated: true)
+                UIApplication.topVisibleViewController()?.present(viewController, animated: true)
             })
             .disposed(by: disposeBag)
 

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
@@ -118,7 +118,7 @@ private extension MainTabBarViewController {
                     selectedID: selection.selectedID
                 )
                 viewController.modalPresentationStyle = .overFullScreen
-                UIApplication.topVisibleViewController()?.present(viewController, animated: true)
+                owner.present(viewController, animated: true)
             })
             .disposed(by: disposeBag)
 

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/Question/QuestionViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/Question/QuestionViewController.swift
@@ -231,32 +231,7 @@ extension QuestionViewController {
             .filter { $0 != .unknown }
             .subscribe(onNext: { [weak self] source in
                 guard let self = self else { return }
-                if source == .addSong {
-                    let link: String = "https://whimsical.com/E3GQxrTaafVVBrhm55BNBS"
-                    let text =
-                        "요청하고자 하는 곡이 왁뮤에 들어갈 수 있는\n 기준을 충족하는지 먼저 확인해 주세요."
-                    guard let textPopupViewController = self.textPopUpFactory.makeView(
-                        text: text,
-                        cancelButtonIsHidden: false,
-                        confirmButtonText: "다음",
-                        cancelButtonText: "충족 기준 보기",
-                        completion: {
-                            self.goToMail(source: source)
-
-                        },
-                        cancelCompletion: {
-                            guard let URL = URL(string: link) else { return }
-                            let safari = SFSafariViewController(url: URL)
-                            self.present(safari, animated: true)
-                        }
-                    ) as? TextPopupViewController else {
-                        return
-                    }
-                    self.showBottomSheet(content: textPopupViewController)
-
-                } else {
-                    self.goToMail(source: source)
-                }
+                self.goToMail(source: source)
             })
             .disposed(by: disposeBag)
 

--- a/Projects/Features/MyInfoFeature/Sources/ViewModels/QuestionViewModel.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewModels/QuestionViewModel.swift
@@ -135,7 +135,7 @@ extension InquiryType {
                 * 자동으로 작성된 시스템 정보입니다. 원활한 문의를 위해서 삭제하지 말아 주세요.\n
                 \(APP_NAME()) v\(APP_VERSION())
                 \(Device().modelName) / \(OS_NAME()) \(OS_VERSION())
-                닉네임: \(Utility.PreferenceManager.userInfo?.decryptedName ?? ""))
+                닉네임: \(Utility.PreferenceManager.userInfo?.decryptedName ?? "")
             """
         }
     }


### PR DESCRIPTION
## 💡 배경 및 개요
- 아티스트 상세:: 크레딧에서 접근한 경우 노래 썸네일이 눌리지않는 오류 수정

Resolves: #1069

## 📃 작업내용
- present 로직 수정
- (PR외) 열매뽑기:: 리워드 이미지 콘텐트모드 수정
- (PR외) 문의하기:: 충족기준보기 기능 제거

## 🙋‍♂️ 리뷰노트
- 노래 상세는 중복 뎁스를 비허용으로 가는게 좋겠습니다. 노래상세에서 재생목록으로 전환을 한다던지, 좋아요 누름/취소 등의 여러 액션이 일어나는경우 여러개가 띄워진 상태면 혼동이 올 것도 같고 그로인한 사이드이펙트가 예상이 되질않네요.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
