### PR TITLE
🔀 :: (#1101) 보관함 - 좋아요 창에서도 제목부분 클릭시 곡 상세로 가도록

### DIFF
--- a/Projects/Features/StorageFeature/Sources/Views/LikeStorageTableViewCell.swift
+++ b/Projects/Features/StorageFeature/Sources/Views/LikeStorageTableViewCell.swift
@@ -14,7 +14,6 @@ public protocol LikeStorageTableViewCellDelegate: AnyObject {
 public enum LikeStorageTableViewCellDelegateConstant {
     case cellTapped(indexPath: IndexPath)
     case playTapped(song: FavoriteSongEntity)
-    case thumbnailTapped(song: FavoriteSongEntity)
 }
 
 class LikeStorageTableViewCell: UITableViewCell {
@@ -152,18 +151,10 @@ private extension LikeStorageTableViewCell {
     func setAction() {
         self.cellSelectButton.addTarget(self, action: #selector(cellSelectButtonAction), for: .touchUpInside)
         self.playButton.addTarget(self, action: #selector(playButtonAction), for: .touchUpInside)
-
-        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(albumImageDidTapAction))
-        self.albumImageView.addGestureRecognizer(tapGestureRecognizer)
     }
 }
 
 private extension LikeStorageTableViewCell {
-    @objc func albumImageDidTapAction() {
-        guard let model else { return }
-        delegate?.buttonTapped(type: .thumbnailTapped(song: model))
-    }
-
     @objc func playButtonAction() {
         guard let model else { return }
         delegate?.buttonTapped(type: .playTapped(song: model))

--- a/Projects/Features/StorageFeature/Sources/Views/LikeStorageView.swift
+++ b/Projects/Features/StorageFeature/Sources/Views/LikeStorageView.swift
@@ -85,7 +85,7 @@ final class LikeStorageView: UIView {
     func configureUI() {
         backgroundColor = DesignSystemAsset.BlueGrayColor.blueGray100.color
         tableView.refreshControl = refreshControl
-        tableView.verticalScrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: 56, right: 0)
+        tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 56, right: 0)
         loginWarningView.isHidden = true
         activityIndicator.isHidden = true
         activityIndicator.stopAnimating()


### PR DESCRIPTION
## 💡 배경 및 개요
- 보관함 - 좋아요 창에서도 제목부분 클릭시 곡상세로 가도록

Resolves: #1101 

## 📃 작업내용
- 터치영역 셀 전체로 확장

## 🙋‍♂️ 리뷰노트
x

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
