### PR TITLE
🔀 :: (#1121) 네트워크 로그를 디테일/간소화 로 분기처리

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -59,7 +59,7 @@ let targets: [Target] = [
                 .release(name: .release, xcconfig: "XCConfig/Secrets.xcconfig")
             ]
         ),
-        environmentVariables: ["NETWORK_LOG_LEVEL" : "short"]
+        environmentVariables: ["NETWORK_LOG_LEVEL": "short"]
     ),
     .target(
         name: "\(env.name)Tests",

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -58,7 +58,8 @@ let targets: [Target] = [
                 .debug(name: .debug, xcconfig: "XCConfig/Secrets.xcconfig"),
                 .release(name: .release, xcconfig: "XCConfig/Secrets.xcconfig")
             ]
-        )
+        ),
+        environmentVariables: ["NETWORK_LOG_LEVEL" : "short"]
     ),
     .target(
         name: "\(env.name)Tests",

--- a/Projects/Domains/BaseDomain/Sources/Logging/CustomLoggingPlugin.swift
+++ b/Projects/Domains/BaseDomain/Sources/Logging/CustomLoggingPlugin.swift
@@ -3,7 +3,7 @@ import Moya
 import OSLog
 
 #if DEBUG
-    fileprivate enum NetworkLogLevel: String {
+    private enum NetworkLogLevel: String {
         case short
         case detail
     }

--- a/Projects/Domains/BaseDomain/Sources/Logging/CustomLoggingPlugin.swift
+++ b/Projects/Domains/BaseDomain/Sources/Logging/CustomLoggingPlugin.swift
@@ -11,11 +11,11 @@ import OSLog
     public final class CustomLoggingPlugin: PluginType {
         let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: "NETWORK")
         private let logLevel: NetworkLogLevel
-        
+
         public init() {
             self.logLevel = CustomLoggingPlugin.getLogLevelFromArguments() ?? .detail
         }
-        
+
         public func willSend(_ request: RequestType, target: TargetType) {
             guard let httpRequest = request.request else {
                 print("--> 유효하지 않은 요청")
@@ -32,7 +32,7 @@ import OSLog
                 log.append("\(bodyString)\n")
             }
             log.append("---------------- END \(method) -----------------------\n")
-        
+
             switch logLevel {
             case .short:
                 let log = "[🛜 Request] [\(method)] [\(target)] \(url)"
@@ -41,7 +41,7 @@ import OSLog
                 logger.log(level: .debug, "\(log)")
             }
         }
-        
+
         public func didReceive(_ result: Result<Response, MoyaError>, target: TargetType) {
             switch result {
             case let .success(response):
@@ -50,7 +50,7 @@ import OSLog
                 onFail(error, target: target)
             }
         }
-        
+
         func onSuceed(_ response: Response, target: TargetType, isFromError: Bool) {
             let request = response.request
             let url = request?.url?.absoluteString ?? "nil"
@@ -65,7 +65,7 @@ import OSLog
                 log.append("\(reString)\n")
             }
             log.append("------------------- END HTTP (\(response.data.count)-byte body) -------------------\n")
-            
+
             switch logLevel {
             case .short:
                 let log = "[🛜 Response] [\(statusCode)] [\(target)] \(url)"
@@ -73,9 +73,8 @@ import OSLog
             case .detail:
                 logger.log(level: .debug, "\(log)")
             }
-            
         }
-        
+
         func onFail(_ error: MoyaError, target: TargetType) {
             if let response = error.response {
                 onSuceed(response, target: target, isFromError: true)
@@ -85,7 +84,7 @@ import OSLog
             log.append("<-- \(error.errorCode) \(target)\n")
             log.append("\(error.failureReason ?? error.errorDescription ?? "unknown error")\n")
             log.append("<-- END HTTP\n")
-            
+
             logger.log("\(log)")
         }
     }

--- a/Projects/Domains/BaseDomain/Sources/Logging/CustomLoggingPlugin.swift
+++ b/Projects/Domains/BaseDomain/Sources/Logging/CustomLoggingPlugin.swift
@@ -5,7 +5,7 @@ import OSLog
 #if DEBUG
     fileprivate enum NetworkLogLevel: String {
         case short
-        case detailed
+        case detail
     }
 
     public final class CustomLoggingPlugin: PluginType {
@@ -13,7 +13,7 @@ import OSLog
         private let logLevel: NetworkLogLevel
         
         public init() {
-            self.logLevel = CustomLoggingPlugin.getLogLevelFromArguments() ?? .detailed
+            self.logLevel = CustomLoggingPlugin.getLogLevelFromArguments() ?? .detail
         }
         
         public func willSend(_ request: RequestType, target: TargetType) {
@@ -37,7 +37,7 @@ import OSLog
             case .short:
                 let log = "[🛜 Request] [\(method)] [\(target)] \(url)"
                 logger.log(level: .debug, "\(log)")
-            case .detailed:
+            case .detail:
                 logger.log(level: .debug, "\(log)")
             }
         }
@@ -70,7 +70,7 @@ import OSLog
             case .short:
                 let log = "[🛜 Response] [\(statusCode)] [\(target)] \(url)"
                 logger.log(level: .debug, "\(log)")
-            case .detailed:
+            case .detail:
                 logger.log(level: .debug, "\(log)")
             }
             
