### PR TITLE
🔀 :: (#1078) 최신음악:: 전체재생 버튼 텍스트의 센터정렬이 맞지않음

### DIFF
--- a/Projects/UsertInterfaces/DesignSystem/Sources/SingleActionButtonView.swift
+++ b/Projects/UsertInterfaces/DesignSystem/Sources/SingleActionButtonView.swift
@@ -85,12 +85,12 @@ private extension SingleActionButtonView {
             $0.centerY.equalTo(baseView.snp.centerY)
         }
 
-        label.snp.makeConstraints {
-            $0.center.equalToSuperview()
-        }
-
         button.snp.makeConstraints {
             $0.edges.equalTo(baseView)
+        }
+
+        label.snp.makeConstraints {
+            $0.center.equalTo(button.snp.center)
         }
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요
- 최신음악:: 전체재생 버튼 텍스트의 센터정렬이 맞지않음

Resolves: #1078 

## 📃 작업내용
- 센터정렬 수정

## 🙋‍♂️ 리뷰노트
x

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
