### PR TITLE
🔀 :: (#1139) 회원탈퇴 버튼에서 '여기' 텍스트 이외에도 탈퇴 동작이 이루어짐

### DIFF
--- a/Projects/Features/BaseFeature/Interface/TextPopUp/TextPopUpFactory.swift
+++ b/Projects/Features/BaseFeature/Interface/TextPopUp/TextPopUpFactory.swift
@@ -10,3 +10,23 @@ public protocol TextPopUpFactory {
         cancelCompletion: (() -> Void)?
     ) -> UIViewController
 }
+
+public extension TextPopUpFactory {
+    func makeView(
+        text: String? = nil,
+        cancelButtonIsHidden: Bool = false,
+        confirmButtonText: String? = nil,
+        cancelButtonText: String? = nil,
+        completion: (() -> Void)? = nil,
+        cancelCompletion: (() -> Void)? = nil
+    ) -> UIViewController {
+        self.makeView(
+            text: text,
+            cancelButtonIsHidden: cancelButtonIsHidden,
+            confirmButtonText: confirmButtonText,
+            cancelButtonText: cancelButtonText,
+            completion: completion,
+            cancelCompletion: cancelCompletion
+        )
+    }
+}

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/Setting/SettingViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/Setting/SettingViewController.swift
@@ -132,30 +132,23 @@ final class SettingViewController: BaseReactorViewController<SettingReactor> {
         reactor.pulse(\.$withDrawButtonDidTap)
             .compactMap { $0 }
             .bind(with: self, onNext: { owner, _ in
-                guard let secondConfirmVC = owner.textPopUpFactory.makeView(
-                    text: "정말 탈퇴하시겠습니까?",
-                    cancelButtonIsHidden: false,
-                    confirmButtonText: nil,
-                    cancelButtonText: nil,
-                    completion: {
-                        owner.reactor?.action.onNext(.confirmWithDrawButtonDidTap)
-                    },
-                    cancelCompletion: nil
-                ) as? TextPopupViewController else {
-                    return
+                let makeSecondConfirmVC: () -> UIViewController = {
+                    owner.textPopUpFactory.makeView(
+                        text: "정말 탈퇴하시겠습니까?",
+                        cancelButtonIsHidden: false,
+                        completion: {
+                            owner.reactor?.action.onNext(.confirmWithDrawButtonDidTap)
+                        }
+                    )
                 }
-                guard let firstConfirmVC = owner.textPopUpFactory.makeView(
+                let firstConfirmVC = owner.textPopUpFactory.makeView(
                     text: "회원탈퇴 신청을 하시겠습니까?",
                     cancelButtonIsHidden: false,
-                    confirmButtonText: nil,
-                    cancelButtonText: nil,
                     completion: {
+                        let secondConfirmVC = makeSecondConfirmVC()
                         owner.showBottomSheet(content: secondConfirmVC)
-                    },
-                    cancelCompletion: nil
-                ) as? TextPopupViewController else {
-                    return
-                }
+                    }
+                )
                 owner.showBottomSheet(content: firstConfirmVC)
             })
             .disposed(by: disposeBag)

--- a/Projects/Features/MyInfoFeature/Sources/Views/WithDrawLabel.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/WithDrawLabel.swift
@@ -1,6 +1,7 @@
 import DesignSystem
 import RxCocoa
 import RxSwift
+import RxGesture
 import UIKit
 
 private protocol WithDrawLabelActionProtocol {
@@ -8,23 +9,19 @@ private protocol WithDrawLabelActionProtocol {
 }
 
 final class WithDrawLabel: UILabel {
-    private let target = "여기"
+    private let targetText: String
+    fileprivate let didTapSubject = PublishSubject<Void>()
+    private let disposeBag = DisposeBag()
 
-    init(_ text: String = "회원 탈퇴를 원하신다면 여기를 눌러주세요.") {
+    init(text: String = "회원 탈퇴를 원하신다면 여기를 눌러주세요.", targetText: String = "여기") {
+        self.targetText = targetText
         super.init(frame: .zero)
         self.text = text
-        configure()
-    }
 
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-    }
-
-    func configure() {
         guard let text = self.text else { return }
         let attrStr = NSMutableAttributedString(string: text)
         let fullRange = NSRange(location: 0, length: attrStr.length)
-        let targetRange = (text as NSString).range(of: target)
+        let targetRange = (text as NSString).range(of: targetText)
         let color = DesignSystemAsset.BlueGrayColor.blueGray500.color
         let font = UIFont.setFont(.t7(weight: .light))
         attrStr.addAttribute(.foregroundColor, value: color, range: fullRange)
@@ -33,14 +30,51 @@ final class WithDrawLabel: UILabel {
         attrStr.addAttribute(.underlineStyle, value: 1, range: targetRange)
 
         self.attributedText = attrStr
+        registerGesture()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func registerGesture() {
+        self.isUserInteractionEnabled = true
+        self.rx.tapGesture()
+            .when(.recognized)
+            .filter { [weak self] gesture in
+                guard let self = self else { return false }
+                let location = gesture.location(in: self)
+                return self.isTargetTapped(at: location)
+            }
+            .map { _ in () }
+            .bind(to: didTapSubject)
+            .disposed(by: disposeBag)
+    }
+
+    private func isTargetTapped(at point: CGPoint) -> Bool {
+        guard let attributedText = attributedText else { return false }
+        
+        let textStorage = NSTextStorage(attributedString: attributedText)
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        
+        let textContainer = NSTextContainer(size: bounds.size)
+        textContainer.lineFragmentPadding = 0
+        layoutManager.addTextContainer(textContainer)
+        
+        let index = layoutManager.characterIndex(
+            for: point,
+            in: textContainer,
+            fractionOfDistanceBetweenInsertionPoints: nil
+        )
+        let targetRange = (text as NSString?)?.range(of: targetText) ?? NSRange(location: 0, length: 0)
+        return NSLocationInRange(index, targetRange)
     }
 }
 
-extension Reactive: WithDrawLabelActionProtocol where Base: WithDrawLabel {
+extension Reactive where Base: WithDrawLabel {
     var didTap: Observable<Void> {
-        let tapGestureRecognizer = UITapGestureRecognizer()
-        base.addGestureRecognizer(tapGestureRecognizer)
-        base.isUserInteractionEnabled = true
-        return tapGestureRecognizer.rx.event.map { _ in }.asObservable()
+        return base.didTapSubject.asObservable()
     }
 }

--- a/Projects/Features/MyInfoFeature/Sources/Views/WithDrawLabel.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/WithDrawLabel.swift
@@ -1,7 +1,7 @@
 import DesignSystem
 import RxCocoa
-import RxSwift
 import RxGesture
+import RxSwift
 import UIKit
 
 private protocol WithDrawLabelActionProtocol {
@@ -54,15 +54,15 @@ final class WithDrawLabel: UILabel {
 
     private func isTargetTapped(at point: CGPoint) -> Bool {
         guard let attributedText = attributedText else { return false }
-        
+
         let textStorage = NSTextStorage(attributedString: attributedText)
         let layoutManager = NSLayoutManager()
         textStorage.addLayoutManager(layoutManager)
-        
+
         let textContainer = NSTextContainer(size: bounds.size)
         textContainer.lineFragmentPadding = 0
         layoutManager.addTextContainer(textContainer)
-        
+
         let index = layoutManager.characterIndex(
             for: point,
             in: textContainer,


### PR DESCRIPTION
## 💡 배경 및 개요

<!--
> PR을 하게 된 문제상황, 배경 등 개요에 대해서 작성해주세요!
>
> 퍼블리싱의 경우 스크린샷/동영상도 추가해주면 좋아요!
-->

<!-- resolved issue 넘버 표기 방식 변경 시 '.github/actions/Auto_close_associate_issue/main.js' 또한 변경 필요 -->

회원탈퇴 버튼에서 '여기' 텍스트 이외에도 탈퇴 동작이 이루어짐

Resolves: #1139

## 📃 작업내용

<!--
> PR에서 한 작업을 자세히 작성해주세요!
-->

- 회원탈퇴 버튼에서 '여기' 텍스트를 눌렀을 때만 회원탈퇴 프로세스 시작
- 회원탈퇴 프로세스를 시작할 때 textPopupViewController를 두개를 미리 만들어서 하고있었으나, 더블체크 단계의 ViewController를 lazy하게 생성하도록 리팩토링
- TextPopupViewController Factory에 기본 파라미터 지정

## 🙋‍♂️ 리뷰노트

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
