### PR TITLE
🔀 :: (#1123) PR merge시 연관 이슈 자동 close가 동작하지 않는 이슈

### DIFF
--- a/.github/workflows/AutoCloseIssueByPullRequest.yml
+++ b/.github/workflows/AutoCloseIssueByPullRequest.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches-ignore: ["develop"]
     types: [closed]
-    paths:
-      - "**/*.swift"
 
 jobs:
   close-issue:

--- a/.github/workflows/AutoCloseIssueByPullRequest.yml
+++ b/.github/workflows/AutoCloseIssueByPullRequest.yml
@@ -1,7 +1,7 @@
 name: Auto close issue when PR is merged
 
 on:
-  pull_request_target:
+  pull_request:
     branches-ignore: ["develop"]
     types: [closed]
     paths:


### PR DESCRIPTION
## 💡 배경 및 개요
PR merge시 연관 이슈 자동 close가 동작하지 않는 이슈

Resolves: #1123 

## 📃 작업내용

PR merge시 연관 이슈 자동 close가 동작하지 않는 이슈

## ✅ PR 체크리스트


- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
