### PR TITLE
🔀 :: (#1091) private 플리 접근 처리

### DIFF
--- a/Projects/Features/PlaylistFeature/Sources/Components/PlaylistDetailComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/PlaylistDetailComponent.swift
@@ -1,6 +1,7 @@
 import NeedleFoundation
 import PlaylistDomainInterface
 import PlaylistFeatureInterface
+import BaseFeatureInterface
 import UIKit
 
 public protocol PlaylistDetailFactoryDependency: Dependency {
@@ -8,6 +9,7 @@ public protocol PlaylistDetailFactoryDependency: Dependency {
     var unknownPlaylistDetailFactory: any UnknownPlaylistDetailFactory { get }
     var wakmusicPlaylistDetailFactory: any WakmusicPlaylistDetailFactory { get }
     var requestPlaylistOwnerIDUsecase: any RequestPlaylistOwnerIDUsecase { get }
+    var textPopUpFactory: any TextPopUpFactory { get }
 }
 
 public final class PlaylistDetailComponent: Component<PlaylistDetailFactoryDependency>, PlaylistDetailFactory {
@@ -21,7 +23,8 @@ public final class PlaylistDetailComponent: Component<PlaylistDetailFactoryDepen
             key: key,
             unknownPlaylistDetailFactory: dependency
                 .unknownPlaylistDetailFactory,
-            myPlaylistDetailFactory: dependency.myPlaylistDetailFactory
+            myPlaylistDetailFactory: dependency.myPlaylistDetailFactory,
+            textPopUpFactory: dependency.textPopUpFactory
         )
     }
 

--- a/Projects/Features/PlaylistFeature/Sources/Components/PlaylistDetailComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/PlaylistDetailComponent.swift
@@ -1,7 +1,7 @@
+import BaseFeatureInterface
 import NeedleFoundation
 import PlaylistDomainInterface
 import PlaylistFeatureInterface
-import BaseFeatureInterface
 import UIKit
 
 public protocol PlaylistDetailFactoryDependency: Dependency {

--- a/Projects/Features/PlaylistFeature/Sources/Components/UnkwonPlaylistDetailComponent.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Components/UnkwonPlaylistDetailComponent.swift
@@ -13,7 +13,6 @@ public protocol UnknownPlaylistDetailDependency: Dependency {
     var checkSubscriptionUseCase: any CheckSubscriptionUseCase { get }
     var logoutUseCase: any LogoutUseCase { get }
     var containSongsFactory: any ContainSongsFactory { get }
-    var textPopUpFactory: any TextPopUpFactory { get }
     var songDetailPresenter: any SongDetailPresentable { get }
 
     var signInFactory: any SignInFactory { get }
@@ -31,7 +30,6 @@ public final class UnknownPlaylistDetailComponent: Component<UnknownPlaylistDeta
                 logoutUseCase: dependency.logoutUseCase
             ),
             containSongsFactory: dependency.containSongsFactory,
-            textPopUpFactory: dependency.textPopUpFactory,
             songDetailPresenter: dependency.songDetailPresenter,
             signInFactory: dependency.signInFactory
         )

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
@@ -82,7 +82,7 @@ extension PlaylistDetailContainerReactor {
                 if wmError == .notFound {
                     return self.updateDetectedNotFound()
                 }
-                
+
                 return .just(Mutation.showToastMessagae(wmError.localizedDescription))
             }
     }
@@ -97,7 +97,7 @@ extension PlaylistDetailContainerReactor {
             Observable.just(.updateLoadingState(false))
         ])
     }
-    
+
     func updateDetectedNotFound() -> Observable<Mutation> {
         .just(.updateDetectedNotFound)
     }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/PlaylistDetailContainerReactor.swift
@@ -13,12 +13,14 @@ final class PlaylistDetailContainerReactor: Reactor {
         case updateOwnerID(String?)
         case updateLoadingState(Bool)
         case showToastMessagae(String)
+        case updateDetectedNotFound
     }
 
     struct State {
         var isLoading: Bool
         var ownerID: String?
         @Pulse var toastMessgae: String?
+        @Pulse var detectedNotFound: Void?
     }
 
     private let requestPlaylistOwnerIDUsecase: any RequestPlaylistOwnerIDUsecase
