### PR TITLE
🔀 :: (#1243) fix 미설치 버튼 터치 영역 확장

### DIFF
--- a/Projects/Features/MyInfoFeature/Sources/Views/PlayTypeTogglePopupItemButton.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/PlayTypeTogglePopupItemButton.swift
@@ -172,24 +172,24 @@ private extension PlayTypeTogglePopupItemButtonView {
             $0.backgroundColor = .white
             $0.clipsToBounds = true
         }
-        
+
         let button = UIButton()
-        
+
         init() {
             super.init(frame: .zero)
             addViews()
             setLayout()
         }
-        
+
         @available(*, unavailable)
         required init?(coder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
-        
+
         func addViews() {
             addSubviews(titleLabel, button)
         }
-        
+
         func setLayout() {
             titleLabel.snp.makeConstraints {
                 $0.width.equalTo(55)
@@ -197,11 +197,10 @@ private extension PlayTypeTogglePopupItemButtonView {
                 $0.trailing.equalToSuperview().inset(20)
                 $0.centerY.equalToSuperview()
             }
-            
+
             button.snp.makeConstraints {
                 $0.edges.equalToSuperview()
             }
-        } 
+        }
     }
-    
 }

--- a/Projects/Features/MyInfoFeature/Sources/Views/PlayTypeTogglePopupItemButton.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/PlayTypeTogglePopupItemButton.swift
@@ -27,17 +27,7 @@ final class PlayTypeTogglePopupItemButtonView: UIView {
         $0.contentMode = .scaleAspectFit
     }
 
