### PR TITLE
🔀 :: (#1258) 닉네임 입력 조건 추가

### DIFF
--- a/Projects/Features/BaseFeature/Resources/Base.storyboard
+++ b/Projects/Features/BaseFeature/Resources/Base.storyboard
@@ -385,13 +385,17 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="cfO-nl-nfD">
-                                        <rect key="frame" x="20" y="145" width="316" height="18.666666666666657"/>
+                                        <rect key="frame" x="20" y="145" width="303" height="18.666666666666657"/>
                                         <color key="textColor" name="gray800"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="O6b-uG-uWT">
-                                        <rect key="frame" x="341" y="137.33333333333334" width="32" height="34"/>
+                                        <rect key="frame" x="328" y="142.33333333333334" width="45" height="24"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="24" id="XQd-rR-LNT"/>
+                                            <constraint firstAttribute="width" constant="45" id="laI-2j-1tT"/>
+                                        </constraints>
                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                         <state key="normal" title="취소">
                                             <color key="titleColor" name="gray400"/>

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
@@ -151,7 +151,6 @@ private extension MultiPurposePopupViewController {
         cancelButton.layer.borderWidth = 1
         cancelButton.backgroundColor = .white
         cancelButton.isHidden = true
-        cancelButton.contentEdgeInsets = .init(top: 3, left: 12, bottom: 3, right: 12)
 
         confirmLabel.font = DesignSystemFontFamily.Pretendard.light.font(size: 12)
         confirmLabel.isHidden = true
@@ -184,21 +183,43 @@ extension MultiPurposePopupViewController: UITextFieldDelegate {
         replacementString string: String
     ) -> Bool {
         guard let char = string.cString(using: String.Encoding.utf8) else { return false }
-        let isBackSpace = strcmp(char, "\\b")
+        let isBackSpace: Bool = strcmp(char, "\\b") == -92
 
-        let latinCharCount = textField.text?.alphabetCharacterCeilCount ?? 0
+        let currentText = textField.text ?? ""
+        let latinCharCount: Double = currentText.alphabetCharacterCount
 
-        guard isBackSpace == -92 || latinCharCount < viewModel.type.textLimitCount else { return false }
+        if let lastChar = currentText.last {
+            // 완성되지 않은 한글인 경우
+            if lastChar.isIncompleteHangul {
+                return true
+            }
+
+            // 완성된 한글이지만, 추가로 자음이 결합될 수 있는 경우
+            if !lastChar.isIncompleteHangul &&
+                lastChar.canAddAdditionalJongseong &&
+                latinCharCount <= Double(viewModel.type.textLimitCount) {
+                return true
+            }
+        }
+
+        guard isBackSpace || latinCharCount < Double(viewModel.type.textLimitCount) else { return false }
+
         return true
     }
 }
 
 private extension String {
+    var alphabetCharacterCount: Double {
+        let count = reduce(0) { count, char in
+            return count + (char.isAlphabetCharacter ? 0.5 : 1)
+        }
+        return count
+    }
+
     var alphabetCharacterCeilCount: Int {
         let count = reduce(0) { count, char in
             return count + (char.isAlphabetCharacter ? 0.5 : 1)
         }
-
         return Int(ceil(count))
     }
 }
@@ -206,5 +227,61 @@ private extension String {
 private extension Character {
     var isAlphabetCharacter: Bool {
         return self.unicodeScalars.allSatisfy { $0.isASCII && $0.properties.isAlphabetic }
+    }
+
+    // 완성되지 않은 한글 여부
+    var isIncompleteHangul: Bool {
+        guard let scalar = unicodeScalars.first else { return false }
+
+        // 한글 범위에 있는지 확인 (유니코드 값 범위 체크)
+        let hangulBase: UInt32 = 0xAC00
+        let hangulEnd: UInt32 = 0xD7A3
+
+        if scalar.value >= hangulBase && scalar.value <= hangulEnd {
+            let syllableIndex = (scalar.value - hangulBase)
+            let isCompleted = syllableIndex % 28 != 0
+            return !isCompleted
+        }
+
+        // 완성되지 않은 자모나 조합 중인 경우
+        return (scalar.value >= 0x1100 && scalar.value <= 0x11FF) ||  // 초성 자모 (현대 한글에서 사용하는 초성, 중성, 종성 등의 조합용 자모)
+               (scalar.value >= 0x3130 && scalar.value <= 0x318F) ||  // 호환용 자모 (구성된 한글 자모, 옛 한글 자모 등)
+               (scalar.value >= 0xA960 && scalar.value <= 0xA97F) ||  // 확장 A (옛 한글 자모의 일부)
+               (scalar.value >= 0xD7B0 && scalar.value <= 0xD7FF)     // 확장 B (옛 한글 자모의 일부)
+    }
+
+    /// 한글 음절이 종성을 가졌으나 추가적인 종성이 더 결합될 수 있는지 여부 확인
+    var canAddAdditionalJongseong: Bool {
+        guard let scalar = unicodeScalars.first else { return false }
+
+        // 한글 음절 유니코드 범위: U+AC00 ~ U+D7A3
+        let hangulBase: UInt32 = 0xAC00
+        let hangulEnd: UInt32 = 0xD7A3
+
+        guard scalar.value >= hangulBase && scalar.value <= hangulEnd else {
+            return false
+        }
+
+        // 종성에 해당하는 인덱스를 계산
+        let syllableIndex = scalar.value - hangulBase
+        let jongseongIndex = Int(syllableIndex % 28)
+
+        // 종성이 있을 때 추가 종성을 가질 수 있는 경우를 판별
+        let canHaveDoubleJongseong: Bool
+
+        switch jongseongIndex {
+        case 1: // ㄱ (U+11A8)
+            canHaveDoubleJongseong = true
+        case 4: // ㄴ (U+11AB)
+            canHaveDoubleJongseong = true
+        case 8: // ㄹ (U+11AF)
+            canHaveDoubleJongseong = true
+        case 17: // ㅂ (U+11B7)
+            canHaveDoubleJongseong = true
+        default:
+            canHaveDoubleJongseong = false
+        }
+
+        return canHaveDoubleJongseong
     }
 }

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
@@ -189,7 +189,7 @@ extension MultiPurposePopupViewController: UITextFieldDelegate {
         let latinCharCount: Double = currentText.alphabetCharacterCount
 
         if let lastChar = currentText.last,
-            latinCharCount <= Double(viewModel.type.textLimitCount) {
+           latinCharCount <= Double(viewModel.type.textLimitCount) {
             // 완성되지 않은 한글인 경우
             if lastChar.isIncompleteHangul {
                 return true

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
@@ -229,7 +229,7 @@ private extension Character {
         return self.unicodeScalars.allSatisfy { $0.isASCII && $0.properties.isAlphabetic }
     }
 
-    // 완성되지 않은 한글 여부
+    /// 완성되지 않은 한글 여부
     var isIncompleteHangul: Bool {
         guard let scalar = unicodeScalars.first else { return false }
 
@@ -244,10 +244,10 @@ private extension Character {
         }
 
         // 완성되지 않은 자모나 조합 중인 경우
-        return (scalar.value >= 0x1100 && scalar.value <= 0x11FF) ||  // 초성 자모 (현대 한글에서 사용하는 초성, 중성, 종성 등의 조합용 자모)
-               (scalar.value >= 0x3130 && scalar.value <= 0x318F) ||  // 호환용 자모 (구성된 한글 자모, 옛 한글 자모 등)
-               (scalar.value >= 0xA960 && scalar.value <= 0xA97F) ||  // 확장 A (옛 한글 자모의 일부)
-               (scalar.value >= 0xD7B0 && scalar.value <= 0xD7FF)     // 확장 B (옛 한글 자모의 일부)
+        return (scalar.value >= 0x1100 && scalar.value <= 0x11FF) || // 초성 자모 (현대 한글에서 사용하는 초성, 중성, 종성 등의 조합용 자모)
+            (scalar.value >= 0x3130 && scalar.value <= 0x318F) || // 호환용 자모 (구성된 한글 자모, 옛 한글 자모 등)
+            (scalar.value >= 0xA960 && scalar.value <= 0xA97F) || // 확장 A (옛 한글 자모의 일부)
+            (scalar.value >= 0xD7B0 && scalar.value <= 0xD7FF) // 확장 B (옛 한글 자모의 일부)
     }
 
     /// 한글 음절이 종성을 가졌으나 추가적인 종성이 더 결합될 수 있는지 여부 확인

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
@@ -188,7 +188,8 @@ extension MultiPurposePopupViewController: UITextFieldDelegate {
         let currentText = textField.text ?? ""
         let latinCharCount: Double = currentText.alphabetCharacterCount
 
-        if let lastChar = currentText.last {
+        if let lastChar = currentText.last,
+            latinCharCount <= Double(viewModel.type.textLimitCount) {
             // 완성되지 않은 한글인 경우
             if lastChar.isIncompleteHangul {
                 return true
@@ -196,8 +197,7 @@ extension MultiPurposePopupViewController: UITextFieldDelegate {
 
             // 완성된 한글이지만, 추가로 자음이 결합될 수 있는 경우
             if !lastChar.isIncompleteHangul &&
-                lastChar.canAddAdditionalJongseong &&
-                latinCharCount <= Double(viewModel.type.textLimitCount) {
+                lastChar.canAddAdditionalJongseong {
                 return true
             }
         }


### PR DESCRIPTION
## 💡 배경 및 개요
- 닉네임, 플리 이름 입력시 마지막 글자에서 한글 자모 조합이 되지 않는 문제 발생

Resolves: #1258 

## 📃 작업내용
- 현재 작성한 조건(백스페이스, 글자수 제한)에서 입력한 '마지막' 글자가 완성된 한글이 아니거나, 추가로 자음이 결합될 수 있는 조건을 추가

## 🙋‍♂️ 리뷰노트
- 이런 조건을 추가했을때, 마지막 글자가 ex: '일' 이라면 추가로 받침이 더 올 수 있으므로 글자 수 제한을 넘어 계속 입력이 가능합니다. 하지만 빨간 경고 UI를 띄워 보여주고 있으므로 괜찮을듯 함. 

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