@@ -91,15 +91,12 @@ import OSLog
     }
 
     extension CustomLoggingPlugin {
-        /// Scheme Arguments에서 로그 레벨을 가져오는 함수
-        /// Arguments Passed On Launch 에 "-networkLogLevel detailed" 또는 "-networkLogLevel short" 입력
+        /// Environment Variables 에서 로그 레벨을 가져오는 함수
+        /// Environment Variables 에 key : NETWORK_LOG_LEVEL, value : shrot  또는 detail
         private static func getLogLevelFromArguments() -> NetworkLogLevel? {
-            let arguments = ProcessInfo.processInfo.arguments
-            if let logLevelIndex = arguments.firstIndex(of: "-networkLogLevel"), logLevelIndex + 1 < arguments.count {
-                let logLevelValue = arguments[logLevelIndex + 1]
-                return NetworkLogLevel(rawValue: logLevelValue)
-            }
-            return nil
+            guard let logLevelValue = ProcessInfo.processInfo.environment["NETWORK_LOG_LEVEL"] else { return nil }
+            guard let networkLogLevel = NetworkLogLevel(rawValue: logLevelValue) else { return nil }
+            return networkLogLevel
         }
     }
 

--- a/Projects/Domains/BaseDomain/Sources/Logging/CustomLoggingPlugin.swift
+++ b/Projects/Domains/BaseDomain/Sources/Logging/CustomLoggingPlugin.swift
@@ -93,11 +93,11 @@ import OSLog
     extension CustomLoggingPlugin {
         /// Scheme Arguments에서 로그 레벨을 가져오는 함수
         /// Arguments Passed On Launch 에 "-networkLogLevel detailed" 또는 "-networkLogLevel short" 입력
-        private static func getLogLevelFromArguments() -> LogLevel? {
+        private static func getLogLevelFromArguments() -> NetworkLogLevel? {
             let arguments = ProcessInfo.processInfo.arguments
             if let logLevelIndex = arguments.firstIndex(of: "-networkLogLevel"), logLevelIndex + 1 < arguments.count {
                 let logLevelValue = arguments[logLevelIndex + 1]
-                return LogLevel(rawValue: logLevelValue)
+                return NetworkLogLevel(rawValue: logLevelValue)
             }
             return nil
         }

--- a/Projects/Domains/BaseDomain/Sources/Logging/CustomLoggingPlugin.swift
+++ b/Projects/Domains/BaseDomain/Sources/Logging/CustomLoggingPlugin.swift
@@ -91,7 +91,7 @@ import OSLog
 
     extension CustomLoggingPlugin {
         /// Environment Variables 에서 로그 레벨을 가져오는 메소드
-        /// Environment Variables 에 key : NETWORK_LOG_LEVEL, value : shrot  또는 detail
+        /// Scheme의 Environment Variables 에 key : NETWORK_LOG_LEVEL, value : short 또는 detail
         private static func getLogLevelFromArguments() -> NetworkLogLevel? {
             guard let logLevelValue = ProcessInfo.processInfo.environment["NETWORK_LOG_LEVEL"] else { return nil }
             guard let networkLogLevel = NetworkLogLevel(rawValue: logLevelValue) else { return nil }

--- a/Projects/Domains/BaseDomain/Sources/Logging/CustomLoggingPlugin.swift
+++ b/Projects/Domains/BaseDomain/Sources/Logging/CustomLoggingPlugin.swift
@@ -91,7 +91,7 @@ import OSLog
     }
 
     extension CustomLoggingPlugin {
-        /// Environment Variables 에서 로그 레벨을 가져오는 함수
+        /// Environment Variables 에서 로그 레벨을 가져오는 메소드
         /// Environment Variables 에 key : NETWORK_LOG_LEVEL, value : shrot  또는 detail
         private static func getLogLevelFromArguments() -> NetworkLogLevel? {
             guard let logLevelValue = ProcessInfo.processInfo.environment["NETWORK_LOG_LEVEL"] else { return nil }


### PR DESCRIPTION
## 💡 배경 및 개요

네트워크 로그가 길기 때문에 콘솔 창이 복잡해지고, 원하는 로그를 찾으려면 스크롤을 한참 올려야하는 문제가 있어요.

로그를 자세히 보고 싶을때 도 있고, 로그를 간소화하여 콘솔창을 간결하게 보고 싶을 때도 있을테니 선택해서 볼 수 있게 개선하면 좋을 것 같아요

Resolves: #1121

## 📃 작업내용

<img width="924" alt="image" src="https://github.com/user-attachments/assets/1e590291-fa47-4dab-a900-71769a2c476b">

Scheme 의 환경 변수를 통해 네트워크 로그를 기존처럼 detail로 볼건지, short으로 볼건지를 분기하도록 했습니다.

tuist 세팅을 통해 앱 스킴에 기본값으로 short으로 설정해두었습니다.

### 사용 방법
Scheme - Environment Values 에 `NETWORK_LOG_LEVEL: short` 또는 `NETWORK_LOG_LEVEL: detail` 입력


## 🙋‍♂️ 리뷰노트

### detailed (기존과 같음)

![image](https://github.com/user-attachments/assets/4263ff89-13b1-4fad-85ca-d3a97f14c823)


### short 

![image](https://github.com/user-attachments/assets/96fb0981-8023-4ffd-8e05-286bfbcb8bd5)

short 양식 추천받습니다


## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
