### PR TITLE
🔀 :: (#1148) 검색 결과 로딩 중  필터나 정렬을 누를 때 앱이 터지는 버그

### DIFF
--- a/Projects/Features/SearchFeature/Sources/After/Reactors/ListSearchResultReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/After/Reactors/ListSearchResultReactor.swift
@@ -81,17 +81,16 @@ extension ListSearchResultReactor {
     private func updateSortType(_ type: SortType) -> Observable<Mutation> {
         return .concat([
             .just(.updateSortType(type)),
-            updateDataSource(order: type, text: self.text, scrollPage: 1, byOption: true)
+            updateDataSource(order: type, text: self.text, scrollPage: 1)
         ])
     }
 
     private func updateDataSource(
         order: SortType,
         text: String,
-        scrollPage: Int,
-        byOption: Bool = false // 필터또는 옵션으로 리프래쉬 하나 , 아니면 스크롤이냐
+        scrollPage: Int
     ) -> Observable<Mutation> {
-        let prev: [SearchPlaylistEntity] = byOption ? [] : self.currentState.dataSource
+        let prev: [SearchPlaylistEntity] = scrollPage == 1 ? [] : self.currentState.dataSource
 
         return .concat([
             .just(Mutation.updateLoadingState(true)),

--- a/Projects/Features/SearchFeature/Sources/After/Reactors/SongSearchResultReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/After/Reactors/SongSearchResultReactor.swift
@@ -118,18 +118,17 @@ final class SongSearchResultReactor: Reactor {
     }
 
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
-
         let flatMapMutation = subject
             .withUnretained(self)
             .flatMap { owner, subjectMutation -> Observable<Mutation> in
-            return .concat([
-                .just(subjectMutation),
-                .just(Mutation.updateScrollPage(owner.currentState.scrollPage+1)),
-                .just(Mutation.updateLoadingState(false))
-            ])
-        }
+                return .concat([
+                    .just(subjectMutation),
+                    .just(Mutation.updateScrollPage(owner.currentState.scrollPage + 1)),
+                    .just(Mutation.updateLoadingState(false))
+                ])
+            }
 
-        return Observable.merge(mutation,flatMapMutation)
+        return Observable.merge(mutation, flatMapMutation)
     }
 }
 
@@ -161,7 +160,6 @@ extension SongSearchResultReactor {
         scrollPage: Int
     ) -> Observable<Mutation> {
         requestDisposeBag = DisposeBag() // 기존 작업 캔슬
-        
 
         fetchSearchSongsUseCase
             .execute(order: order, filter: filter, text: text, page: scrollPage, limit: limit)

--- a/Projects/Features/SearchFeature/Sources/After/Reactors/SongSearchResultReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/After/Reactors/SongSearchResultReactor.swift
@@ -1,9 +1,9 @@
 import Localization
 import LogManager
 import ReactorKit
+import RxSwift
 import SearchDomainInterface
 import SongsDomainInterface
-import RxSwift
 
 final class SongSearchResultReactor: Reactor {
     enum Action {
@@ -44,7 +44,7 @@ final class SongSearchResultReactor: Reactor {
     private let limit: Int = 20
     private var requestDisposeBag = DisposeBag()
     private let subject = PublishSubject<Mutation>()
-    
+
     init(text: String, fetchSearchSongsUseCase: any FetchSearchSongsUseCase) {
         self.initialState = State(
             isLoading: true,
@@ -115,29 +115,24 @@ final class SongSearchResultReactor: Reactor {
 
         return newState
     }
-    
-    func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
 
-        
+    func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
 //        let currentState = currentState
 //        let scrollPage = currentState.scrollPage
-        
+
 //        let finishTask =  Observable.concat([
 //            Observable.just(Mutation.updateScrollPage(scrollPage + 1)),
 //            Observable.just(.updateLoadingState(false))
-//        
+//
 //        ])
-        
-        let subjectMutation =  subject.asObservable()
-        
-       
-            
+
+        let subjectMutation = subject.asObservable()
+
         return Observable.merge(mutation, subjectMutation)
     }
 }
 
 extension SongSearchResultReactor {
-    
     private func updateSortType(_ type: SortType) -> Observable<Mutation> {
         let state = self.currentState
 
@@ -164,7 +159,6 @@ extension SongSearchResultReactor {
         text: String,
         scrollPage: Int
     ) -> Observable<Mutation> {
-        
         requestDisposeBag = DisposeBag() // 기존 작업 캔슬
 
         fetchSearchSongsUseCase
@@ -194,12 +188,8 @@ extension SongSearchResultReactor {
             .bind(to: subject)
             .disposed(by: requestDisposeBag)
 
-        
-        
         return Observable.just(.updateLoadingState(false))
     }
-    
-
 
     func updateItemSelected(_ index: Int) -> Observable<Mutation> {
         let state = currentState

--- a/Projects/Features/SearchFeature/Sources/After/Reactors/SongSearchResultReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/After/Reactors/SongSearchResultReactor.swift
@@ -2,6 +2,7 @@ import Localization
 import LogManager
 import ReactorKit
 import RxSwift
+import RxCocoa
 import SearchDomainInterface
 import SongsDomainInterface
 
@@ -185,7 +186,9 @@ extension SongSearchResultReactor {
                     Mutation.showToast(wmErorr.errorDescription ?? LocalizationStrings.unknownErrorWarning)
                 )
             }
-            .bind(to: subject)
+            .bind(with: subject, onNext: { subject, mutation in
+                subject.onNext(mutation)
+            })
             .disposed(by: requestDisposeBag)
 
         return Observable.just(.updateLoadingState(false))

--- a/Projects/Features/SearchFeature/Sources/After/Reactors/SongSearchResultReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/After/Reactors/SongSearchResultReactor.swift
@@ -121,7 +121,7 @@ extension SongSearchResultReactor {
         return .concat([
             .just(.updateSelectedCount(0)),
             .just(.updateSortType(type)),
-            updateDataSource(order: type, filter: state.filterType, text: self.text, scrollPage: 1, byOption: true)
+            updateDataSource(order: type, filter: state.filterType, text: self.text, scrollPage: 1)
         ])
     }
 
@@ -131,7 +131,7 @@ extension SongSearchResultReactor {
         return .concat([
             .just(.updateSelectedCount(0)),
             .just(.updateFilterType(type)),
-            updateDataSource(order: state.sortType, filter: type, text: self.text, scrollPage: 1, byOption: true)
+            updateDataSource(order: state.sortType, filter: type, text: self.text, scrollPage: 1)
         ])
     }
 
@@ -139,8 +139,7 @@ extension SongSearchResultReactor {
         order: SortType,
         filter: FilterType,
         text: String,
-        scrollPage: Int,
-        byOption: Bool = false // 필터또는 옵션으로 리프래쉬 하나 , 아니면 스크롤이냐
+        scrollPage: Int
     ) -> Observable<Mutation> {
         return .concat([
             .just(.updateLoadingState(true)),
@@ -151,7 +150,7 @@ extension SongSearchResultReactor {
 
                     guard let self else { return .updateDataSource(dataSource: [], canLoad: false) }
 
-                    let prev: [SongEntity] = byOption ? [] : self.currentState.dataSource
+                    let prev: [SongEntity] = scrollPage == 1 ? [] : self.currentState.dataSource
 
                     if scrollPage == 1 {
                         LogManager.analytics(SearchAnalyticsLog.viewSearchResult(

--- a/Projects/Features/SearchFeature/Sources/After/Reactors/SongSearchResultReactor.swift
+++ b/Projects/Features/SearchFeature/Sources/After/Reactors/SongSearchResultReactor.swift
@@ -1,8 +1,8 @@
 import Localization
 import LogManager
 import ReactorKit
-import RxSwift
 import RxCocoa
+import RxSwift
 import SearchDomainInterface
 import SongsDomainInterface
 

--- a/Projects/Features/SearchFeature/Sources/After/ViewControllers/ListSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/After/ViewControllers/ListSearchResultViewController.swift
@@ -24,7 +24,7 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
 
     private lazy var collectionView: UICollectionView = createCollectionView().then {
         $0.backgroundColor = DesignSystemAsset.BlueGrayColor.gray100.color
-        $0.isHidden = true 
+        $0.isHidden = true
     }
 
     private lazy var headerView: SearchOptionHeaderView = SearchOptionHeaderView(false)
@@ -121,7 +121,7 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
                 owner.headerView.updateSortState(type)
             }
             .disposed(by: disposeBag)
-        
+
         sharedState.map(\.isLoading)
             .bind(with: self) { owner, isLoading in
 
@@ -153,7 +153,6 @@ final class ListSearchResultViewController: BaseReactorViewController<ListSearch
                 } else {
                     owner.collectionView.restore()
                 }
-                
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/SearchFeature/Sources/After/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/After/ViewControllers/SongSearchResultViewController.swift
@@ -170,8 +170,8 @@ final class SongSearchResultViewController: BaseReactorViewController<SongSearch
             .disposed(by: disposeBag)
 
         sharedState.map { $0.dataSource }
+            .distinctUntilChanged()
             .bind(with: self) { owner, dataSource in
-
                 var snapshot = NSDiffableDataSourceSnapshot<SongSearchResultSection, SongEntity>()
 
                 snapshot.appendSections([.song])

--- a/Projects/Features/SearchFeature/Sources/Before/ViewControllers/BeforeSearchContentViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/Before/ViewControllers/BeforeSearchContentViewController.swift
@@ -355,6 +355,6 @@ extension BeforeSearchContentViewController: BeforeSearchSectionHeaderViewDelega
 
 extension BeforeSearchContentViewController {
     func scrollToTop() {
-        tableView.setContentOffset(.zero, animated: true)
+        collectionView.scroll(to: .top)
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요

검색 결과가 append되면서 같은 id를 갖는 데이터들이 중복되는 버그가 있습니다.

<!-- resolved issue 넘버 표기 방식 변경 시 '.github/actions/Auto_close_associate_issue/main.js' 또한 변경 필요 -->

Resolves: #1148
Resolves: #1163 

## 📃 작업내용

scrollPage가 1일 때는 비어있는 배열로 데이터를 처리했습니다.


## 🙋‍♂️ 리뷰노트

<!--
> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!
-->

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
