### PR TITLE
🔀 :: (#1199) 보관함 > 내 플리 상세 진입 시 플로팅 버튼 위치 안맞는 UI 오류 수정

### DIFF
--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainContainerViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainContainerViewController.swift
@@ -56,7 +56,9 @@ private extension MainContainerViewController {
         view.addSubview(playlistFloatingActionButton)
 
         let startPage: Int = PreferenceManager.startPage ?? 0
-        let bottomOffset: Int = startPage == 3 ? -80 : -20
+        let bottomOffset: CGFloat = startPage == 3 ?
+            PlaylistFloatingButtonPosition.top.bottomOffset :
+            PlaylistFloatingButtonPosition.default.bottomOffset
         playlistFloatingActionButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(20)
             $0.bottom.equalTo(bottomContainerView.snp.top).offset(bottomOffset)
@@ -169,13 +171,21 @@ private extension MainContainerViewController {
 
         Observable.combineLatest(
             PreferenceManager.$startPage.map { $0 ?? 0 },
-            NotificationCenter.default.rx.notification(.didChangeTabInStorage).map { $0.object as? Int ?? 0 }
-        ) { startPage, storagePage -> (Int, Int) in
-            return (startPage, storagePage)
+            NotificationCenter.default.rx
+                .notification(.shouldMovePositionPlaylistFloatingButton)
+                .map { $0.object as? PlaylistFloatingButtonPosition ?? .default }
+        ) { startPage, pos -> (Int, PlaylistFloatingButtonPosition) in
+            return (startPage, pos)
         }
         .bind(with: self, onNext: { owner, params in
-            let (startPage, storagePage) = params
-            let bottomOffset: Int = (startPage == 3) ? ((storagePage == 0) ? -80 : -20) : -20
+            let (startPage, pos) = params
+            var bottomOffset: CGFloat
+            switch startPage {
+            case 3:
+                bottomOffset = pos.bottomOffset
+            default:
+                bottomOffset = PlaylistFloatingButtonPosition.default.bottomOffset
+            }
             owner.playlistFloatingActionButton.snp.updateConstraints {
                 $0.trailing.equalToSuperview().inset(20)
                 $0.bottom.equalTo(owner.bottomContainerView.snp.top).offset(bottomOffset)

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainContainerViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainContainerViewController.swift
@@ -172,7 +172,7 @@ private extension MainContainerViewController {
         Observable.combineLatest(
             PreferenceManager.$startPage.map { $0 ?? 0 },
             NotificationCenter.default.rx
-                .notification(.shouldMovePositionPlaylistFloatingButton)
+                .notification(.shouldMovePlaylistFloatingButton)
                 .map { $0.object as? PlaylistFloatingButtonPosition ?? .default }
         ) { startPage, pos -> (Int, PlaylistFloatingButtonPosition) in
             return (startPage, pos)

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
@@ -150,7 +150,7 @@ private extension MainTabBarViewController {
             // 보관함에서 플리상세 접근 시 플로팅버튼 내림
             if selectedIndex == 3 {
                 NotificationCenter.default.post(
-                    name: .shouldMovePositionPlaylistFloatingButton,
+                    name: .shouldMovePlaylistFloatingButton,
                     object: PlaylistFloatingButtonPosition.default
                 )
             }

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
@@ -147,6 +147,14 @@ private extension MainTabBarViewController {
             let viewController = playlistDetailFactory.makeView(key: key)
             navigationController?.pushViewController(viewController, animated: true)
 
+            // 보관함에서 플리상세 접근 시 플로팅버튼 내림
+            if selectedIndex == 3 {
+                NotificationCenter.default.post(
+                    name: .shouldMovePositionPlaylistFloatingButton,
+                    object: PlaylistFloatingButtonPosition.default
+                )
+            }
+
         case "songDetail":
             let id = params["id"] as? String ?? ""
             songDetailPresenter.present(id: id)

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
@@ -62,7 +62,7 @@ final class ListStorageViewController: BaseReactorViewController<ListStorageReac
 
         // 플리 상세에서 내 리스트로 돌아오는 경우, 플로팅 버튼 올림
         NotificationCenter.default.post(
-            name: .shouldMovePositionPlaylistFloatingButton,
+            name: .shouldMovePlaylistFloatingButton,
             object: PlaylistFloatingButtonPosition.top
         )
     }
@@ -99,7 +99,7 @@ final class ListStorageViewController: BaseReactorViewController<ListStorageReac
             .bind(with: self, onNext: { owner, key in
                 // 플리 상세 진입 시, 플로팅 버튼 내림
                 NotificationCenter.default.post(
-                    name: .shouldMovePositionPlaylistFloatingButton,
+                    name: .shouldMovePlaylistFloatingButton,
                     object: PlaylistFloatingButtonPosition.default
                 )
                 owner.navigatePlaylistDetail(key: key)

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
@@ -59,6 +59,12 @@ final class ListStorageViewController: BaseReactorViewController<ListStorageReac
         super.viewDidAppear(animated)
         LogManager.analytics(CommonAnalyticsLog.viewPage(pageName: .storagePlaylist))
         listStorageView.resetParticeAnimation()
+
+        // 플리 상세에서 내 리스트로 돌아오는 경우, 플로팅 버튼 올림
+        NotificationCenter.default.post(
+            name: .shouldMovePositionPlaylistFloatingButton,
+            object: PlaylistFloatingButtonPosition.top
+        )
     }
 
     override func configureUI() {
@@ -91,6 +97,7 @@ final class ListStorageViewController: BaseReactorViewController<ListStorageReac
         reactor.pulse(\.$showDetail)
             .compactMap { $0 }
             .bind(with: self, onNext: { owner, key in
+                // 플리 상세 진입 시, 플로팅 버튼 내림
                 NotificationCenter.default.post(
                     name: .shouldMovePositionPlaylistFloatingButton,
                     object: PlaylistFloatingButtonPosition.default

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/ListStorageViewController.swift
@@ -91,6 +91,10 @@ final class ListStorageViewController: BaseReactorViewController<ListStorageReac
         reactor.pulse(\.$showDetail)
             .compactMap { $0 }
             .bind(with: self, onNext: { owner, key in
+                NotificationCenter.default.post(
+                    name: .shouldMovePositionPlaylistFloatingButton,
+                    object: PlaylistFloatingButtonPosition.default
+                )
                 owner.navigatePlaylistDetail(key: key)
             })
             .disposed(by: disposeBag)

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
@@ -83,7 +83,12 @@ final class StorageViewController: TabmanViewController, View {
         animated: Bool
     ) {
         self.reactor?.action.onNext(.switchTab(index))
-        NotificationCenter.default.post(name: .didChangeTabInStorage, object: index)
+        NotificationCenter.default.post(
+            name: .shouldMovePositionPlaylistFloatingButton,
+            object: index == 0 ?
+                PlaylistFloatingButtonPosition.top :
+                PlaylistFloatingButtonPosition.default
+        )
     }
 
     /// 탭맨 탭 터치 이벤트 감지 함수

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
@@ -83,6 +83,7 @@ final class StorageViewController: TabmanViewController, View {
         animated: Bool
     ) {
         self.reactor?.action.onNext(.switchTab(index))
+        // 탭 이동 간 플로팅 버튼 위치 조정
         NotificationCenter.default.post(
             name: .shouldMovePositionPlaylistFloatingButton,
             object: index == 0 ?

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/StorageViewController.swift
@@ -85,7 +85,7 @@ final class StorageViewController: TabmanViewController, View {
         self.reactor?.action.onNext(.switchTab(index))
         // 탭 이동 간 플로팅 버튼 위치 조정
         NotificationCenter.default.post(
-            name: .shouldMovePositionPlaylistFloatingButton,
+            name: .shouldMovePlaylistFloatingButton,
             object: index == 0 ?
                 PlaylistFloatingButtonPosition.top :
                 PlaylistFloatingButtonPosition.default

--- a/Projects/Modules/Utility/Sources/Enums/PlaylistFloatingButtonPosition.swift
+++ b/Projects/Modules/Utility/Sources/Enums/PlaylistFloatingButtonPosition.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public enum PlaylistFloatingButtonPosition {
+    case `default`
+    case top
+
+    public var bottomOffset: CGFloat {
+        switch self {
+        case .default:
+            return -20
+        case .top:
+            return -80
+        }
+    }
+}

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
@@ -9,5 +9,5 @@ public extension Notification.Name {
     static let willStatusBarEnterLightBackground = Notification.Name("willStatusBarEnterLightBackground")
     static let shouldHidePlaylistFloatingButton = Notification.Name("shouldHidePlaylistFloatingButton")
     static let shouldShowPlaylistFloatingButton = Notification.Name("shouldShowPlaylistFloatingButton")
-    static let shouldMovePositionPlaylistFloatingButton = Notification.Name("shouldMovePositionPlaylistFloatingButton")
+    static let shouldMovePlaylistFloatingButton = Notification.Name("shouldMovePlaylistFloatingButton")
 }

--- a/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
+++ b/Projects/Modules/Utility/Sources/Extensions/Extension+Notification.Name.swift
@@ -9,5 +9,5 @@ public extension Notification.Name {
     static let willStatusBarEnterLightBackground = Notification.Name("willStatusBarEnterLightBackground")
     static let shouldHidePlaylistFloatingButton = Notification.Name("shouldHidePlaylistFloatingButton")
     static let shouldShowPlaylistFloatingButton = Notification.Name("shouldShowPlaylistFloatingButton")
-    static let didChangeTabInStorage = Notification.Name("didChangeTabInStorage")
+    static let shouldMovePositionPlaylistFloatingButton = Notification.Name("shouldMovePositionPlaylistFloatingButton")
 }


### PR DESCRIPTION
## 💡 배경 및 개요
- 플로팅 버튼 위치가 안맞음 

Resolves: #1199

## 📃 작업내용
- 플로팅 버튼 위치 조정

## 🙋‍♂️ 리뷰노트
- 최대한 코드를 적게 작성하려 했으나, 이게 최선으로 결론 지음.

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
