### PR TITLE
🔀 :: (#1221) 구독 버튼 보여지는 시기 변경

### DIFF
--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -53,6 +53,7 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
 
     private var moreButton: UIButton = UIButton().then {
         $0.setImage(DesignSystemAsset.MyInfo.more.image, for: .normal)
+        $0.isHidden = true
     }
 
     private var saveCompletionIndicator = NVActivityIndicatorView(frame: .zero).then {

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
@@ -254,7 +254,6 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
                 }
 
                 owner.subscriptionButton.setTitle(flag ? "구독 중" : "구독", for: .normal)
-               
             }
             .disposed(by: disposeBag)
 

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
@@ -50,6 +50,7 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
     private lazy var subscriptionButton: RectangleButton = RectangleButton().then {
         $0.setBackgroundColor(.clear, for: .normal)
         $0.setColor(isHighlight: true)
+        $0.isHidden = true
         $0.setTitle("구독", for: .normal)
         $0.titleLabel?.font = .setFont(.t7(weight: .bold))
         $0.layer.borderWidth = 1
@@ -237,6 +238,7 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
                 } else {
                     owner.indicator.stopAnimating()
                     owner.tableView.isHidden = false
+                    owner.subscriptionButton.isHidden = false
                 }
             }
             .disposed(by: disposeBag)
@@ -252,6 +254,7 @@ final class UnknownPlaylistDetailViewController: BaseReactorViewController<Unkno
                 }
 
                 owner.subscriptionButton.setTitle(flag ? "구독 중" : "구독", for: .normal)
+               
             }
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 💡 배경 및 개요

구독 버튼 보여지는 시기가 ux상 맞지 않아 수정합니다.
https://discord.com/channels/1269673735380537404/1276982247412727862

Resolves: #1221

## 📃 작업내용

isHidden 시점을 tableview와 같게 맞춰줍니다.

## 🙋‍♂️ 리뷰노트



## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
