### PR TITLE
🔀 :: (#1093) 더보기 버튼을 통해 하단 뷰 숨기기

### DIFF
--- a/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
@@ -107,7 +107,6 @@ final class MyPlaylistDetailReactor: Reactor {
     }
 
     func mutate(action: Action) -> Observable<Mutation> {
-                
         switch action {
         case .viewDidLoad:
             return viewDidLoad()
@@ -478,7 +477,7 @@ private extension MyPlaylistDetailReactor {
     func postNotification(notiName: Notification.Name) -> Observable<Mutation> {
         .just(.postNotification(notiName))
     }
-    
+
     func updateShareLink() -> Observable<Mutation> {
         return .concat([
             .just(.showShareLink(deepLinkGenerator.generatePlaylistDeepLink(key: key))),

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
@@ -24,6 +24,7 @@ final class MyPlaylistDetailReactor: Reactor {
         case removeSongs
         case changeImageData(PlaylistImageKind)
         case shareButtonDidTap
+        case moreButtonDidTap
     }
 
     enum Mutation {
@@ -34,6 +35,7 @@ final class MyPlaylistDetailReactor: Reactor {
         case updateLoadingState(Bool)
         case updateSelectedCount(Int)
         case updateImageData(PlaylistImageKind?)
+        case updateShowEditSheet(Bool)
         case showToast(String)
         case showShareLink(String)
         case postNotification(Notification.Name)
@@ -47,6 +49,7 @@ final class MyPlaylistDetailReactor: Reactor {
         var isLoading: Bool
         var selectedCount: Int
         var imageData: PlaylistImageKind?
+        var showEditSheet: Bool
         @Pulse var toastMessage: String?
         @Pulse var shareLink: String?
         @Pulse var notiName: Notification.Name?
@@ -98,11 +101,13 @@ final class MyPlaylistDetailReactor: Reactor {
             backupPlaylistModels: [],
             isLoading: true,
             selectedCount: 0,
+            showEditSheet: false,
             notiName: nil
         )
     }
 
     func mutate(action: Action) -> Observable<Mutation> {
+                
         switch action {
         case .viewDidLoad:
             return viewDidLoad()
@@ -142,7 +147,9 @@ final class MyPlaylistDetailReactor: Reactor {
         case let .changeImageData(imageData):
             return updateImageData(imageData: imageData)
         case .shareButtonDidTap:
-            return .just(.showShareLink(deepLinkGenerator.generatePlaylistDeepLink(key: key)))
+            return updateShareLink()
+        case .moreButtonDidTap:
+            return updateShowEditSheet(flag: !self.currentState.showEditSheet)
         }
     }
 
@@ -177,6 +184,8 @@ final class MyPlaylistDetailReactor: Reactor {
             newState.shareLink = link
         case let .postNotification(notiName):
             newState.notiName = notiName
+        case let .updateShowEditSheet(flag):
+            newState.showEditSheet = flag
         }
 
         return newState
@@ -356,7 +365,8 @@ private extension MyPlaylistDetailReactor {
 
         return .concat([
             .just(.updateEditingState(true)),
-            .just(.updateBackUpPlaylist(currentPlaylists))
+            .just(.updateBackUpPlaylist(currentPlaylists)),
+            updateShowEditSheet(flag: false),
         ])
     }
 
@@ -467,5 +477,16 @@ private extension MyPlaylistDetailReactor {
 
     func postNotification(notiName: Notification.Name) -> Observable<Mutation> {
         .just(.postNotification(notiName))
+    }
+    
+    func updateShareLink() -> Observable<Mutation> {
+        return .concat([
+            .just(.showShareLink(deepLinkGenerator.generatePlaylistDeepLink(key: key))),
+            updateShowEditSheet(flag: false)
+        ])
+    }
+
+    func updateShowEditSheet(flag: Bool) -> Observable<Mutation> {
+        return .just(.updateShowEditSheet(flag))
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -198,13 +198,13 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
                 }
             }
             .disposed(by: disposeBag)
+        
 
+        
         moreButton.rx
             .tap
-            .bind(with: self) { owner, _ in
-                owner.showplaylistEditSheet(in: owner.view)
-                owner.playlisteditSheetView?.delegate = owner
-            }
+            .map { Reactor.Action.moreButtonDidTap }
+            .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
         completeButton.rx
@@ -376,6 +376,21 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
                 }
             }
             .disposed(by: disposeBag)
+        
+        
+        sharedState.map(\.showEditSheet)
+            .distinctUntilChanged()
+            .bind(with: self) { owner, flag in
+                
+                if flag {
+                    owner.showplaylistEditSheet(in: owner.view)
+                    owner.playlisteditSheetView?.delegate = owner
+                } else {
+                    owner.hideplaylistEditSheet()
+                }
+            }
+            .disposed(by: disposeBag)
+        
     }
 }
 
@@ -597,8 +612,6 @@ extension MyPlaylistDetailViewController: PlaylistEditSheetDelegate {
             LogManager.analytics(PlaylistAnalyticsLog.clickPlaylistShareButton)
             reactor?.action.onNext(.shareButtonDidTap)
         }
-
-        self.hideplaylistEditSheet()
     }
 }
 

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -198,9 +198,7 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
                 }
             }
             .disposed(by: disposeBag)
-        
 
-        
         moreButton.rx
             .tap
             .map { Reactor.Action.moreButtonDidTap }
@@ -376,12 +374,11 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
                 }
             }
             .disposed(by: disposeBag)
-        
-        
+
         sharedState.map(\.showEditSheet)
             .distinctUntilChanged()
             .bind(with: self) { owner, flag in
-                
+
                 if flag {
                     owner.showplaylistEditSheet(in: owner.view)
                     owner.playlisteditSheetView?.delegate = owner
@@ -390,7 +387,6 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
                 }
             }
             .disposed(by: disposeBag)
-        
     }
 }
 


### PR DESCRIPTION
## 💡 배경 및 개요

기존에 편집 하단뷰를 선택하지 않으면 닫히지 않았습니다.

Resolves: #1093

## 📃 작업내용

더보기 버튼을 다시 누르면 내려갑니다.

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
