### PR TITLE
🔀 :: (#1259) 아티스트 설명글 짤림 보완

### DIFF
--- a/Projects/Features/ArtistFeature/Resources/Artist.storyboard
+++ b/Projects/Features/ArtistFeature/Resources/Artist.storyboard
@@ -151,16 +151,13 @@
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                     </button>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이세계아이돌" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="he6-oI-bGB">
-                                                        <rect key="frame" x="16" y="56" width="166.33333333333334" height="24"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="24" id="6B8-5r-FG8"/>
-                                                        </constraints>
+                                                        <rect key="frame" x="16" y="56" width="166.33333333333334" height="17"/>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                                         <color key="textColor" red="0.062745098040000002" green="0.094117647060000004" blue="0.15686274510000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="세계 최초의 무7도록 킹받는 아이돌그 뒤에 숨겨진 귀여움이 '좀 더' 킹받는 그녀" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ne5-kV-2su">
-                                                        <rect key="frame" x="16" y="92" width="166.33333333333334" height="50.333333333333343"/>
+                                                        <rect key="frame" x="16" y="87" width="166.33333333333334" height="50.333333333333343"/>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                                         <color key="textColor" red="0.062745098040000002" green="0.094117647060000004" blue="0.15686274510000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -170,7 +167,7 @@
                                                     <constraint firstItem="7rb-8Q-BEe" firstAttribute="leading" secondItem="FNn-dd-tDU" secondAttribute="leading" constant="16" id="BAQ-lY-NvS"/>
                                                     <constraint firstAttribute="trailing" secondItem="4gB-Rq-DeW" secondAttribute="trailing" constant="16" id="Cya-rc-sKO"/>
                                                     <constraint firstAttribute="trailing" secondItem="he6-oI-bGB" secondAttribute="trailing" constant="16" id="DPc-F0-IuF"/>
-                                                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="ne5-kV-2su" secondAttribute="bottom" constant="16" id="FNe-2r-Avv"/>
+                                                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="ne5-kV-2su" secondAttribute="bottom" id="FNe-2r-Avv"/>
                                                     <constraint firstItem="4gB-Rq-DeW" firstAttribute="leading" secondItem="7rb-8Q-BEe" secondAttribute="trailing" id="Fet-VD-KLT"/>
                                                     <constraint firstItem="he6-oI-bGB" firstAttribute="top" secondItem="7rb-8Q-BEe" secondAttribute="bottom" constant="8" id="I3h-yC-NzL"/>
                                                     <constraint firstItem="7rb-8Q-BEe" firstAttribute="top" secondItem="FNn-dd-tDU" secondAttribute="top" constant="12" id="L67-RP-pYQ"/>
@@ -178,16 +175,16 @@
                                                     <constraint firstItem="4gB-Rq-DeW" firstAttribute="top" secondItem="FNn-dd-tDU" secondAttribute="top" constant="16" id="mPR-QE-w15"/>
                                                     <constraint firstItem="he6-oI-bGB" firstAttribute="leading" secondItem="7rb-8Q-BEe" secondAttribute="leading" id="nFq-RK-3pt"/>
                                                     <constraint firstItem="ne5-kV-2su" firstAttribute="leading" secondItem="he6-oI-bGB" secondAttribute="leading" id="pwr-x8-lDS"/>
-                                                    <constraint firstItem="ne5-kV-2su" firstAttribute="top" secondItem="he6-oI-bGB" secondAttribute="bottom" constant="12" id="v8Q-Ea-Jh8"/>
+                                                    <constraint firstItem="ne5-kV-2su" firstAttribute="top" secondItem="he6-oI-bGB" secondAttribute="bottom" constant="14" id="v8Q-Ea-Jh8"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6eV-FK-IbB">
                                                 <rect key="frame" x="0.0" y="0.0" width="198.33333333333334" height="188.66666666666666"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="소개글" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cYZ-24-Z5e">
-                                                        <rect key="frame" x="16" y="16" width="142.33333333333334" height="24"/>
+                                                        <rect key="frame" x="16" y="16" width="142.33333333333334" height="22"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" constant="24" id="ZR1-lj-UTC"/>
+                                                            <constraint firstAttribute="height" constant="22" id="ZR1-lj-UTC"/>
                                                         </constraints>
                                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                                         <color key="textColor" red="0.062745098040000002" green="0.094117647060000004" blue="0.15686274510000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -238,7 +235,7 @@
                                                     </scrollView>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstItem="msH-8e-y5Q" firstAttribute="top" secondItem="cYZ-24-Z5e" secondAttribute="bottom" constant="8" id="2c1-R8-T4c"/>
+                                                    <constraint firstItem="msH-8e-y5Q" firstAttribute="top" secondItem="cYZ-24-Z5e" secondAttribute="bottom" constant="10" id="2c1-R8-T4c"/>
                                                     <constraint firstItem="oAc-YA-UoU" firstAttribute="leading" secondItem="cYZ-24-Z5e" secondAttribute="trailing" id="3kU-zK-aq0"/>
                                                     <constraint firstItem="oAc-YA-UoU" firstAttribute="top" secondItem="6eV-FK-IbB" secondAttribute="top" constant="16" id="9eg-8b-pqX"/>
                                                     <constraint firstAttribute="bottom" secondItem="msH-8e-y5Q" secondAttribute="bottom" constant="16" id="Dci-Jw-Es2"/>
@@ -286,7 +283,6 @@
                         <outlet property="artistGroupLabel" destination="he6-oI-bGB" id="uQN-HD-EDe"/>
                         <outlet property="artistImageView" destination="meV-gF-5BZ" id="dUg-HZ-EFX"/>
                         <outlet property="artistIntroLabel" destination="ne5-kV-2su" id="I4d-LH-IDA"/>
-                        <outlet property="artistIntroLabelBottomConstraint" destination="FNe-2r-Avv" id="7bR-jq-6uI"/>
                         <outlet property="artistNameLabel" destination="7rb-8Q-BEe" id="JdJ-eX-T81"/>
                         <outlet property="artistNameLabelHeight" destination="zPQ-dD-b7K" id="Tv4-wl-ZF4"/>
                         <outlet property="descriptionBackButton" destination="oAc-YA-UoU" id="yYA-wc-8Gr"/>

--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistDetailHeaderViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistDetailHeaderViewController.swift
@@ -96,7 +96,6 @@ extension ArtistDetailHeaderViewController {
                     [.font: UIFont.WMFontSystem.t3(weight: .bold).font],
                     range: artistKrNameRange
                 )
-
             }
         }
 

