### PR TITLE
🔀 :: (#1285) 참여정보(크레딧) > 데이터 없을 때 UI 처리

### DIFF
--- a/Projects/Features/SongCreditFeature/Sources/SongCreditViewController.swift
+++ b/Projects/Features/SongCreditFeature/Sources/SongCreditViewController.swift
@@ -71,6 +71,26 @@ final class SongCreditViewController: BaseReactorViewController<SongCreditReacto
         $0.clipsToBounds = true
     }
 
+    private let warningView = UIView().then {
+        $0.isHidden = true
+    }
+
+    private let warningImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFit
+        $0.image = DesignSystemAsset.LyricHighlighting.errorDark.image
+    }
+
+    private let warningLabel = WMLabel(
+        text: "참여 정보가 없습니다.",
+        textColor: DesignSystemAsset.BlueGrayColor.blueGray200.color,
+        font: .t6(weight: .light),
+        alignment: .center,
+        lineHeight: UIFont.WMFontSystem.t6(weight: .light).lineHeight
+    ).then {
+        $0.numberOfLines = 0
+        $0.preferredMaxLayoutWidth = APP_WIDTH() - 40
+    }
+
     private let dimmedBackgroundView = UIView()
     private var dimmedGridentLayer: DimmedGradientLayer?
     private let wmNavigationbarView = WMNavigationBarView()
@@ -104,7 +124,14 @@ final class SongCreditViewController: BaseReactorViewController<SongCreditReacto
     }
 
     override func addView() {
-        view.addSubviews(backgroundImageView, dimmedBackgroundView, songCreditCollectionView, wmNavigationbarView)
+        view.addSubviews(
+            backgroundImageView,
+            dimmedBackgroundView,
+            songCreditCollectionView,
+            wmNavigationbarView,
+            warningView
+        )
+        warningView.addSubviews(warningImageView, warningLabel)
     }
 
     override func setLayout() {
@@ -125,6 +152,23 @@ final class SongCreditViewController: BaseReactorViewController<SongCreditReacto
             $0.top.equalToSuperview().offset(STATUS_BAR_HEGHIT())
             $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(48)
+        }
+
+        warningView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(APP_HEIGHT() * ((294.0 - 6.0) / 812.0))
+            $0.centerX.equalToSuperview()
+        }
+
+        warningImageView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
+            $0.centerX.equalToSuperview()
+        }
+
+        warningLabel.snp.makeConstraints {
+            $0.top.equalTo(warningImageView.snp.bottom).offset(-2)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalToSuperview()
         }
     }
 
@@ -161,8 +205,10 @@ final class SongCreditViewController: BaseReactorViewController<SongCreditReacto
         let sharedState = reactor.state.share()
 
         sharedState.map(\.credits)
+            .skip(1)
             .distinctUntilChanged()
-            .bind { [creditDiffableDataSource] credits in
+            .bind { [creditDiffableDataSource, warningView] credits in
+                warningView.isHidden = !credits.isEmpty
                 var snapshot = NSDiffableDataSourceSnapshot<SectionType, ItemType>()
                 snapshot.appendSections(credits.map(\.position))
                 credits.forEach { snapshot.appendItems($0.names, toSection: $0.position) }


### PR DESCRIPTION
## 💡 배경 및 개요
- 신곡의 경우 크레딧 정보가 없는 상태가 있음


Resolves: #1285 

## 📃 작업내용
- 빈 데이터 UI 처리

## 🙋‍♂️ 리뷰노트
x

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
