### PR TITLE
🔀 :: (#1105)  My 플리 저장 시 인디케이터 작업

### DIFF
--- a/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
@@ -263,7 +263,10 @@ private extension MyPlaylistDetailReactor {
             return $0.updateIsSelected(isSelected: false)
         }
 
-        var mutations: [Observable<Mutation>] = [updateComplectionButtonVisible(flag: false) , updateIsSecondaryLoading(flag: true)]
+        var mutations: [Observable<Mutation>] = [
+            updateComplectionButtonVisible(flag: false),
+            updateIsSecondaryLoading(flag: true)
+        ]
 
         if let imageData = state.imageData {
             switch imageData {
@@ -502,9 +505,11 @@ private extension MyPlaylistDetailReactor {
     func updateShowEditSheet(flag: Bool) -> Observable<Mutation> {
         return .just(.updateShowEditSheet(flag))
     }
+
     func updateComplectionButtonVisible(flag: Bool) -> Observable<Mutation> {
         return .just(.updateComplectionButtonVisible(flag))
     }
+
     func updateIsSecondaryLoading(flag: Bool) -> Observable<Mutation> {
         return .just(.updateIsSecondaryLoading(flag))
     }

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
@@ -106,7 +106,7 @@ final class MyPlaylistDetailReactor: Reactor {
             isLoading: true,
             selectedCount: 0,
             showEditSheet: false,
-             completionButtonVisible: false,
+            completionButtonVisible: false,
             isSecondaryLoading: false,
             notiName: nil
         )

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
@@ -13,7 +13,7 @@ final class MyPlaylistDetailReactor: Reactor {
         case itemDidTap(Int)
         case editButtonDidTap
         case privateButtonDidTap
-        case completeButtonDidTap
+        case completionButtonDidTap
         case restore
         case itemDidMoved(Int, Int)
         case forceSave
@@ -35,7 +35,7 @@ final class MyPlaylistDetailReactor: Reactor {
         case updateLoadingState(Bool)
         case updateSelectedCount(Int)
         case updateImageData(PlaylistImageKind?)
-        case updateComplectionButtonVisible(Bool)
+        case updateCompletionButtonVisible(Bool)
         case updateIsSecondaryLoading(Bool)
         case updateShowEditSheet(Bool)
         case showToast(String)
@@ -52,7 +52,7 @@ final class MyPlaylistDetailReactor: Reactor {
         var selectedCount: Int
         var imageData: PlaylistImageKind?
         var showEditSheet: Bool
-        var complectionButtonVisible: Bool
+        var completionButtonVisible: Bool
         var isSecondaryLoading: Bool
         @Pulse var toastMessage: String?
         @Pulse var shareLink: String?
@@ -106,7 +106,7 @@ final class MyPlaylistDetailReactor: Reactor {
             isLoading: true,
             selectedCount: 0,
             showEditSheet: false,
-            complectionButtonVisible: false,
+             completionButtonVisible: false,
             isSecondaryLoading: false,
             notiName: nil
         )
@@ -123,7 +123,7 @@ final class MyPlaylistDetailReactor: Reactor {
         case .privateButtonDidTap:
             return updatePrivate()
 
-        case .forceSave, .completeButtonDidTap:
+        case .forceSave, .completionButtonDidTap:
             return endEditingWithSave()
 
         case .forceEndEditing:
@@ -191,8 +191,8 @@ final class MyPlaylistDetailReactor: Reactor {
             newState.notiName = notiName
         case let .updateShowEditSheet(flag):
             newState.showEditSheet = flag
-        case let .updateComplectionButtonVisible(flag):
-            newState.complectionButtonVisible = flag
+        case let .updateCompletionButtonVisible(flag):
+            newState.completionButtonVisible = flag
         case let .updateIsSecondaryLoading(flag):
             newState.isSecondaryLoading = flag
         }
@@ -507,7 +507,7 @@ private extension MyPlaylistDetailReactor {
     }
 
     func updateComplectionButtonVisible(flag: Bool) -> Observable<Mutation> {
-        return .just(.updateComplectionButtonVisible(flag))
+        return .just(.updateCompletionButtonVisible(flag))
     }
 
     func updateIsSecondaryLoading(flag: Bool) -> Observable<Mutation> {

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
@@ -53,7 +53,7 @@ final class MyPlaylistDetailReactor: Reactor {
         var imageData: PlaylistImageKind?
         var showEditSheet: Bool
         var completionButtonVisible: Bool
-        var isSecondaryLoading: Bool
+        var isSaveCompletionLoading: Bool
         @Pulse var toastMessage: String?
         @Pulse var shareLink: String?
         @Pulse var notiName: Notification.Name?
@@ -107,7 +107,7 @@ final class MyPlaylistDetailReactor: Reactor {
             selectedCount: 0,
             showEditSheet: false,
             completionButtonVisible: false,
-            isSecondaryLoading: false,
+            isSaveCompletionLoading: false,
             notiName: nil
         )
     }
@@ -194,7 +194,7 @@ final class MyPlaylistDetailReactor: Reactor {
         case let .updateCompletionButtonVisible(flag):
             newState.completionButtonVisible = flag
         case let .updateIsSecondaryLoading(flag):
-            newState.isSecondaryLoading = flag
+            newState.isSaveCompletionLoading = flag
         }
 
         return newState

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -55,7 +55,7 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
         $0.setImage(DesignSystemAsset.MyInfo.more.image, for: .normal)
     }
 
-    private var secondaryIndicator = NVActivityIndicatorView(frame: .zero).then {
+    private var saveCompletionIndicator = NVActivityIndicatorView(frame: .zero).then {
         $0.color = DesignSystemAsset.PrimaryColorV2.point.color
         $0.type = .circleStrokeSpin
     }
@@ -126,9 +126,9 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
 
     override func addView() {
         super.addView()
-        self.view.addSubviews(wmNavigationbarView, tableView, secondaryIndicator)
+        self.view.addSubviews(wmNavigationbarView, tableView, saveCompletionIndicator)
         wmNavigationbarView.setLeftViews([dismissButton])
-        wmNavigationbarView.setRightViews([lockButton, moreButton, completionButton, secondaryIndicator])
+        wmNavigationbarView.setRightViews([lockButton, moreButton, completionButton, saveCompletionIndicator])
     }
 
     override func setLayout() {
@@ -151,7 +151,7 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
             $0.bottom.equalToSuperview().offset(-5)
         }
 
-        secondaryIndicator.snp.makeConstraints {
+        saveCompletionIndicator.snp.makeConstraints {
             $0.size.equalTo(15)
         }
     }
@@ -364,14 +364,14 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
             }
             .disposed(by: disposeBag)
 
-        sharedState.map(\.isSecondaryLoading)
+        sharedState.map(\.isSaveCompletionLoading)
             .distinctUntilChanged()
             .bind(with: self) { owner, isLoading in
 
                 if isLoading {
-                    owner.secondaryIndicator.startAnimating()
+                    owner.saveCompletionIndicator.startAnimating()
                 } else {
-                    owner.secondaryIndicator.stopAnimating()
+                    owner.saveCompletionIndicator.stopAnimating()
                 }
             }
             .disposed(by: disposeBag)

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -75,7 +75,7 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
         $0.contentInset = .init(top: .zero, left: .zero, bottom: 60.0, right: .zero)
     }
 
-    private lazy var completeButton: RectangleButton = RectangleButton().then {
+    private lazy var completionButton: RectangleButton = RectangleButton().then {
         $0.setBackgroundColor(.clear, for: .normal)
         $0.setColor(isHighlight: true)
         $0.setTitle("완료", for: .normal)
@@ -128,7 +128,7 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
         super.addView()
         self.view.addSubviews(wmNavigationbarView, tableView, secondaryIndicator)
         wmNavigationbarView.setLeftViews([dismissButton])
-        wmNavigationbarView.setRightViews([lockButton, moreButton, completeButton, secondaryIndicator])
+        wmNavigationbarView.setRightViews([lockButton, moreButton, completionButton, secondaryIndicator])
     }
 
     override func setLayout() {
@@ -145,7 +145,7 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
             $0.leading.trailing.bottom.equalToSuperview()
         }
 
-        completeButton.snp.makeConstraints {
+        completionButton.snp.makeConstraints {
             $0.width.equalTo(45)
             $0.height.equalTo(24)
             $0.bottom.equalToSuperview().offset(-5)
@@ -216,10 +216,10 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
-        completeButton.rx
+        completionButton.rx
             .tap
             .throttle(.seconds(1), latest: false, scheduler: MainScheduler.asyncInstance)
-            .map { Reactor.Action.completeButtonDidTap }
+            .map { Reactor.Action.completionButtonDidTap }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
@@ -308,7 +308,6 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
             .bind(with: self) { owner, isEditing in
                 owner.lockButton.isHidden = isEditing
                 owner.moreButton.isHidden = isEditing
-                owner.completeButton.isHidden = !isEditing
                 owner.tableView.isEditing = isEditing
                 owner.headerView.updateEditState(isEditing)
                 owner.navigationController?.interactivePopGestureRecognizer?.delegate = isEditing ? owner : nil
@@ -377,10 +376,10 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
             }
             .disposed(by: disposeBag)
 
-        sharedState.map(\.complectionButtonVisible)
+        sharedState.map(\.completionButtonVisible)
             .distinctUntilChanged()
             .map { !$0 }
-            .bind(to: completeButton.rx.isHidden)
+            .bind(to: completionButton.rx.isHidden)
             .disposed(by: disposeBag)
 
         sharedState.map(\.selectedCount)

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -3,6 +3,7 @@ import BaseFeatureInterface
 import DesignSystem
 import Localization
 import LogManager
+import NVActivityIndicatorView
 import PhotosUI
 import PlaylistFeatureInterface
 import ReactorKit
@@ -11,7 +12,6 @@ import SongsDomainInterface
 import Then
 import UIKit
 import Utility
-import NVActivityIndicatorView
 
 final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylistDetailReactor>,
     PlaylistEditSheetViewType, SongCartViewType {
@@ -54,12 +54,11 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
     private var moreButton: UIButton = UIButton().then {
         $0.setImage(DesignSystemAsset.MyInfo.more.image, for: .normal)
     }
-    
+
     private var secondaryIndicator = NVActivityIndicatorView(frame: .zero).then {
         $0.color = DesignSystemAsset.PrimaryColorV2.point.color
         $0.type = .circleStrokeSpin
     }
-    
 
     private var headerView: MyPlaylistHeaderView = MyPlaylistHeaderView(frame: .init(
         x: .zero,
@@ -129,9 +128,7 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
         super.addView()
         self.view.addSubviews(wmNavigationbarView, tableView, secondaryIndicator)
         wmNavigationbarView.setLeftViews([dismissButton])
-        wmNavigationbarView.setRightViews([lockButton, moreButton, completeButton,secondaryIndicator])
-        
-
+        wmNavigationbarView.setRightViews([lockButton, moreButton, completeButton, secondaryIndicator])
     }
 
     override func setLayout() {
@@ -153,7 +150,7 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
             $0.height.equalTo(24)
             $0.bottom.equalToSuperview().offset(-5)
         }
-        
+
         secondaryIndicator.snp.makeConstraints {
             $0.size.equalTo(15)
         }
@@ -367,23 +364,22 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
                 }
             }
             .disposed(by: disposeBag)
-        
+
         sharedState.map(\.isSecondaryLoading)
             .distinctUntilChanged()
             .bind(with: self) { owner, isLoading in
-                
+
                 if isLoading {
                     owner.secondaryIndicator.startAnimating()
                 } else {
                     owner.secondaryIndicator.stopAnimating()
                 }
-                
             }
             .disposed(by: disposeBag)
-        
+
         sharedState.map(\.complectionButtonVisible)
             .distinctUntilChanged()
-            .map{ !$0 }
+            .map { !$0 }
             .bind(to: completeButton.rx.isHidden)
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 💡 배경 및 개요

기존에 오래걸리는 작업 시 완료버튼이 계속 클릭되어 음표열매가 삭제되는 버그가 있습니다.


Resolves: #1105

## 📃 작업내용

https://github.com/user-attachments/assets/7dcf9531-a733-4b16-9c2f-6cd5b567d245



완료버튼을 숨기고 응답을 기다리는 동안 인디케이터를 노출합니다.

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
