### PR TITLE
🔀 :: [#1150] 보관함 탭 로그 추가

### DIFF
--- a/Projects/Features/BaseFeature/Sources/Analytics/ContainSongsAnalyticsLog.swift
+++ b/Projects/Features/BaseFeature/Sources/Analytics/ContainSongsAnalyticsLog.swift
@@ -1,0 +1,13 @@
+import LogManager
+
+enum ContainSongsAnalyticsLog: AnalyticsLogType {
+    case clickCreatePlaylistButton(location: CreatePlaylistLocation)
+}
+
+enum CreatePlaylistLocation: String, CustomStringConvertible {
+    case addMusics = "add-musics"
+    
+    var description: String {
+        self.rawValue
+    }
+}

--- a/Projects/Features/BaseFeature/Sources/Analytics/ContainSongsAnalyticsLog.swift
+++ b/Projects/Features/BaseFeature/Sources/Analytics/ContainSongsAnalyticsLog.swift
@@ -5,7 +5,7 @@ enum ContainSongsAnalyticsLog: AnalyticsLogType {
 }
 
 enum CreatePlaylistLocation: String, AnalyticsLogEnumParametable {
-    case addMusics = "add-musics"
+    case addMusics = "add_musics"
 
     var description: String {
         self.rawValue

--- a/Projects/Features/BaseFeature/Sources/Analytics/ContainSongsAnalyticsLog.swift
+++ b/Projects/Features/BaseFeature/Sources/Analytics/ContainSongsAnalyticsLog.swift
@@ -4,7 +4,7 @@ enum ContainSongsAnalyticsLog: AnalyticsLogType {
     case clickCreatePlaylistButton(location: CreatePlaylistLocation)
 }
 
-enum CreatePlaylistLocation: String, CustomStringConvertible {
+enum CreatePlaylistLocation: String, AnalyticsLogEnumParametable {
     case addMusics = "add-musics"
 
     var description: String {

--- a/Projects/Features/BaseFeature/Sources/Analytics/ContainSongsAnalyticsLog.swift
+++ b/Projects/Features/BaseFeature/Sources/Analytics/ContainSongsAnalyticsLog.swift
@@ -6,7 +6,7 @@ enum ContainSongsAnalyticsLog: AnalyticsLogType {
 
 enum CreatePlaylistLocation: String, CustomStringConvertible {
     case addMusics = "add-musics"
-    
+
     var description: String {
         self.rawValue
     }

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -218,6 +218,7 @@ extension ContainSongsViewController: UITableViewDelegate {
 
 extension ContainSongsViewController: ContainPlayListHeaderViewDelegate {
     public func action() {
+        LogManager.analytics(ContainSongsAnalyticsLog.clickCreatePlaylistButton(location: .addMusics))
         input.creationButtonDidTap.onNext(())
     }
 }

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -2,13 +2,13 @@ import BaseDomainInterface
 import BaseFeatureInterface
 import DesignSystem
 import Localization
+import LogManager
 import NVActivityIndicatorView
 import PlaylistDomainInterface
 import RxSwift
 import UIKit
 import UserDomainInterface
 import Utility
-import LogManager
 
 public final class ContainSongsViewController: BaseViewController, ViewControllerFromStoryBoard {
     @IBOutlet weak var closeButton: UIButton!

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -8,6 +8,7 @@ import RxSwift
 import UIKit
 import UserDomainInterface
 import Utility
+import LogManager
 
 public final class ContainSongsViewController: BaseViewController, ViewControllerFromStoryBoard {
     @IBOutlet weak var closeButton: UIButton!
@@ -166,6 +167,7 @@ extension ContainSongsViewController {
                     type: .creation,
                     key: "",
                     completion: { text in
+                        LogManager.analytics(ContainSongsAnalyticsLog.clickCreatePlaylistButton(location: .addMusics))
                         owner.input.createPlaylist.onNext(text)
                     }
                 )

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/ContainSongsViewController.swift
@@ -167,7 +167,6 @@ extension ContainSongsViewController {
                     type: .creation,
                     key: "",
                     completion: { text in
-                        LogManager.analytics(ContainSongsAnalyticsLog.clickCreatePlaylistButton(location: .addMusics))
                         owner.input.createPlaylist.onNext(text)
                     }
                 )

--- a/Projects/Features/StorageFeature/Sources/Analytics/StorageAnalyticsLog.swift
+++ b/Projects/Features/StorageFeature/Sources/Analytics/StorageAnalyticsLog.swift
@@ -10,7 +10,7 @@ enum StorageAnalyticsLog: AnalyticsLogType {
     case clickMyLikeListMusicButton(id: String)
 }
 
-enum StorageTab: String, CustomStringConvertible {
+enum StorageTab: String, AnalyticsLogEnumParametable {
     case myPlaylist = "my-playlist"
     case myLikeList = "my-like-list"
 
@@ -19,7 +19,7 @@ enum StorageTab: String, CustomStringConvertible {
     }
 }
 
-enum CreatePlaylistLocation: String, CustomStringConvertible {
+enum CreatePlaylistLocation: String, AnalyticsLogEnumParametable {
     case myPlaylist = "my-playlist"
 
     var description: String {
@@ -27,7 +27,7 @@ enum CreatePlaylistLocation: String, CustomStringConvertible {
     }
 }
 
-enum FruitDrawEntryLocation: String, CustomStringConvertible {
+enum FruitDrawEntryLocation: String, AnalyticsLogEnumParametable {
     case myPlaylist = "my-playlist"
 
     var description: String {
@@ -35,7 +35,7 @@ enum FruitDrawEntryLocation: String, CustomStringConvertible {
     }
 }
 
-enum LoginLocation: String, CustomStringConvertible {
+enum LoginLocation: String, AnalyticsLogEnumParametable {
     case myPlaylist = "my-playlist"
     case myLikeList = "my-like-list"
     case addMusics = "add-musics"

--- a/Projects/Features/StorageFeature/Sources/Analytics/StorageAnalyticsLog.swift
+++ b/Projects/Features/StorageFeature/Sources/Analytics/StorageAnalyticsLog.swift
@@ -11,8 +11,8 @@ enum StorageAnalyticsLog: AnalyticsLogType {
 }
 
 enum StorageTab: String, AnalyticsLogEnumParametable {
-    case myPlaylist = "my-playlist"
-    case myLikeList = "my-like-list"
+    case myPlaylist = "my_playlist"
+    case myLikeList = "my_like_list"
 
     var description: String {
         self.rawValue
@@ -20,7 +20,7 @@ enum StorageTab: String, AnalyticsLogEnumParametable {
 }
 
 enum CreatePlaylistLocation: String, AnalyticsLogEnumParametable {
-    case myPlaylist = "my-playlist"
+    case myPlaylist = "my_playlist"
 
     var description: String {
         self.rawValue
@@ -28,7 +28,7 @@ enum CreatePlaylistLocation: String, AnalyticsLogEnumParametable {
 }
 
 enum FruitDrawEntryLocation: String, AnalyticsLogEnumParametable {
-    case myPlaylist = "my-playlist"
+    case myPlaylist = "my_playlist"
 
     var description: String {
         self.rawValue
@@ -36,9 +36,8 @@ enum FruitDrawEntryLocation: String, AnalyticsLogEnumParametable {
 }
 
 enum LoginLocation: String, AnalyticsLogEnumParametable {
-    case myPlaylist = "my-playlist"
-    case myLikeList = "my-like-list"
-    case addMusics = "add-musics"
+    case myPlaylist = "my_playlist"
+    case myLikeList = "my_like_list"
 
     var description: String {
         self.rawValue

--- a/Projects/Features/StorageFeature/Sources/Analytics/StorageAnalyticsLog.swift
+++ b/Projects/Features/StorageFeature/Sources/Analytics/StorageAnalyticsLog.swift
@@ -6,8 +6,8 @@ enum StorageAnalyticsLog: AnalyticsLogType {
     case clickMyPlaylistEditButton
     case clickMyLikeListEditButton
     case clickLoginButton(location: LoginLocation)
-
     case clickFruitDrawEntryButton(location: FruitDrawEntryLocation)
+    case clickMyLikeListMusicButton(id: String)
 }
 
 enum StorageTab: String, CustomStringConvertible {
@@ -44,23 +44,3 @@ enum LoginLocation: String, CustomStringConvertible {
         self.rawValue
     }
 }
-
-/*
- 보관함 화면 보여짐 (내리스트, 좋아요) // common
-
- 내 리스트 탭 클릭함
- 좋아요 탭 클릭함
-
- 내 리스트 - 리스트 만들기 클릭함
- 내 리스트 - 리스트 클릭함 (id) // common
- 내 리스트 - 플레이버튼 클릭함 (id) // common
- 내 리스트 - 편집 버튼 클릭함
- 내 리스트 - 열매 뽑기 버튼 클릭함
- 내 리스트 - 로그인 버튼 클릭함
- 내 리스트 - 리스트 만들기 - 로그인 버튼 클릭함
-
- 좋아요 탭 - 곡 클릭함 (id)
- 좋아요 탭 - 플레이버튼 클릭함 (id) // common
- 좋아요 탭 - 편집 버튼 클릭함
- 좋아요 탭 - 로그인 버튼 클릭함
- */

--- a/Projects/Features/StorageFeature/Sources/Analytics/StorageAnalyticsLog.swift
+++ b/Projects/Features/StorageFeature/Sources/Analytics/StorageAnalyticsLog.swift
@@ -1,0 +1,27 @@
+import LogManager
+
+enum StorageAnalyticsLog: AnalyticsLogType {
+    case viewPage(pageName: String)
+    case clickFruitDrawButton
+    case clickMusicItem(location: MusicItemLocation, id: String)
+    case clickMusicItemPlayButton(location: MusicItemLocation, id: String)
+}
+
+enum MusicItemLocation: String, CustomStringConvertible {
+    case homeTop100 = "storage-like"
+    case homeRecent = "home-recent"
+
+    var description: String {
+        self.rawValue
+    }
+}
+
+/*
+ 내 리스트 탭 클릭함 click
+ 좋아요 탭 클릭함
+ 내 리스트 - 리스트 만들기 클릭함
+ 내 리스트 - 리스트 클릭함 (id)
+ 내 리스트 - 플레이버튼 클릭함 (id)
+ 좋아요 탭 - 곡 클릭함 (id)
+ 좋아요 탭 - 플레이버튼 클릭함 (id)
+ */

--- a/Projects/Features/StorageFeature/Sources/Analytics/StorageAnalyticsLog.swift
+++ b/Projects/Features/StorageFeature/Sources/Analytics/StorageAnalyticsLog.swift
@@ -1,15 +1,44 @@
 import LogManager
 
 enum StorageAnalyticsLog: AnalyticsLogType {
-    case viewPage(pageName: String)
-    case clickFruitDrawButton
-    case clickMusicItem(location: MusicItemLocation, id: String)
-    case clickMusicItemPlayButton(location: MusicItemLocation, id: String)
+    case clickStorageTabbarTab(tab: StorageTab)
+    case clickCreatePlaylistButton(location: CreatePlaylistLocation)
+    case clickMyPlaylistEditButton
+    case clickMyLikeListEditButton
+    case clickLoginButton(location: LoginLocation)
+    
+    case clickFruitDrawEntryButton(location: FruitDrawEntryLocation)
 }
 
-enum MusicItemLocation: String, CustomStringConvertible {
-    case homeTop100 = "storage-like"
-    case homeRecent = "home-recent"
+enum StorageTab: String, CustomStringConvertible {
+    case myPlaylist = "my-playlist"
+    case myLikeList = "my-like-list"
+    
+    var description: String {
+        self.rawValue
+    }
+}
+
+enum CreatePlaylistLocation: String, CustomStringConvertible {
+    case myPlaylist = "my-playlist"
+    
+    var description: String {
+        self.rawValue
+    }
+}
+
+enum FruitDrawEntryLocation: String, CustomStringConvertible {
+    case myPlaylist = "my-playlist"
+
+    var description: String {
+        self.rawValue
+    }
+}
+
+enum LoginLocation: String, CustomStringConvertible {
+    case myPlaylist = "my-playlist"
+    case myLikeList = "my-like-list"
+    case addMusics = "add-musics"
 
     var description: String {
         self.rawValue
@@ -17,11 +46,21 @@ enum MusicItemLocation: String, CustomStringConvertible {
 }
 
 /*
- 내 리스트 탭 클릭함 click
+ 보관함 화면 보여짐 (내리스트, 좋아요) // common
+ 
+ 내 리스트 탭 클릭함
  좋아요 탭 클릭함
+ 
  내 리스트 - 리스트 만들기 클릭함
- 내 리스트 - 리스트 클릭함 (id)
- 내 리스트 - 플레이버튼 클릭함 (id)
+ 내 리스트 - 리스트 클릭함 (id) // common
+ 내 리스트 - 플레이버튼 클릭함 (id) // common
+ 내 리스트 - 편집 버튼 클릭함
+ 내 리스트 - 열매 뽑기 버튼 클릭함
+ 내 리스트 - 로그인 버튼 클릭함
+ 내 리스트 - 리스트 만들기 - 로그인 버튼 클릭함
+ 
  좋아요 탭 - 곡 클릭함 (id)
- 좋아요 탭 - 플레이버튼 클릭함 (id)
+ 좋아요 탭 - 플레이버튼 클릭함 (id) // common
+ 좋아요 탭 - 편집 버튼 클릭함
+ 좋아요 탭 - 로그인 버튼 클릭함
  */

--- a/Projects/Features/StorageFeature/Sources/Analytics/StorageAnalyticsLog.swift
+++ b/Projects/Features/StorageFeature/Sources/Analytics/StorageAnalyticsLog.swift
@@ -6,14 +6,14 @@ enum StorageAnalyticsLog: AnalyticsLogType {
     case clickMyPlaylistEditButton
     case clickMyLikeListEditButton
     case clickLoginButton(location: LoginLocation)
-    
+
     case clickFruitDrawEntryButton(location: FruitDrawEntryLocation)
 }
 
 enum StorageTab: String, CustomStringConvertible {
     case myPlaylist = "my-playlist"
     case myLikeList = "my-like-list"
-    
+
     var description: String {
         self.rawValue
     }
@@ -21,7 +21,7 @@ enum StorageTab: String, CustomStringConvertible {
 
 enum CreatePlaylistLocation: String, CustomStringConvertible {
     case myPlaylist = "my-playlist"
-    
+
     var description: String {
         self.rawValue
     }
@@ -47,10 +47,10 @@ enum LoginLocation: String, CustomStringConvertible {
 
 /*
  보관함 화면 보여짐 (내리스트, 좋아요) // common
- 
+
  내 리스트 탭 클릭함
  좋아요 탭 클릭함
- 
+
  내 리스트 - 리스트 만들기 클릭함
  내 리스트 - 리스트 클릭함 (id) // common
  내 리스트 - 플레이버튼 클릭함 (id) // common
@@ -58,7 +58,7 @@ enum LoginLocation: String, CustomStringConvertible {
  내 리스트 - 열매 뽑기 버튼 클릭함
  내 리스트 - 로그인 버튼 클릭함
  내 리스트 - 리스트 만들기 - 로그인 버튼 클릭함
- 
+
  좋아요 탭 - 곡 클릭함 (id)
  좋아요 탭 - 플레이버튼 클릭함 (id) // common
  좋아요 탭 - 편집 버튼 클릭함

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/LikeStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/LikeStorageViewController.swift
@@ -40,6 +40,10 @@ final class LikeStorageViewController: BaseReactorViewController<LikeStorageReac
         setTableView()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        LogManager.analytics(CommonAnalyticsLog.viewPage(pageName: .storageLike))
+    }
+    
     static func viewController(
         reactor: Reactor,
         containSongsFactory: ContainSongsFactory,
@@ -186,6 +190,7 @@ final class LikeStorageViewController: BaseReactorViewController<LikeStorageReac
         super.bindAction(reactor: reactor)
 
         likeStorageView.rx.loginButtonDidTap
+            .do(onNext: { LogManager.analytics(StorageAnalyticsLog.clickLoginButton(location: .myLikeList)) })
             .map { Reactor.Action.loginButtonDidTap }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
@@ -204,6 +209,7 @@ final class LikeStorageViewController: BaseReactorViewController<LikeStorageReac
             .withLatestFrom(reactor.state.map(\.dataSource)) { ($0, $1) }
             .map { $0.1[$0.0.section].items[$0.0.row].songID }
             .bind(with: self, onNext: { owner, songID in
+                LogManager.analytics(StorageAnalyticsLog.clickMyLikeListMusicButton(id: songID))
                 owner.songDetailPresenter.present(id: songID)
             })
             .disposed(by: disposeBag)
@@ -265,6 +271,7 @@ extension LikeStorageViewController: LikeStorageTableViewCellDelegate {
         case let .cellTapped(indexPath):
             self.reactor?.action.onNext(.songDidTap(indexPath.row))
         case let .playTapped(song):
+            LogManager.analytics(CommonAnalyticsLog.clickPlayButton(location: .storageLike, type: .single))
             self.reactor?.action.onNext(.playDidTap(song: song))
         }
     }

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/LikeStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/LikeStorageViewController.swift
@@ -43,7 +43,7 @@ final class LikeStorageViewController: BaseReactorViewController<LikeStorageReac
     override func viewDidAppear(_ animated: Bool) {
         LogManager.analytics(CommonAnalyticsLog.viewPage(pageName: .storageLike))
     }
-    
+
     static func viewController(
         reactor: Reactor,
         containSongsFactory: ContainSongsFactory,

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/LikeStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/LikeStorageViewController.swift
@@ -41,7 +41,7 @@ final class LikeStorageViewController: BaseReactorViewController<LikeStorageReac
     }
 
     override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated: animated)
+        super.viewDidAppear(animated)
         LogManager.analytics(CommonAnalyticsLog.viewPage(pageName: .storageLike))
     }
 

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/LikeStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/LikeStorageViewController.swift
@@ -41,6 +41,7 @@ final class LikeStorageViewController: BaseReactorViewController<LikeStorageReac
     }
 
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated: animated)
         LogManager.analytics(CommonAnalyticsLog.viewPage(pageName: .storageLike))
     }
 

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
@@ -56,6 +56,7 @@ final class ListStorageViewController: BaseReactorViewController<ListStorageReac
     }
 
     override func viewDidAppear(_ animated: Bool) {
+        LogManager.analytics(CommonAnalyticsLog.viewPage(pageName: .storagePlaylist))
         listStorageView.resetParticeAnimation()
     }
 
@@ -219,6 +220,7 @@ final class ListStorageViewController: BaseReactorViewController<ListStorageReac
 
     override func bindAction(reactor: ListStorageReactor) {
         listStorageView.rx.loginButtonDidTap
+            .do(onNext: { LogManager.analytics(StorageAnalyticsLog.clickLoginButton(location: .myPlaylist)) })
             .map { Reactor.Action.loginButtonDidTap }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
@@ -229,12 +231,14 @@ final class ListStorageViewController: BaseReactorViewController<ListStorageReac
             .disposed(by: disposeBag)
 
         listStorageView.rx.drawFruitButtonDidTap
+            .do(onNext: { LogManager.analytics(StorageAnalyticsLog.clickFruitDrawEntryButton(location: .myPlaylist)) })
             .map { Reactor.Action.drawFruitButtonDidTap }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
         listStorageView.rx.createListButtonDidTap
             .throttle(.milliseconds(500), latest: false, scheduler: MainScheduler.asyncInstance)
+            .do(onNext: { LogManager.analytics(StorageAnalyticsLog.clickCreatePlaylistButton(location: .myPlaylist)) })
             .map { Reactor.Action.createListButtonDidTap }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
@@ -298,14 +302,16 @@ extension ListStorageViewController: SongCartViewDelegate {
 extension ListStorageViewController: ListStorageTableViewCellDelegate {
     public func buttonTapped(type: ListStorageTableViewCellDelegateConstant) {
         switch type {
-        case let .listTapped(indexPath):
-            self.reactor?.action.onNext(.listDidTap(indexPath))
+        case let .listTapped(passModel):
+            LogManager.analytics(CommonAnalyticsLog.clickPlaylistItem(location: .storage, key: passModel.key))
+            self.reactor?.action.onNext(.listDidTap(passModel.indexPath))
 
-        case let .playTapped(indexPath):
-            self.reactor?.action.onNext(.playDidTap(indexPath.row))
+        case let .playTapped(passModel):
+            LogManager.analytics(CommonAnalyticsLog.clickPlayButton(location: .storagePlaylist, type: .playlist))
+            self.reactor?.action.onNext(.playDidTap(passModel.indexPath.row))
 
-        case let .cellTapped(indexPath):
-            self.reactor?.action.onNext(.cellDidTap(indexPath.row))
+        case let .cellTapped(passModel):
+            self.reactor?.action.onNext(.cellDidTap(passModel.indexPath.row))
         }
     }
 }

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
@@ -56,6 +56,7 @@ final class ListStorageViewController: BaseReactorViewController<ListStorageReac
     }
 
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         LogManager.analytics(CommonAnalyticsLog.viewPage(pageName: .storagePlaylist))
         listStorageView.resetParticeAnimation()
     }

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
@@ -2,6 +2,7 @@ import BaseFeature
 import BaseFeatureInterface
 import DesignSystem
 import Localization
+import LogManager
 import Pageboy
 import ReactorKit
 import RxSwift
@@ -9,7 +10,6 @@ import SignInFeatureInterface
 import Tabman
 import UIKit
 import Utility
-import LogManager
 
 final class StorageViewController: TabmanViewController, View {
     typealias Reactor = StorageReactor
@@ -85,11 +85,11 @@ final class StorageViewController: TabmanViewController, View {
         self.reactor?.action.onNext(.switchTab(index))
         NotificationCenter.default.post(name: .didChangeTabInStorage, object: index)
     }
-    
+
     /// 탭맨 탭 터치 이벤트 감지 함수
     override func bar(_ bar: any TMBar, didRequestScrollTo index: PageboyViewController.PageIndex) {
         super.bar(bar, didRequestScrollTo: index)
-        
+
         guard let viewController = viewControllers[safe: index] else { return }
         switch viewController {
         case is ListStorageViewController:

--- a/Projects/Features/StorageFeature/Sources/Views/ListStorageTableViewCell.swift
+++ b/Projects/Features/StorageFeature/Sources/Views/ListStorageTableViewCell.swift
@@ -13,9 +13,9 @@ public protocol ListStorageTableViewCellDelegate: AnyObject {
 }
 
 public enum ListStorageTableViewCellDelegateConstant {
-    case cellTapped(indexPath: IndexPath)
-    case listTapped(indexPath: IndexPath)
-    case playTapped(indexPath: IndexPath)
+    case cellTapped((indexPath: IndexPath, key: String))
+    case listTapped((indexPath: IndexPath, key: String))
+    case playTapped((indexPath: IndexPath, key: String))
 }
 
 class ListStorageTableViewCell: UITableViewCell {
@@ -184,14 +184,14 @@ extension ListStorageTableViewCell {
 
 extension ListStorageTableViewCell {
     @objc func cellSelectButtonAction() {
-        delegate?.buttonTapped(type: .cellTapped(indexPath: passToModel.0))
+        delegate?.buttonTapped(type: .cellTapped(passToModel))
     }
 
     @objc func listSelectButtonAction() {
-        delegate?.buttonTapped(type: .listTapped(indexPath: passToModel.0))
+        delegate?.buttonTapped(type: .listTapped(passToModel))
     }
 
     @objc func playButtonAction() {
-        delegate?.buttonTapped(type: .playTapped(indexPath: passToModel.0))
+        delegate?.buttonTapped(type: .playTapped(passToModel))
     }
 }

--- a/Projects/Modules/LogManager/Sources/CommonAnalyticsLog.swift
+++ b/Projects/Modules/LogManager/Sources/CommonAnalyticsLog.swift
@@ -27,7 +27,8 @@ public extension CommonAnalyticsLog {
         case myPlaylistDetail = "my_playlist_detail"
         case chart
         case artist
-        case storage
+        case storagePlaylist = "storage_playlist"
+        case storageLike = "storage_like"
         case search
         case fruitDraw = "fruit_draw" // 열매 뽑기
         case playlist
@@ -58,9 +59,9 @@ public extension CommonAnalyticsLog {
         case search
         case artist
         case playlist
+        case storagePlaylist = "storage_playlist"
         case storageLike = "storage_like"
         case playlistDetail = "playlist_detail"
-        case storage
         case chart
         case recentMusic = "recent_music"
         case musicDetail = "music_detail"


### PR DESCRIPTION
## 💡 배경 및 개요

보관함 탭 로그를 추가했어요

Resolves: #1150 

## 📃 작업내용

- 보관함 화면 보여짐 (내리스트, 좋아요)✅

- 내 리스트 탭 클릭함 ✅
- 좋아요 탭 클릭함 ✅

- 내 리스트 - 리스트 만들기 클릭함 ✅
- 내 리스트 - 리스트 클릭함 (id) ✅
- 내 리스트 - 플레이버튼 클릭함 (id) ✅
- 내 리스트 - 편집 버튼 클릭함 ✅
- 내 리스트 - 열매 뽑기 버튼 클릭함 ✅
- 내 리스트 - 로그인 버튼 클릭함 ✅

- 좋아요 탭 - 곡 클릭함 (id) ✅
- 좋아요 탭 - 플레이버튼 클릭함 (id) ✅
- 좋아요 탭 - 편집 버튼 클릭함 ✅
- 좋아요 탭 - 로그인 버튼 클릭함 ✅




## 🙋‍♂️ 리뷰노트


## ✅ PR 체크리스트


- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
