### PR TITLE
🔀 :: (#1227) 노래 상세에 진입 시 진입점 구분 없이 노래 상세의 데이터를 사용하도록 변경

### DIFF
--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicContentViewController.swift
@@ -219,7 +219,9 @@ extension ArtistMusicContentViewController: ArtistMusicCellDelegate {
             .first(where: { $0.songID == id })
         else { return }
         PlayState.shared.append(item: .init(id: tappedSong.songID, title: tappedSong.title, artist: tappedSong.artist))
-        songDetailPresenter.present(id: id)
+        let playlistIDs = PlayState.shared.currentPlaylist
+            .map(\.id)
+        songDetailPresenter.present(ids: playlistIDs, selectedID: tappedSong.songID)
     }
 }
 

--- a/Projects/Features/ChartFeature/Sources/ViewContrillers/ChartContentViewController.swift
+++ b/Projects/Features/ChartFeature/Sources/ViewContrillers/ChartContentViewController.swift
@@ -196,7 +196,9 @@ extension ChartContentViewController: ChartContentTableViewCellDelegate {
             .first(where: { $0.id == id })
         else { return }
         PlayState.shared.append(item: .init(id: tappedSong.id, title: tappedSong.title, artist: tappedSong.artist))
-        songDetailPresenter.present(id: id)
+        let playlistIDs = PlayState.shared.currentPlaylist
+            .map(\.id)
+        songDetailPresenter.present(ids: playlistIDs, selectedID: tappedSong.id)
     }
 }
 

