### PR TITLE
🔀 :: (#1196) notiname 변경 및 마이 플리 편집모드 버그 해결

### DIFF
--- a/Projects/Features/BaseFeature/Sources/Protocols/EditSheetViewType.swift
+++ b/Projects/Features/BaseFeature/Sources/Protocols/EditSheetViewType.swift
@@ -51,7 +51,7 @@ public extension EditSheetViewType where Self: UIViewController {
         bottomSheetView.present(in: view)
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 숨깁니다.
-        NotificationCenter.default.post(name: .willShowSongCart, object: nil)
+        NotificationCenter.default.post(name: .shouldHidePlaylistFloatingButton, object: nil)
     }
 
     /// 편집하기 팝업을 제거합니다.
@@ -66,6 +66,6 @@ public extension EditSheetViewType where Self: UIViewController {
         self.bottomSheetView = nil
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 다시 보여줍니다.
-        NotificationCenter.default.post(name: .willHideSongCart, object: nil)
+        NotificationCenter.default.post(name: .shouldShowPlaylistFloatingButton, object: nil)
     }
 }

--- a/Projects/Features/BaseFeature/Sources/Protocols/PlaylistEditSheetViewType.swift
+++ b/Projects/Features/BaseFeature/Sources/Protocols/PlaylistEditSheetViewType.swift
@@ -42,7 +42,7 @@ public extension PlaylistEditSheetViewType where Self: UIViewController {
         bottomSheetView.present(in: view)
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 숨깁니다.
-        NotificationCenter.default.post(name: .willShowSongCart, object: nil)
+        NotificationCenter.default.post(name: .shouldHidePlaylistFloatingButton, object: nil)
     }
 
     /// 편집하기 팝업을 제거합니다.
@@ -57,6 +57,6 @@ public extension PlaylistEditSheetViewType where Self: UIViewController {
         self.bottomSheetView = nil
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 다시 보여줍니다.
-        NotificationCenter.default.post(name: .willHideSongCart, object: nil)
+        NotificationCenter.default.post(name: .shouldShowPlaylistFloatingButton, object: nil)
     }
 }

--- a/Projects/Features/BaseFeature/Sources/Protocols/SongCartViewType.swift
+++ b/Projects/Features/BaseFeature/Sources/Protocols/SongCartViewType.swift
@@ -77,7 +77,7 @@ public extension SongCartViewType where Self: UIViewController {
         bottomSheetView.present(in: view)
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 숨깁니다.
-        NotificationCenter.default.post(name: .willShowSongCart, object: nil)
+        NotificationCenter.default.post(name: .shouldHidePlaylistFloatingButton, object: nil)
     }
 
     /// 노래 담기 팝업을 제거합니다.
@@ -92,6 +92,6 @@ public extension SongCartViewType where Self: UIViewController {
         self.bottomSheetView = nil
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 다시 보여줍니다.
-        NotificationCenter.default.post(name: .willHideSongCart, object: nil)
+        NotificationCenter.default.post(name: .shouldShowPlaylistFloatingButton, object: nil)
     }
 }

--- a/Projects/Features/BaseFeature/Sources/Protocols/WMBottomSheetViewType.swift
+++ b/Projects/Features/BaseFeature/Sources/Protocols/WMBottomSheetViewType.swift
@@ -37,7 +37,7 @@ public extension WMBottomSheetViewType where Self: UIViewController {
         bottomSheetView.present(in: view)
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 숨깁니다.
-        NotificationCenter.default.post(name: .willShowSongCart, object: nil)
+        NotificationCenter.default.post(name: .shouldHidePlaylistFloatingButton, object: nil)
     }
 
     /// 편집하기 팝업을 제거합니다.
@@ -52,7 +52,7 @@ public extension WMBottomSheetViewType where Self: UIViewController {
 
         // 메인 컨테이너 뷰컨에서 해당 노티를 수신, 팝업이 올라오면 미니 플레이어를 다시 보여줍니다.
         if postNoti {
-            NotificationCenter.default.post(name: .willHideSongCart, object: nil)
+            NotificationCenter.default.post(name: .shouldShowPlaylistFloatingButton, object: nil)
         }
     }
 }

