### PR TITLE
🔀 :: (#950) 좋아요 로직 고도화

### DIFF
--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailReactor.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailReactor.swift
@@ -165,6 +165,17 @@ final class MusicDetailReactor: Reactor {
         return Observable.merge(mutation, signInIsRequired, likeRequestObservable)
     }
 
+    /// 좋아요 요청을 처리하고 대기 중인 요청이 있다면 연속적으로 처리해요.
+    ///
+    /// 이 함수는 주어진 좋아요 요청을 처리하고, 해당 요청의 처리가 완료된 후 대기 중인 다른 요청이 있는지 확인해요.
+    /// 대기 중인 요청이 있다면 해당 요청도 처리합니다.
+    ///
+    /// - Parameters:
+    ///   - request: 처리할 좋아요 요청
+    ///
+    /// - Returns: 처리 결과에 따른 Mutation Observable 스트림
+    ///
+    /// - Note: 이 함수는 에러 발생 시 로그를 출력하고 빈 Observable을 반환해요.
     private func handleLikeRequest(_ request: LikeRequest) -> Observable<Mutation> {
         let useCase: (_ id: String) -> Observable<Void> = request.isLiked
             ? { [addLikeSongUseCase] id in
@@ -199,6 +210,15 @@ final class MusicDetailReactor: Reactor {
             }
     }
 
+    /// 다음으로 처리할 대기 중인 좋아요 요청을 반환해요.
+    ///
+    /// 이 함수는 현재 처리 중인 곡의 ID에 해당하는 대기 중인 요청이 있는지 먼저 확인해요.
+    /// 만약 있다면, 해당 요청의 상태가 최신 상태와 다를 경우에만 반환해요.
+    /// 현재 곡의 대기 중인 요청이 없거나 상태가 같다면, 다른 곡의 대기 중인 요청 중 첫 번째 요청을 반환해요.
+    ///
+    /// - Returns: 다음으로 처리할 `LikeRequest` 객체. 처리할 마땅한 요청이 없다면 `nil`을 반환
+    ///
+    /// - Note: 이 함수는 대기 중인 요청들의 우선순위에 따라 반환됩니다.
     private func getNextPendingRequest() -> LikeRequest? {
         if let currentSongID = currentLikeRequestSongID,
            let nextPendingRequest = pendingLikeRequests[currentSongID] {

--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailViewController.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailViewController.swift
@@ -199,7 +199,6 @@ final class MusicDetailViewController: BaseReactorViewController<MusicDetailReac
             .disposed(by: disposeBag)
 
         musicDetailView.rx.likeButtonDidTap
-            .throttle(.seconds(1), latest: false, scheduler: MainScheduler.asyncInstance)
             .map { Reactor.Action.likeButtonDidTap }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)


### PR DESCRIPTION
## 💡 배경 및 개요
- 노래 상세에서 좋아요를 할 때 내부 로직을 고도화했어요.

Resolves: #950 

## 📃 작업내용
- 노래 상세에서 좋아요를 할 때 내부 로직을 고도화했어요.

요청이 닿기 전에 다른 좋아요 요청이 왔을 떄의 처리를 했어요.
- 좋아요 요청을 보내고, 요청이 끝나면 마지막으로 온 요청의 좋아요 여부를 확인해 마지막의 요청이 끝난 좋아요와 다르다면 새로운 요청, 만약 같다면 요청 안보냄
- 좋아요 요청을 보내고 요청이 끝나기 전에 다른 음악의 좋아요를 한다면 다른 음악의 좋아요 로직을 먼저 처리함 (현재 화면에 보여지는 노래의 좋아요를 먼저 처리함)

## 🙋‍♂️ 리뷰노트

시나리오
1. 좋아요 클릭
좋아요 요청

2. 좋아요 클릭 -> 좋아요 클릭
좋아요 요청 -> 좋아요 취소 요청 (좋아요 요청 완료 이후)

3. 좋아요 클릭 -> 좋아요 클릭 -> 좋아요 클릭
좋아요 요청 (취소 요청 보내지 않음)

4. A노래 좋아요 클릭 -> B노래로 이동 -> B노래 좋아요 클릭
A노래 좋아요 요청 -> B노래 좋아요 요청

5. A노래 좋아요 클릭 -> A노래 좋아요 취소 클릭 -> B노래로 이동 -> B노래 좋아요 클릭
- (A노래 좋아요 요청이 끝나지 않은 상태에서 좋아요 취소 클릭과 B노래 좋아요를 클릭했을 때)
A노래 좋아요 요청 -> B노래 좋아요 요청 -> A노래 좋아요 취소 요청

- (A노래 좋아요 요청이 끝난 상태에서 좋아요 취소 클릭 후 B노래 좋아요를 클릭했을 때)
A노래 좋아요 요청 -> A노래 좋아요 취소 요청->  B노래 좋아요 요청

6. A노래 좋아요 클릭 -> A노래 좋아요 클릭 -> B노래로 이동 -> B노래 좋아요 클릭 -> B노래 좋아요 클릭 
A노래 좋아요 요청 -> B노래 좋아요 요청 -> B노래 좋아요 취소 요청 -> A노래 좋아요 취소 요청

7. A노래 좋아요 클릭 -> A노래 좋아요 클릭 -> B노래로 이동 -> B노래 좋아요 클릭 -> B노래 좋아요 클릭 -> B노래 좋아요 클릭
A노래 좋아요 요청 -> B노래 좋아요 요청 -> A노래 좋아요 취소 요청

8. A노래 좋아요 클릭 -> B노래 좋아요 클릭 -> C노래 좋아요 클릭
- (만약 A노래 좋아요 요청이 끝나지 않은 상태에서 C노래 좋아요 클릭했을 시)
 A노래 좋아요 요청 -> C노래 좋아요 요청 -> B노래 좋아요 요총

- (만약 A노래 좋아요 요청이 끝나지 않은 상태에서 B노래 좋아요 클릭하고 B노래 요청 중 C노래 좋아요 클릭했을 시)
A노래 좋아요 요청 -> B노래 좋아요 요청 -> C노래 좋아요 요청

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