--- a/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/CreditSongListTabItemReactor.swift
+++ b/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/CreditSongListTabItemReactor.swift
@@ -81,7 +81,9 @@ final class CreditSongListTabItemReactor: Reactor {
             return songDidTap(id: id)
         case let .songThumbnailDidTap(id):
             return navigateMutation(navigateType: .dismiss(completion: { [songDetailPresenter] in
-                songDetailPresenter.present(id: id)
+                let playlistIDs = PlayState.shared.currentPlaylist
+                    .map(\.id)
+                songDetailPresenter.present(ids: playlistIDs, selectedID: id)
             }))
         case .randomPlayButtonDidTap:
             return randomPlayButtonDidTap()

--- a/Projects/Features/HomeFeature/Sources/ViewControllers/HomeViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewControllers/HomeViewController.swift
@@ -410,7 +410,9 @@ extension HomeViewController: HomeChartCellDelegate {
     func thumbnailDidTap(model: ChartRankingEntity) {
         LogManager.analytics(HomeAnalyticsLog.clickMusicItem(location: .homeTop100, id: model.id))
         PlayState.shared.append(item: .init(id: model.id, title: model.title, artist: model.artist))
-        songDetailPresenter.present(id: model.id)
+        let playlistIDs = PlayState.shared.currentPlaylist
+            .map(\.id)
+        songDetailPresenter.present(ids: playlistIDs, selectedID: model.id)
     }
 
     func playButtonDidTap(model: ChartRankingEntity) {
@@ -426,7 +428,9 @@ extension HomeViewController: HomeNewSongCellDelegate {
     func thumbnailDidTap(model: NewSongsEntity) {
         LogManager.analytics(HomeAnalyticsLog.clickMusicItem(location: .homeRecent, id: model.id))
         PlayState.shared.append(item: .init(id: model.id, title: model.title, artist: model.artist))
-        songDetailPresenter.present(id: model.id)
+        let playlistIDs = PlayState.shared.currentPlaylist
+            .map(\.id)
+        songDetailPresenter.present(ids: playlistIDs, selectedID: model.id)
     }
 
     func playButtonDidTap(model: NewSongsEntity) {

--- a/Projects/Features/HomeFeature/Sources/ViewControllers/NewSongsContentViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewControllers/NewSongsContentViewController.swift
@@ -221,7 +221,9 @@ extension NewSongsContentViewController: NewSongsCellDelegate {
             .first(where: { $0.id == id })
         else { return }
         PlayState.shared.append(item: .init(id: tappedSong.id, title: tappedSong.title, artist: tappedSong.artist))
-        songDetailPresenter.present(id: id)
+        let playlistIDs = PlayState.shared.currentPlaylist
+            .map(\.id)
+        songDetailPresenter.present(ids: playlistIDs, selectedID: id)
     }
 }
 

--- a/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
+++ b/Projects/Features/MainTabFeature/Sources/ViewControllers/MainTabBarViewController.swift
@@ -157,7 +157,9 @@ private extension MainTabBarViewController {
 
         case "songDetail":
             let id = params["id"] as? String ?? ""
-            songDetailPresenter.present(id: id)
+            let playlistIDs = PlayState.shared.currentPlaylist
+                .map(\.id)
+            songDetailPresenter.present(ids: playlistIDs, selectedID: id)
 
         default:
             break

--- a/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailViewController.swift
+++ b/Projects/Features/MusicDetailFeature/Sources/MusicDetail/MusicDetailViewController.swift
@@ -60,7 +60,7 @@ final class MusicDetailViewController: BaseReactorViewController<MusicDetailReac
     override func bindState(reactor: MusicDetailReactor) {
         let sharedState = reactor.state
             .subscribe(on: MainScheduler.asyncInstance)
-            .share(replay: 2)
+            .share(replay: 8)
         let youtubeURLGenerator = YoutubeURLGenerator()
 
         sharedState.map(\.songIDs)
@@ -117,16 +117,17 @@ final class MusicDetailViewController: BaseReactorViewController<MusicDetailReac
         sharedState
             .filter { !$0.songIDs.isEmpty }
             .map(\.selectedIndex)
-            .skip(1)
-            .distinctUntilChanged()
-            .bind(onNext: musicDetailView.updateSelectedIndex(index:))
+            .skip(2)
+            .take(1)
+            .bind(onNext: musicDetailView.updateInitialSelectedIndex(index:))
             .disposed(by: disposeBag)
 
         sharedState
             .filter { !$0.songIDs.isEmpty }
             .map(\.selectedIndex)
-            .take(1)
-            .bind(onNext: musicDetailView.updateInitialSelectedIndex(index:))
+            .skip(3)
+            .distinctUntilChanged()
+            .bind(onNext: musicDetailView.updateSelectedIndex(index:))
             .disposed(by: disposeBag)
 
         sharedState.compactMap(\.navigateType)

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -260,7 +260,9 @@ final class MyPlaylistDetailViewController: BaseReactorViewController<MyPlaylist
                 guard let model = owner.dataSource.itemIdentifier(for: indexPath) else { return }
 
                 PlayState.shared.append(item: .init(id: model.id, title: model.title, artist: model.artist))
-                owner.songDetailPresenter.present(id: model.id)
+                let playlistIDs = PlayState.shared.currentPlaylist
+                    .map(\.id)
+                owner.songDetailPresenter.present(ids: playlistIDs, selectedID: model.id)
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/UnknownPlaylistDetailViewController.swift
@@ -356,7 +356,9 @@ extension UnknownPlaylistDetailViewController: PlaylistDateTableViewCellDelegate
             .first(where: { $0.id == key })
         else { return }
         PlayState.shared.append(item: .init(id: tappedSong.id, title: tappedSong.title, artist: tappedSong.artist))
-        songDetailPresenter.present(id: key)
+        let playlistIDs = PlayState.shared.currentPlaylist
+            .map(\.id)
+        songDetailPresenter.present(ids: playlistIDs, selectedID: key)
     }
 }
 

--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/WakmusicPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/WakmusicPlaylistDetailViewController.swift
@@ -328,7 +328,9 @@ extension WakmusicPlaylistDetailViewController: PlaylistDateTableViewCellDelegat
             .first(where: { $0.id == key })
         else { return }
         PlayState.shared.append(item: .init(id: tappedSong.id, title: tappedSong.title, artist: tappedSong.artist))
-        songDetailPresenter.present(id: key)
+        let playlistIDs = PlayState.shared.currentPlaylist
+            .map(\.id)
+        songDetailPresenter.present(ids: playlistIDs, selectedID: key)
     }
 }
 

--- a/Projects/Features/SearchFeature/Sources/After/ViewControllers/SongSearchResultViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/After/ViewControllers/SongSearchResultViewController.swift
@@ -322,7 +322,9 @@ extension SongSearchResultViewController: SongResultCellDelegate {
             .first(where: { $0.id == key })
         else { return }
         PlayState.shared.append(item: .init(id: tappedSong.id, title: tappedSong.title, artist: tappedSong.artist))
-        songDetailPresenter.present(id: key)
+        let playlistIDs = PlayState.shared.currentPlaylist
+            .map(\.id)
+        songDetailPresenter.present(ids: playlistIDs, selectedID: key)
     }
 }
 

--- a/Projects/Features/StorageFeature/Sources/ViewControllers/LikeStorageViewController.swift
+++ b/Projects/Features/StorageFeature/Sources/ViewControllers/LikeStorageViewController.swift
@@ -216,7 +216,9 @@ final class LikeStorageViewController: BaseReactorViewController<LikeStorageReac
                 LogManager.analytics(StorageAnalyticsLog.clickMyLikeListMusicButton(id: song.songID))
 
                 PlayState.shared.append(item: .init(id: song.songID, title: song.title, artist: song.artist))
-                owner.songDetailPresenter.present(id: song.songID)
+                let playlistIDs = PlayState.shared.currentPlaylist
+                    .map(\.id)
+                owner.songDetailPresenter.present(ids: playlistIDs, selectedID: song.songID)
             })
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 💡 배경 및 개요

<!--
> PR을 하게 된 문제상황, 배경 등 개요에 대해서 작성해주세요!
>
> 퍼블리싱의 경우 스크린샷/동영상도 추가해주면 좋아요!
-->

<!-- resolved issue 넘버 표기 방식 변경 시 '.github/actions/Auto_close_associate_issue/main.js' 또한 변경 필요 -->

노래 상세에 진입 시 진입점 구분 없이 노래 상세의 데이터를 사용하도록 변경

Resolves: #1227 

## 📃 작업내용

<!--
> PR에서 한 작업을 자세히 작성해주세요!
-->

노래 상세에 진입 시 진입점 구분 없이 노래 상세의 데이터를 사용하도록 변경

## 🙋‍♂️ 리뷰노트

혹시나 단일 노래를 보여줘야하는 상황이 생기거나 할 수도 있을거라 생각해서 일단 id, ids 파라미터는 남기고 직접 재생목록 데이터를 보내주는 식으로 바꿔놓았어요.
혹은 songDetailPresenter.present() 이렇게 id없이보내면 재생목록 데이터를 자동으로 사용하게 할 수도 있겠네요

<!--
> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!
-->

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