--- a/Projects/Features/BaseFeature/Sources/Views/WMBottomSheetView.swift
+++ b/Projects/Features/BaseFeature/Sources/Views/WMBottomSheetView.swift
@@ -68,7 +68,7 @@ public extension UIViewController {
         )
 
         bottomSheetView.present(in: self.view)
-        NotificationCenter.default.post(name: .willShowSongCart, object: nil)
+        NotificationCenter.default.post(name: .shouldHidePlaylistFloatingButton, object: nil)
     }
 
     func hideInlineBottomSheet() {
@@ -77,6 +77,6 @@ public extension UIViewController {
             .last as? BottomSheetView else { return }
 
         bottomSheetView.dismiss()
-        NotificationCenter.default.post(name: .willHideSongCart, object: nil)
+        NotificationCenter.default.post(name: .shouldShowPlaylistFloatingButton, object: nil)
     }
 }

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainContainerViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainContainerViewController.swift
@@ -150,7 +150,7 @@ private extension MainContainerViewController {
             .disposed(by: disposeBag)
 
         NotificationCenter.default.rx
-            .notification(.willShowSongCart)
+            .notification(.shouldHidePlaylistFloatingButton)
             .subscribe(onNext: { [playlistFloatingActionButton] _ in
                 UIView.animate(withDuration: 0.2) {
                     playlistFloatingActionButton.alpha = 0
@@ -159,7 +159,7 @@ private extension MainContainerViewController {
             .disposed(by: disposeBag)
 
         NotificationCenter.default.rx
-            .notification(.willHideSongCart)
+            .notification(.shouldShowPlaylistFloatingButton)
             .subscribe(onNext: { [playlistFloatingActionButton] _ in
                 UIView.animate(withDuration: 0.2) {
                     playlistFloatingActionButton.alpha = 1

--- a/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
+++ b/Projects/Features/PlaylistFeature/Sources/Reactors/MyPlaylistDetailReactor.swift
@@ -424,6 +424,7 @@ private extension MyPlaylistDetailReactor {
         let backUpPlaylist = state.backupPlaylistModels
 
         return .concat([
+            updateComplectionButtonVisible(flag: false),
             .just(Mutation.updateEditingState(false)),
             .just(Mutation.updatePlaylist(backUpPlaylist)),
             .just(.updateSelectedCount(0))

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
@@ -7,7 +7,7 @@ public extension Notification.Name {
     static let willRefreshUserInfo = Notification.Name("willRefreshUserInfo") // 유저 정보 갱신
     static let willStatusBarEnterDarkBackground = Notification.Name("willStatusBarEnterDarkBackground")
     static let willStatusBarEnterLightBackground = Notification.Name("willStatusBarEnterLightBackground")
-    static let willShowSongCart = Notification.Name("willShowSongCart")
-    static let willHideSongCart = Notification.Name("willHideSongCart")
+    static let shouldHidePlaylistFloatingButton = Notification.Name("shouldHidePlaylistFloatingButton")
+    static let shouldShowPlaylistFloatingButton = Notification.Name("shouldShowPlaylistFloatingButton")
     static let didChangeTabInStorage = Notification.Name("didChangeTabInStorage")
 }


### PR DESCRIPTION
## 💡 배경 및 개요

노티 네이밍이 명확하지 않아 수정합니다.
마이플리 편집 시작 후 다른 화면을 갔다오면 나오면 완료버튼이 사라지지 않았습니다.

<!-- resolved issue 넘버 표기 방식 변경 시 '.github/actions/Auto_close_associate_issue/main.js' 또한 변경 필요 -->

Resolves: #1196

## 📃 작업내용

- 노티이름 변경 
- 완료버튼 숨김 처리

## 🙋‍♂️ 리뷰노트

<!--
> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!
-->

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
