### PR TITLE
🔀 :: (#1129) 음악 상세 노래방 번호 표시가 안되는 이슈 해결

### DIFF
--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
@@ -212,7 +212,13 @@ private extension ArtistMusicContentViewController {
 
 extension ArtistMusicContentViewController: ArtistMusicCellDelegate {
     func tappedThumbnail(id: String) {
-        songDetailPresenter.present(id: id)
+        if let presentingViewController = self.presentingViewController {
+            presentingViewController.dismiss(animated: true) { [songDetailPresenter] () in
+                songDetailPresenter?.present(id: id)
+            }
+        } else {
+            songDetailPresenter.present(id: id)
+        }
     }
 }
 

--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
@@ -212,13 +212,7 @@ private extension ArtistMusicContentViewController {
 
 extension ArtistMusicContentViewController: ArtistMusicCellDelegate {
     func tappedThumbnail(id: String) {
-        if let presentingViewController = self.presentingViewController {
-            presentingViewController.dismiss(animated: true) { [songDetailPresenter] () in
-                songDetailPresenter?.present(id: id)
-            }
-        } else {
-            songDetailPresenter.present(id: id)
-        }
+        songDetailPresenter.present(id: id)
     }
 }
 

--- a/Projects/Features/MusicDetailFeature/Demo/Sources/AppDelegate.swift
+++ b/Projects/Features/MusicDetailFeature/Demo/Sources/AppDelegate.swift
@@ -5,6 +5,7 @@ import LikeDomainInterface
 import LikeDomainTesting
 import LyricHighlightingFeatureInterface
 @testable import MusicDetailFeature
+import MusicDetailFeatureInterface
 import RxSwift
 import SignInFeatureInterface
 import SongCreditFeatureInterface
@@ -68,6 +69,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
                     signInFactory: DummySignInFactory(),
                     containSongsFactory: DummyContainSongsFactory(),
                     textPopupFactory: DummyTextPopupFactory(),
+                    karaokeFactory: DummyKaraokeFactory(),
                     playlistPresenterGlobalState: DummyPlaylistPresenterGlobalState()
                 )
             )
@@ -119,4 +121,10 @@ final class DummyTextPopupFactory: TextPopUpFactory {
 final class DummyPlaylistPresenterGlobalState: PlayListPresenterGlobalStateProtocol {
     var presentPlayListObservable: RxSwift.Observable<Void> { .empty() }
     func presentPlayList() {}
+}
+
+final class DummyKaraokeFactory: KaraokeFactory {
+    func makeViewController(ky: Int?, tj: Int?) -> UIViewController {
+        UIViewController()
+    }
 }

--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/Component/MusicDetailComponent.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/Component/MusicDetailComponent.swift
@@ -15,6 +15,7 @@ public protocol MusicDetailDependency: Dependency {
     var songCreditFactory: any SongCreditFactory { get }
     var signInFactory: any SignInFactory { get }
     var containSongsFactory: any ContainSongsFactory { get }
+    var karaokeFactory: any KaraokeFactory { get }
     var textPopUpFactory: any TextPopUpFactory { get }
     var playlistPresenterGlobalState: any PlayListPresenterGlobalStateProtocol { get }
     var addLikeSongUseCase: any AddLikeSongUseCase { get }
@@ -38,6 +39,7 @@ public final class MusicDetailComponent: Component<MusicDetailDependency>, Music
             signInFactory: dependency.signInFactory,
             containSongsFactory: dependency.containSongsFactory,
             textPopupFactory: dependency.textPopUpFactory,
+            karaokeFactory: dependency.karaokeFactory,
             playlistPresenterGlobalState: dependency.playlistPresenterGlobalState
         )
 

--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/Model/SongModel.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/Model/SongModel.swift
@@ -43,7 +43,7 @@ extension SongDetailEntity {
             isLiked: self.isLiked,
             karaokeNumber: SongModel.KaraokeNumber(
                 tj: self.karaokeNumber.tj,
-                ky: self.karaokeNumber.tj
+                ky: self.karaokeNumber.ky
             )
         )
     }

--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailReactor.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailReactor.swift
@@ -43,6 +43,7 @@ final class MusicDetailReactor: Reactor {
         case dismiss
         case textPopup(text: String, completion: () -> Void)
         case signin
+        case karaoke(ky: Int?, tj: Int?)
     }
 
     struct State {
@@ -234,7 +235,7 @@ private extension MusicDetailReactor {
         guard let song = currentState.selectedSong, !song.videoID.isEmpty else { return .empty() }
         let log = Log.clickSingingRoomButton(id: song.videoID)
         LogManager.analytics(log)
-        return .empty()
+        return navigateMutation(navigate: .karaoke(ky: song.karaokeNumber.ky, tj: song.karaokeNumber.tj))
     }
 
     func lyricsButtonDidTap() -> Observable<Mutation> {

--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailViewController.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailViewController.swift
@@ -3,6 +3,7 @@ import BaseFeatureInterface
 import DesignSystem
 import LogManager
 import LyricHighlightingFeatureInterface
+import MusicDetailFeatureInterface
 import RxSwift
 import SignInFeatureInterface
 import SnapKit
@@ -18,6 +19,7 @@ final class MusicDetailViewController: BaseReactorViewController<MusicDetailReac
     private let signInFactory: any SignInFactory
     private let containSongsFactory: any ContainSongsFactory
     private let textPopupFactory: any TextPopUpFactory
+    private let karaokeFactory: any KaraokeFactory
     private let playlistPresenterGlobalState: any PlayListPresenterGlobalStateProtocol
 
     init(
@@ -27,6 +29,7 @@ final class MusicDetailViewController: BaseReactorViewController<MusicDetailReac
         signInFactory: any SignInFactory,
         containSongsFactory: any ContainSongsFactory,
         textPopupFactory: any TextPopUpFactory,
+        karaokeFactory: any KaraokeFactory,
         playlistPresenterGlobalState: any PlayListPresenterGlobalStateProtocol
     ) {
         self.lyricHighlightingFactory = lyricHighlightingFactory
@@ -34,6 +37,7 @@ final class MusicDetailViewController: BaseReactorViewController<MusicDetailReac
         self.signInFactory = signInFactory
         self.containSongsFactory = containSongsFactory
         self.textPopupFactory = textPopupFactory
+        self.karaokeFactory = karaokeFactory
         self.playlistPresenterGlobalState = playlistPresenterGlobalState
         super.init(reactor: reactor)
     }
@@ -90,6 +94,9 @@ final class MusicDetailViewController: BaseReactorViewController<MusicDetailReac
                 owner.musicDetailView.updateArtist(artist: song.artistString)
                 owner.musicDetailView.updateViews(views: song.views)
                 owner.musicDetailView.updateIsLike(likes: song.likes, isLike: song.isLiked)
+
+                let isEnabled = song.karaokeNumber.ky != nil || song.karaokeNumber.tj != nil
+                owner.musicDetailView.updateIsDisabledSingingRoom(isDisabled: !isEnabled)
             }
             .disposed(by: disposeBag)
 
@@ -139,6 +146,8 @@ final class MusicDetailViewController: BaseReactorViewController<MusicDetailReac
                     owner.presentTextPopup(text: text, completion: completion)
                 case .signin:
                     owner.presentSignIn()
+                case let .karaoke(ky, tj):
+                    owner.presentKaraokeSheet(ky: ky, tj: tj)
                 case .dismiss:
                     owner.dismiss()
                 }
@@ -250,6 +259,11 @@ private extension MusicDetailViewController {
             completion: completion,
             cancelCompletion: nil
         )
+        self.showBottomSheet(content: viewController)
+    }
+
+    func presentKaraokeSheet(ky: Int?, tj: Int?) {
+        let viewController = karaokeFactory.makeViewController(ky: ky, tj: tj)
         self.showBottomSheet(content: viewController)
     }
 


### PR DESCRIPTION
## 💡 배경 및 개요

<img src="https://github.com/user-attachments/assets/5795abbb-1214-4b2f-b092-701bc1308507" width="150" />

<!-- resolved issue 넘버 표기 방식 변경 시 '.github/actions/Auto_close_associate_issue/main.js' 또한 변경 필요 -->

- 음악 상세 노래방 번호 표시가 안되는 이슈 해결
  - 놀랍게도 상태를 바인딩 시켜놓지 않았어요
  - 금영, 태진이 모두 태진으로만 표시되는 이슈도 있었어요

Resolves: #1129 

## 📃 작업내용

- 음악 상세 노래방 번호 표시가 안되는 이슈 해결

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