--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistDetailHeaderViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistDetailHeaderViewController.swift
@@ -17,7 +17,6 @@ class ArtistDetailHeaderViewController: UIViewController, ViewControllerFromStor
     @IBOutlet weak var artistNameLabelHeight: NSLayoutConstraint!
     @IBOutlet weak var artistGroupLabel: UILabel!
     @IBOutlet weak var artistIntroLabel: UILabel!
-    @IBOutlet weak var artistIntroLabelBottomConstraint: NSLayoutConstraint!
 
     /// Description Back
     @IBOutlet weak var descriptionBackView: UIView!
@@ -56,7 +55,7 @@ extension ArtistDetailHeaderViewController {
         let artistNameAttributedString = NSMutableAttributedString(
             string: artistKrName + " " + artistEnName,
             attributes: [
-                .font: DesignSystemFontFamily.Pretendard.bold.font(size: 24),
+                .font: UIFont.WMFontSystem.t1(weight: .bold).font,
                 .foregroundColor: DesignSystemAsset.BlueGrayColor.gray900.color,
                 .kern: -0.5
             ]
@@ -65,12 +64,10 @@ extension ArtistDetailHeaderViewController {
         let artistKrNameRange = (artistNameAttributedString.string as NSString).range(of: artistKrName)
         let artistEnNameRange = (artistNameAttributedString.string as NSString).range(of: artistEnName)
 
-        artistNameAttributedString.addAttributes(
-            [
-                .font: DesignSystemFontFamily.Pretendard.light.font(size: 14),
-                .foregroundColor: DesignSystemAsset.BlueGrayColor.gray900.color.withAlphaComponent(0.6),
-                .kern: -0.5
-            ],
+        artistNameAttributedString.addAttributes([
+            .font: UIFont.WMFontSystem.t6(weight: .light).font,
+            .foregroundColor: DesignSystemAsset.BlueGrayColor.gray900.color.withAlphaComponent(0.6),
+            .kern: -0.5],
             range: artistEnNameRange
         )
 
@@ -82,57 +79,42 @@ extension ArtistDetailHeaderViewController {
         DEBUG_LOG("\(model.krName): \(artistNameWidth)")
 
         artistNameAttributedString.addAttributes(
-            [.font: DesignSystemFontFamily.Pretendard.bold.font(size: availableWidth >= artistNameWidth ? 24 : 20)],
+            [.font: availableWidth >= artistNameWidth ?
+             UIFont.WMFontSystem.t1(weight: .bold).font : UIFont.WMFontSystem.t3(weight: .bold).font],
             range: artistKrNameRange
         )
 
-        self.artistNameLabelHeight.constant =
-            (availableWidth >= artistNameWidth) ? 36 :
-            ceil(artistNameAttributedString.height(containerWidth: availableWidth))
+        artistNameLabelHeight.constant = (availableWidth >= artistNameWidth) ?
+            36 : ceil(artistNameAttributedString.height(containerWidth: availableWidth))
+        artistNameLabel.attributedText = artistNameAttributedString
 
-        self.artistNameLabel.attributedText = artistNameAttributedString
-
-        self.artistGroupLabel.text = model.groupName + (model.graduated ? " · 졸업" : "")
-
-        let artistIntroParagraphStyle = NSMutableParagraphStyle()
-        artistIntroParagraphStyle.lineHeightMultiple = (APP_WIDTH() < 375) ? 0 : 1.44
-
-        let artistIntroAttributedString = NSMutableAttributedString(
-            string: model.title,
-            attributes: [
-                .font: DesignSystemFontFamily.Pretendard.medium.font(size: 14),
-                .foregroundColor: DesignSystemAsset.BlueGrayColor.gray900.color,
-                .paragraphStyle: artistIntroParagraphStyle,
-                .kern: -0.5
-            ]
+        artistGroupLabel.text = (model.id == "woowakgood") ? "" : model.groupName + (model.graduated ? " · 졸업" : "")
+        artistGroupLabel.setTextWithAttributes(
+            lineHeight: UIFont.WMFontSystem.t6(weight: .medium).lineHeight,
+            lineBreakMode: .byCharWrapping
         )
-        self.artistIntroLabel.lineBreakMode = .byCharWrapping
-        self.artistIntroLabel.attributedText = artistIntroAttributedString
-        self.artistIntroLabelBottomConstraint.constant = (APP_WIDTH() < 375) ? 0 : 16
 
-        self.introTitleLabel.text = "소개글"
-        let artistIntroDescriptionParagraphStyle = NSMutableParagraphStyle()
-        artistIntroDescriptionParagraphStyle.lineHeightMultiple = 1.26
-
-        let artistIntroDescriptionAttributedString = NSMutableAttributedString(
-            string: model.description,
-            attributes: [
-                .font: DesignSystemFontFamily.Pretendard.light.font(size: 12),
-                .foregroundColor: DesignSystemAsset.BlueGrayColor.gray900.color,
-                .paragraphStyle: artistIntroDescriptionParagraphStyle,
-                .kern: -0.5
-            ]
+        artistIntroLabel.text = model.title
+        artistIntroLabel.setTextWithAttributes(
+            lineHeight: UIFont.WMFontSystem.t6(weight: .medium).lineHeight,
+            lineBreakMode: .byWordWrapping,
+            hangulWordPriority: true
         )
-        self.introDescriptionLabel.attributedText = artistIntroDescriptionAttributedString
+
+        introDescriptionLabel.text = model.description
+        introDescriptionLabel.setTextWithAttributes(
+            lineHeight: UIFont.WMFontSystem.t7(weight: .light).lineHeight,
+            lineBreakMode: .byCharWrapping
+        )
 
         let encodedImageURLString: String = model.squareImage
             .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? model.squareImage
+
         artistImageView.kf.setImage(
             with: URL(string: encodedImageURLString),
             placeholder: nil,
             options: [.transition(.fade(0.2))]
         )
-        self.view.layoutIfNeeded()
     }
 }
 
@@ -179,23 +161,22 @@ private extension ArtistDetailHeaderViewController {
         descriptionFrontView.isHidden = false
         descriptionBackView.isHidden = true
 
-        artistGroupLabel.font = DesignSystemFontFamily.Pretendard.medium.font(size: 14)
+        artistGroupLabel.font = UIFont.WMFontSystem.t6(weight: .medium).font
         artistGroupLabel.textColor = DesignSystemAsset.BlueGrayColor.gray900.color
-        artistGroupLabel.setTextWithAttributes(kernValue: -0.5)
+        artistGroupLabel.numberOfLines = 1
 
-        artistIntroLabel.font = DesignSystemFontFamily.Pretendard.medium.font(size: 14)
+        artistIntroLabel.font = UIFont.WMFontSystem.t6(weight: .medium).font
         artistIntroLabel.textColor = DesignSystemAsset.BlueGrayColor.gray900.color
-        artistIntroLabel.textAlignment = .left
+        artistIntroLabel.numberOfLines = 0
 
-        introTitleLabel.font = DesignSystemFontFamily.Pretendard.bold.font(size: 14)
+        introTitleLabel.text = "소개글"
+        introTitleLabel.font = UIFont.WMFontSystem.t6(weight: .bold).font
         introTitleLabel.textColor = DesignSystemAsset.BlueGrayColor.gray900.color
         introTitleLabel.setTextWithAttributes(kernValue: -0.5)
 
-        introDescriptionLabel.font = DesignSystemFontFamily.Pretendard.light.font(size: 12)
+        introDescriptionLabel.font = UIFont.WMFontSystem.t7(weight: .light).font
         introDescriptionLabel.textColor = DesignSystemAsset.BlueGrayColor.gray900.color
-        introDescriptionLabel.textAlignment = .left
-        introDescriptionLabel.lineBreakMode = .byWordWrapping
-        introDescriptionLabel.setTextWithAttributes(kernValue: -0.5)
+        introDescriptionLabel.numberOfLines = 0
 
         scrollView.verticalScrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: -3)
     }

--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistDetailHeaderViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistDetailHeaderViewController.swift
@@ -86,7 +86,7 @@ extension ArtistDetailHeaderViewController {
                 range: artistKrNameRange
             )
         } else {
-            if model.krName.count >= 10 { // ex: 김치만두
+            if model.krName.count >= 9 { // ex: 김치만두번영택사스가, 캘리칼리 데이비슨
                 artistNameAttributedString.addAttributes(
                     [.font: UIFont.WMFontSystem.t4(weight: .bold).font],
                     range: artistKrNameRange

--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistDetailHeaderViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistDetailHeaderViewController.swift
@@ -80,19 +80,32 @@ extension ArtistDetailHeaderViewController {
         DEBUG_LOG("availableWidth: \(availableWidth)")
         DEBUG_LOG("\(model.krName): \(artistNameWidth)")
 
-        artistNameAttributedString.addAttributes(
-            [
-                .font: availableWidth >= artistNameWidth ?
-                    UIFont.WMFontSystem.t1(weight: .bold).font : UIFont.WMFontSystem.t3(weight: .bold).font
-            ],
-            range: artistKrNameRange
-        )
+        if availableWidth >= artistNameWidth {
+            artistNameAttributedString.addAttributes(
+                [.font: UIFont.WMFontSystem.t1(weight: .bold).font],
+                range: artistKrNameRange
+            )
+        } else {
+            if model.krName.count >= 10 { // ex: 김치만두
+                artistNameAttributedString.addAttributes(
+                    [.font: UIFont.WMFontSystem.t4(weight: .bold).font],
+                    range: artistKrNameRange
+                )
+            } else {
+                artistNameAttributedString.addAttributes(
+                    [.font: UIFont.WMFontSystem.t3(weight: .bold).font],
+                    range: artistKrNameRange
+                )
+
+            }
+        }
 
         artistNameLabelHeight.constant = (availableWidth >= artistNameWidth) ?
             36 : ceil(artistNameAttributedString.height(containerWidth: availableWidth))
         artistNameLabel.attributedText = artistNameAttributedString
 
-        artistGroupLabel.text = (model.id == "woowakgood") ? "" : model.groupName + (model.graduated ? " · 졸업" : "")
+        artistGroupLabel.text = (model.id == "woowakgood") ?
+            "" : model.groupName + (model.graduated ? " · 졸업" : "")
         artistGroupLabel.setTextWithAttributes(
             lineHeight: UIFont.WMFontSystem.t6(weight: .medium).lineHeight,
             lineBreakMode: .byCharWrapping

--- a/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistDetailHeaderViewController.swift
+++ b/Projects/Features/ArtistFeature/Sources/ViewControllers/ArtistDetailHeaderViewController.swift
@@ -64,10 +64,12 @@ extension ArtistDetailHeaderViewController {
         let artistKrNameRange = (artistNameAttributedString.string as NSString).range(of: artistKrName)
         let artistEnNameRange = (artistNameAttributedString.string as NSString).range(of: artistEnName)
 
-        artistNameAttributedString.addAttributes([
-            .font: UIFont.WMFontSystem.t6(weight: .light).font,
-            .foregroundColor: DesignSystemAsset.BlueGrayColor.gray900.color.withAlphaComponent(0.6),
-            .kern: -0.5],
+        artistNameAttributedString.addAttributes(
+            [
+                .font: UIFont.WMFontSystem.t6(weight: .light).font,
+                .foregroundColor: DesignSystemAsset.BlueGrayColor.gray900.color.withAlphaComponent(0.6),
+                .kern: -0.5
+            ],
             range: artistEnNameRange
         )
 
@@ -79,8 +81,10 @@ extension ArtistDetailHeaderViewController {
         DEBUG_LOG("\(model.krName): \(artistNameWidth)")
 
         artistNameAttributedString.addAttributes(
-            [.font: availableWidth >= artistNameWidth ?
-             UIFont.WMFontSystem.t1(weight: .bold).font : UIFont.WMFontSystem.t3(weight: .bold).font],
+            [
+                .font: availableWidth >= artistNameWidth ?
+                    UIFont.WMFontSystem.t1(weight: .bold).font : UIFont.WMFontSystem.t3(weight: .bold).font
+            ],
             range: artistKrNameRange
         )
 

--- a/Projects/UsertInterfaces/DesignSystem/Sources/Extension+UILabel.swift
+++ b/Projects/UsertInterfaces/DesignSystem/Sources/Extension+UILabel.swift
@@ -63,6 +63,7 @@ public extension UILabel {
     /// - Parameter lineHeightMultiple: 줄 간격의 배수 (lineSpacing *  lineHeightMultiple)
     func getTextWithAttributes(
         lineHeight: CGFloat? = nil,
+        lineBreakMode: NSLineBreakMode = .byTruncatingTail,
         kernValue: Double? = nil,
         lineSpacing: CGFloat? = nil,
         lineHeightMultiple: CGFloat? = nil,
@@ -73,7 +74,7 @@ public extension UILabel {
         if let lineSpacing { paragraphStyle.lineSpacing = lineSpacing }
         if let lineHeightMultiple { paragraphStyle.lineHeightMultiple = lineHeightMultiple }
 
-        paragraphStyle.lineBreakMode = .byTruncatingTail
+        paragraphStyle.lineBreakMode = lineBreakMode
         paragraphStyle.alignment = alignment
 
         let baselineOffset: CGFloat
@@ -104,18 +105,24 @@ public extension UILabel {
 
     func setTextWithAttributes(
         lineHeight: CGFloat? = nil,
+        lineBreakMode: NSLineBreakMode = .byTruncatingTail,
         kernValue: Double? = -0.5,
         lineSpacing: CGFloat? = nil,
         lineHeightMultiple: CGFloat? = nil,
-        alignment: NSTextAlignment = .left
+        alignment: NSTextAlignment = .left,
+        hangulWordPriority: Bool = false
     ) {
         let paragraphStyle = NSMutableParagraphStyle()
 
         if let lineSpacing { paragraphStyle.lineSpacing = lineSpacing }
         if let lineHeightMultiple { paragraphStyle.lineHeightMultiple = lineHeightMultiple }
 
-        paragraphStyle.lineBreakMode = .byTruncatingTail
+        paragraphStyle.lineBreakMode = lineBreakMode
         paragraphStyle.alignment = alignment
+        
+        if hangulWordPriority {
+            paragraphStyle.lineBreakStrategy = .hangulWordPriority
+        }
 
         let baselineOffset: CGFloat
         let offsetDivisor: CGFloat

--- a/Projects/UsertInterfaces/DesignSystem/Sources/Extension+UILabel.swift
+++ b/Projects/UsertInterfaces/DesignSystem/Sources/Extension+UILabel.swift
@@ -119,7 +119,7 @@ public extension UILabel {
 
         paragraphStyle.lineBreakMode = lineBreakMode
         paragraphStyle.alignment = alignment
-        
+
         if hangulWordPriority {
             paragraphStyle.lineBreakStrategy = .hangulWordPriority
         }


### PR DESCRIPTION
## 💡 배경 및 개요
- 아티스트 설명글이 짤림


Resolves: #1259


## 📃 작업내용
- 텍스트 간격 피그마와 최대한 일치 (설명 글 하단 간격이 쓸데없이 크게 잡혀있었음)
- 설명글은 한글 텍스트 라인브레이크 적용

## 🙋‍♂️ 리뷰노트
- UILabel 특성상 다각형 레이아웃을 구성할 수 없어 김치만두, 데스해머쵸로키 같은 레이아웃은 구성할 수가 없음.
- '우왁굳' 이름 폰트 크기가 맞지않는 것도 옆에 영문 이름이 따라붙어야 하는(줄바꿈 조건 포함) 공통의 조건을 만족시키기 위함.

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
