### PR TITLE
🔀 :: (#1099) Credit 로딩 인디케이터가 불필요한 상황에 표시되는 이슈 해결

### DIFF
--- a/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/CreditSongListTabItemReactor.swift
+++ b/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/CreditSongListTabItemReactor.swift
@@ -125,6 +125,11 @@ final class CreditSongListTabItemReactor: Reactor {
 private extension CreditSongListTabItemReactor {
     func viewDidLoad() -> Observable<Mutation> {
         let initialCreditSongListObservable = fetchPaginatedCreditSongList()
+            .do(onNext: { [weak self] creditModels in
+                if creditModels.isEmpty || creditModels.count < Metric.pageLimit {
+                    self?.isLastPage = true
+                }
+            })
             .map(Mutation.updateSongs)
         return withLoadingMutation(observable: initialCreditSongListObservable)
     }


### PR DESCRIPTION
## 💡 배경 및 개요
- Credit 로딩 인디케이터가 불필요한 상황에 표시되는 이슈 해결

Resolves #1099

## 📃 작업내용

- Credit 로딩 인디케이터가 불필요한 상황에 표시되는 이슈 해결

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
