### PR TITLE
🔀 :: (#1253) n등분 페이지 컨트롤러 화면 탭 버튼 사이간격 제거

### DIFF
--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistMusicViewController.swift
@@ -68,6 +68,7 @@ extension ArtistMusicViewController {
         bar.layout.contentInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
         bar.layout.contentMode = .fit
         bar.layout.transitionStyle = .progressive
+        bar.layout.interButtonSpacing = 0
 
         // 버튼 글씨 커스텀
         bar.buttons.customize { button in

--- a/Projects/Features/ChartFeature/Sources/ViewContrillers/ChartViewController.swift
+++ b/Projects/Features/ChartFeature/Sources/ViewContrillers/ChartViewController.swift
@@ -86,6 +86,7 @@ private extension ChartViewController {
         bar.layout.contentInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
         bar.layout.contentMode = .fit
         bar.layout.transitionStyle = .progressive
+        bar.layout.interButtonSpacing = 0
 
         // 버튼 글씨 커스텀
         bar.buttons.customize { button in

--- a/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/CreditSongListTabViewController.swift
+++ b/Projects/Features/CreditSongListFeature/Sources/CreditSongListTab/CreditSongListTabViewController.swift
@@ -74,6 +74,7 @@ private extension CreditSongListTabViewController {
         bar.layout.contentInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
         bar.layout.contentMode = .fit
         bar.layout.transitionStyle = .progressive
+        bar.layout.interButtonSpacing = 0
 
         bar.buttons.customize { button in
             button.tintColor = DesignSystemAsset.BlueGrayColor.blueGray400.color

--- a/Projects/Features/HomeFeature/Sources/ViewControllers/NewSongsViewController.swift
+++ b/Projects/Features/HomeFeature/Sources/ViewControllers/NewSongsViewController.swift
@@ -93,6 +93,7 @@ extension NewSongsViewController {
         bar.layout.contentInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
         bar.layout.contentMode = .fit
         bar.layout.transitionStyle = .progressive
+        bar.layout.interButtonSpacing = 0
 
         // 버튼 글씨 커스텀
         bar.buttons.customize { button in

--- a/Projects/Features/SearchFeature/Sources/After/ViewControllers/AfterSearchViewController.swift
+++ b/Projects/Features/SearchFeature/Sources/After/ViewControllers/AfterSearchViewController.swift
@@ -99,6 +99,7 @@ extension AfterSearchViewController {
         bar.layout.contentInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
         bar.layout.contentMode = .fit
         bar.layout.transitionStyle = .progressive
+        bar.layout.interButtonSpacing = 0
 
         // 버튼 글씨 커스텀
         bar.buttons.customize { button in

--- a/Projects/Features/TeamFeature/Sources/ViewControllers/TeamInfoViewController.swift
+++ b/Projects/Features/TeamFeature/Sources/ViewControllers/TeamInfoViewController.swift
@@ -151,6 +151,7 @@ private extension TeamInfoViewController {
         bar.layout.contentInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
         bar.layout.contentMode = .fit
         bar.layout.transitionStyle = .progressive
+        bar.layout.interButtonSpacing = 0
 
         // 버튼 글씨 커스텀
         bar.buttons.customize { button in


### PR DESCRIPTION
## 💡 배경 및 개요
최신음악 탭에서 n등분 탭의 텍스트가 짤리는 현상 발견

Resolves: #1253 

## 📃 작업내용
- bar.layout.contentMode = .fit 으로 사용중인 화면의 버튼간격 0으로 수정 (내부 까보니 디폴트 간격이 있었음)

## 🙋‍♂️ 리뷰노트
x

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