@@ -50,6 +52,8 @@ final class PlaylistDetailContainerReactor: Reactor {
             newState.toastMessgae = message
         case let .updateLoadingState(flag):
             newState.isLoading = flag
+        case .updateDetectedNotFound:
+            newState.detectedNotFound = ()
         }
 
         return newState
@@ -74,6 +78,11 @@ extension PlaylistDetailContainerReactor {
             }
             .catch { error in
                 let wmError = error.asWMError
+
+                if wmError == .notFound {
+                    return self.updateDetectedNotFound()
+                }
+                
                 return .just(Mutation.showToastMessagae(wmError.localizedDescription))
             }
     }
@@ -87,5 +96,9 @@ extension PlaylistDetailContainerReactor {
             Observable.just(Mutation.updateOwnerID(nil)),
             Observable.just(.updateLoadingState(false))
         ])
+    }
+    
+    func updateDetectedNotFound() -> Observable<Mutation> {
+        .just(.updateDetectedNotFound)
     }
 }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/UnknownPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/UnknownPlaylistDetailReactor.swift
@@ -29,7 +29,7 @@ final class UnknownPlaylistDetailReactor: Reactor {
         case showToast(String)
         case updateLoginPopupState(Bool)
         case updateRefresh
-        case updateDetectedNotFound
+      
     }
 
     struct State {
@@ -135,8 +135,6 @@ final class UnknownPlaylistDetailReactor: Reactor {
         case .updateRefresh:
             newState.refresh = ()
 
-        case .updateDetectedNotFound:
-            newState.detectedNotFound = ()
         }
 
         return newState
@@ -185,13 +183,10 @@ private extension UnknownPlaylistDetailReactor {
 
                     guard let self else { return .empty() }
 
-                    let wmErorr = error.asWMError
+                    let wmError = error.asWMError
 
-                    if wmErorr == .notFound {
-                        return self.updateDetectedNotFound()
-                    }
                     return Observable.just(
-                        Mutation.showToast(wmErorr.errorDescription ?? LocalizationStrings.unknownErrorWarning)
+                        Mutation.showToast(wmError.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                     )
                 },
             .just(.updateLoadingState(false))
@@ -292,7 +287,5 @@ private extension UnknownPlaylistDetailReactor {
         .just(.updateRefresh)
     }
 
-    func updateDetectedNotFound() -> Observable<Mutation> {
-        .just(.updateDetectedNotFound)
-    }
+
 }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/UnknownPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/UnknownPlaylistDetailReactor.swift
@@ -29,7 +29,6 @@ final class UnknownPlaylistDetailReactor: Reactor {
         case showToast(String)
         case updateLoginPopupState(Bool)
         case updateRefresh
-      
     }
 
     struct State {
@@ -134,7 +133,6 @@ final class UnknownPlaylistDetailReactor: Reactor {
 
         case .updateRefresh:
             newState.refresh = ()
-
         }
 
         return newState
@@ -286,6 +284,4 @@ private extension UnknownPlaylistDetailReactor {
     func updateSendRefreshNoti() -> Observable<Mutation> {
         .just(.updateRefresh)
     }
-
-
 }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
@@ -6,6 +6,7 @@ import SnapKit
 import Then
 import UIKit
 import Utility
+import BaseFeatureInterface
 
 final class PlaylistDetailContainerViewController: BaseReactorViewController<PlaylistDetailContainerReactor>,
     ContainerViewType {
@@ -22,6 +23,7 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
 
     private let unknownPlaylistDetailFactory: any UnknownPlaylistDetailFactory
     private let myPlaylistDetailFactory: any MyPlaylistDetailFactory
+    private let textPopUpFactory: any TextPopUpFactory
     private let key: String
     lazy var unknownPlaylistVC = unknownPlaylistDetailFactory.makeView(key: key)
     lazy var myPlaylistVC = myPlaylistDetailFactory.makeView(key: key)
@@ -30,11 +32,13 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
         reactor: PlaylistDetailContainerReactor,
         key: String,
         unknownPlaylistDetailFactory: any UnknownPlaylistDetailFactory,
-        myPlaylistDetailFactory: any MyPlaylistDetailFactory
+        myPlaylistDetailFactory: any MyPlaylistDetailFactory,
+        textPopUpFactory: any TextPopUpFactory
     ) {
         self.key = key
         self.unknownPlaylistDetailFactory = unknownPlaylistDetailFactory
         self.myPlaylistDetailFactory = myPlaylistDetailFactory
+        self.textPopUpFactory = textPopUpFactory
 
         super.init(reactor: reactor)
     }
@@ -131,6 +135,24 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
                 } else {
                     owner.add(asChildViewController: owner.unknownPlaylistVC)
                 }
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.pulse(\.$detectedNotFound)
+            .compactMap { $0 }
+            .bind(with: self) { owner, _ in
+                let vc = owner.textPopUpFactory.makeView(
+                    text: "존재하지 않거나 비공개된 리스트입니다.",
+                    cancelButtonIsHidden: true,
+                    confirmButtonText: "확인",
+                    cancelButtonText: nil,
+                    completion: {
+                        owner.navigationController?.popViewController(animated: true)
+                    },
+                    cancelCompletion: nil
+                )
+
+                owner.showBottomSheet(content: vc, dismissOnOverlayTapAndPull: false) // 드래그로 닫기 불가
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/PlaylistDetailContainerViewController.swift
@@ -1,4 +1,5 @@
 import BaseFeature
+import BaseFeatureInterface
 import DesignSystem
 import PlaylistFeatureInterface
 import RxSwift
@@ -6,7 +7,6 @@ import SnapKit
 import Then
 import UIKit
 import Utility
-import BaseFeatureInterface
 
 final class PlaylistDetailContainerViewController: BaseReactorViewController<PlaylistDetailContainerReactor>,
     ContainerViewType {
@@ -137,7 +137,7 @@ final class PlaylistDetailContainerViewController: BaseReactorViewController<Pla
                 }
             }
             .disposed(by: disposeBag)
-        
+
         reactor.pulse(\.$detectedNotFound)
             .compactMap { $0 }
             .bind(with: self) { owner, _ in

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
@@ -20,8 +20,6 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
 
     private let containSongsFactory: any ContainSongsFactory
 
-    private let textPopUpFactory: any TextPopUpFactory
-
     private let songDetailPresenter: any SongDetailPresentable
 
     private let signInFactory: any SignInFactory
@@ -63,12 +61,10 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
     init(
         reactor: UnknownPlaylistDetailReactor,
         containSongsFactory: any ContainSongsFactory,
-        textPopUpFactory: any TextPopUpFactory,
         songDetailPresenter: any SongDetailPresentable,
         signInFactory: any SignInFactory
     ) {
         self.containSongsFactory = containSongsFactory
-        self.textPopUpFactory = textPopUpFactory
         self.songDetailPresenter = songDetailPresenter
         self.signInFactory = signInFactory
         super.init(reactor: reactor)
@@ -192,24 +188,6 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
             .compactMap { $0 }
             .bind { _ in
                 NotificationCenter.default.post(name: .shouldRefreshPlaylist, object: nil)
-            }
-            .disposed(by: disposeBag)
-
-        reactor.pulse(\.$detectedNotFound)
-            .compactMap { $0 }
-            .bind(with: self) { owner, _ in
-                let vc = owner.textPopUpFactory.makeView(
-                    text: "비공개된 리스트 입니다.",
-                    cancelButtonIsHidden: true,
-                    confirmButtonText: "확인",
-                    cancelButtonText: nil,
-                    completion: {
-                        owner.navigationController?.popViewController(animated: true)
-                    },
-                    cancelCompletion: nil
-                )
-
-                owner.showBottomSheet(content: vc, dismissOnOverlayTapAndPull: false) // 드래그로 닫기 불가
             }
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 💡 배경 및 개요

private 플리 접근 시 화면이 숨김처리되는 버그가 있습니다.

Resolves: #1091

## 📃 작업내용

private 알림을 unknown playlist에서 container VC쪽으로 옮겼습니다.


## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
