### PR TITLE
🔀 :: (#1193) 플리 이미지 변경 시 로딩 인디케이터 센터 정렬

### DIFF
--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -128,7 +128,8 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
         super.addView()
         self.view.addSubviews(wmNavigationbarView, tableView, saveCompletionIndicator)
         wmNavigationbarView.setLeftViews([dismissButton])
-        wmNavigationbarView.setRightViews([lockButton, moreButton, completionButton, saveCompletionIndicator])
+        wmNavigationbarView.setRightViews([lockButton, moreButton, completionButton])
+        wmNavigationbarView.addSubview(saveCompletionIndicator)
     }
 
     override func setLayout() {
@@ -148,10 +149,11 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
         completionButton.snp.makeConstraints {
             $0.width.equalTo(45)
             $0.height.equalTo(24)
-            $0.bottom.equalToSuperview().offset(-5)
         }
 
         saveCompletionIndicator.snp.makeConstraints {
+            $0.trailing.equalToSuperview().offset(-35)
+            $0.centerY.equalToSuperview()
             $0.size.equalTo(15)
         }
     }
@@ -368,7 +370,6 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
         sharedState.map(\.isSaveCompletionLoading)
             .distinctUntilChanged()
             .bind(with: self) { owner, isLoading in
-
                 if isLoading {
                     owner.saveCompletionIndicator.startAnimating()
                 } else {

--- a/Projects/UsertInterfaces/DesignSystem/Sources/WMNavigationBarView.swift
+++ b/Projects/UsertInterfaces/DesignSystem/Sources/WMNavigationBarView.swift
@@ -5,14 +5,14 @@ import UIKit
 public final class WMNavigationBarView: UIView {
     private let leftStackView = UIStackView().then {
         $0.axis = .horizontal
-        $0.alignment = .leading
+        $0.alignment = .center
     }
 
     public private(set) var titleView: UIView = UIView()
     private let rightStackView = UIStackView().then {
         $0.isUserInteractionEnabled = true
         $0.axis = .horizontal
-        $0.alignment = .trailing
+        $0.alignment = .center
         $0.distribution = .fillEqually
         $0.spacing = 10
     }


### PR DESCRIPTION
## 💡 배경 및 개요
- 로딩 인디케이터 위치가 안맞음

Resolves: #1193 

## 📃 작업내용
- 센터정렬

## 🙋‍♂️ 리뷰노트
<img width="114" alt="스크린샷 2024-08-18 오후 8 20 13" src="https://github.com/user-attachments/assets/8e47d5d5-f229-4bfd-9351-a5c6d6277a92">

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
