### PR TITLE
🔀 :: [#1165] 내 열매 버튼 테두리 색상이 다른 문제 수정

### DIFF
--- a/Projects/Features/MyInfoFeature/Sources/Views/FruitDrawButtonView.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/FruitDrawButtonView.swift
@@ -17,9 +17,7 @@ final class FruitDrawButtonView: UIView {
     let backgroundView = UIView().then {
         $0.backgroundColor = .white.withAlphaComponent(0.4)
         $0.layer.borderWidth = 1
-        $0.layer.borderColor = DesignSystemAsset.BlueGrayColor.blueGray200.color
-            .withAlphaComponent(0.4)
-            .cgColor
+        $0.layer.borderColor = UIColor(hex: "ECEFF3").cgColor
         $0.layer.cornerRadius = 8
         $0.clipsToBounds = true
     }


### PR DESCRIPTION
## 💡 배경 및 개요

알파값으로 조정해보려했으나, 전부 디자인과 다름.. 그냥 하드코딩으로 때웠습니다

Resolves: #1165

## 📃 작업내용

<img width="620" alt="image" src="https://github.com/user-attachments/assets/4bdd35ca-0c7d-4aa7-b79a-d66dc3442201">

왼쪽이 디자인 오른쪽이 개발
디자인 테두리 색상 컬러피커로 찍어서 하드코딩했습니다

## 🙋‍♂️ 리뷰노트


## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