-    private let installButton = UIButton().then {
-        $0.layer.cornerRadius = 4
-        $0.layer.borderWidth = 1
-        $0.layer.borderColor = DesignSystemAsset.BlueGrayColor.gray300.color.cgColor
-        $0.setTitle("미설치", for: .normal)
-        $0.setBackgroundColor(.white, for: .normal)
-        $0.setBackgroundColor(.lightGray, for: .highlighted)
-        $0.setTitleColor(DesignSystemAsset.BlueGrayColor.gray400.color, for: .normal)
-        $0.setTitleColor(.white, for: .highlighted)
-        $0.titleLabel?.font = UIFont.WMFontSystem.t7(weight: .bold).font
-        $0.clipsToBounds = true
+    private let installButtonView = InstallButtonView().then {
         $0.isHidden = true
     }
 
@@ -89,7 +79,7 @@ final class PlayTypeTogglePopupItemButtonView: UIView {
         } else {
             isInstalled = false
         }
-        installButton.isHidden = isInstalled
+        installButtonView.isHidden = isInstalled
         button.isEnabled = isInstalled
 
         return isInstalled
@@ -125,7 +115,7 @@ private extension PlayTypeTogglePopupItemButtonView {
         }
         button.addAction(buttonAction, for: .touchUpInside)
 
-        installButton.addAction {
+        installButtonView.button.addAction {
             let youtubeMusicAppStoreURL = "itms-apps://apps.apple.com/app/id1017492454"
             if let url = URL(string: youtubeMusicAppStoreURL) {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
@@ -138,7 +128,7 @@ private extension PlayTypeTogglePopupItemButtonView {
         addSubview(titleLabel)
         addSubview(imageView)
         addSubview(button)
-        addSubview(installButton)
+        addSubview(installButtonView)
     }
 
     func setLayout() {
@@ -162,11 +152,56 @@ private extension PlayTypeTogglePopupItemButtonView {
             $0.edges.equalTo(baseView)
         }
 
-        installButton.snp.makeConstraints {
-            $0.width.equalTo(55)
-            $0.height.equalTo(24)
-            $0.trailing.equalToSuperview().inset(20)
-            $0.centerY.equalToSuperview()
+        installButtonView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
     }
+}
+
+private extension PlayTypeTogglePopupItemButtonView {
+    class InstallButtonView: UIView {
+        private let titleLabel = WMLabel(
+            text: "미설치",
+            textColor: DesignSystemAsset.BlueGrayColor.gray400.color,
+            font: .t7(weight: .bold),
+            alignment: .center
+        ).then {
+            $0.layer.cornerRadius = 4
+            $0.layer.borderWidth = 1
+            $0.layer.borderColor = DesignSystemAsset.BlueGrayColor.gray300.color.cgColor
+            $0.backgroundColor = .white
+            $0.clipsToBounds = true
+        }
+        
+        let button = UIButton()
+        
+        init() {
+            super.init(frame: .zero)
+            addViews()
+            setLayout()
+        }
+        
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+        
+        func addViews() {
+            addSubviews(titleLabel, button)
+        }
+        
+        func setLayout() {
+            titleLabel.snp.makeConstraints {
+                $0.width.equalTo(55)
+                $0.height.equalTo(24)
+                $0.trailing.equalToSuperview().inset(20)
+                $0.centerY.equalToSuperview()
+            }
+            
+            button.snp.makeConstraints {
+                $0.edges.equalToSuperview()
+            }
+        } 
+    }
+    
 }

--- a/Projects/Features/MyInfoFeature/Sources/Views/PlayTypeTogglePopupItemButton.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/PlayTypeTogglePopupItemButton.swift
@@ -27,7 +27,7 @@ final class PlayTypeTogglePopupItemButtonView: UIView {
         $0.contentMode = .scaleAspectFit
     }
 
-    private let installButtonView = InstallButtonView().then {
+    private let installButton = InstallButton().then {
         $0.isHidden = true
     }
 
@@ -79,7 +79,7 @@ final class PlayTypeTogglePopupItemButtonView: UIView {
         } else {
             isInstalled = false
         }
-        installButtonView.isHidden = isInstalled
+        installButton.isHidden = isInstalled
         button.isEnabled = isInstalled
 
         return isInstalled
@@ -115,7 +115,7 @@ private extension PlayTypeTogglePopupItemButtonView {
         }
         button.addAction(buttonAction, for: .touchUpInside)
 
-        installButtonView.button.addAction {
+        installButton.addAction {
             let youtubeMusicAppStoreURL = "itms-apps://apps.apple.com/app/id1017492454"
             if let url = URL(string: youtubeMusicAppStoreURL) {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
@@ -128,7 +128,7 @@ private extension PlayTypeTogglePopupItemButtonView {
         addSubview(titleLabel)
         addSubview(imageView)
         addSubview(button)
-        addSubview(installButtonView)
+        addSubview(installButton)
     }
 
     func setLayout() {
@@ -152,15 +152,15 @@ private extension PlayTypeTogglePopupItemButtonView {
             $0.edges.equalTo(baseView)
         }
 
-        installButtonView.snp.makeConstraints {
+        installButton.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
     }
 }
 
 private extension PlayTypeTogglePopupItemButtonView {
-    class InstallButtonView: UIView {
-        private let titleLabel = WMLabel(
+    class InstallButton: UIButton {
+        private let messageLabel = WMLabel(
             text: "미설치",
             textColor: DesignSystemAsset.BlueGrayColor.gray400.color,
             font: .t7(weight: .bold),
@@ -172,8 +172,6 @@ private extension PlayTypeTogglePopupItemButtonView {
             $0.backgroundColor = .white
             $0.clipsToBounds = true
         }
-
-        let button = UIButton()
 
         init() {
             super.init(frame: .zero)
@@ -187,19 +185,15 @@ private extension PlayTypeTogglePopupItemButtonView {
         }
 
         func addViews() {
-            addSubviews(titleLabel, button)
+            addSubviews(messageLabel)
         }
 
         func setLayout() {
-            titleLabel.snp.makeConstraints {
+            messageLabel.snp.makeConstraints {
                 $0.width.equalTo(55)
                 $0.height.equalTo(24)
                 $0.trailing.equalToSuperview().inset(20)
                 $0.centerY.equalToSuperview()
-            }
-
-            button.snp.makeConstraints {
-                $0.edges.equalToSuperview()
             }
         }
     }


### PR DESCRIPTION
## 💡 배경 및 개요

디자인 요구사항 변경에 따라 터치 영역을 확장합니다.

Resolves: #1243

## 📃 작업내용

- 미설치 버튼 뷰 분리

## 🙋‍♂️ 리뷰노트

| 화면 | 하이어라키 |
|--------|--------|
| ![simulator_screenshot_8E01ACE1-E3AD-4C6E-8691-5FA607F3F096](https://github.com/user-attachments/assets/fca59f83-01e1-4e41-a6e5-d8db1aff43ec) | <img width="100%" alt="image" src="https://github.com/user-attachments/assets/131206eb-b0d3-423a-b6b0-dc6901115821"> | 

지금보니 디자인이 많이 바뀌었네요.. 다음 PR에서 이어집니다 😄 

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
