### PR TITLE
🔀 :: (#1287) privacy, terms 주소 변경

### DIFF
--- a/Projects/App/Support/Info.plist
+++ b/Projects/App/Support/Info.plist
@@ -55,6 +55,8 @@
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
+        <string>naversearchapp</string>
+        <string>naversearchthirdlogin</string>
 		<string>youtube</string>
 		<string>youtubemusic</string>
 	</array>

--- a/Projects/App/Support/Info.plist
+++ b/Projects/App/Support/Info.plist
@@ -55,8 +55,8 @@
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
-		<string>naversearchapp</string>
-		<string>naversearchthirdlogin</string>
+		<string>youtube</string>
+		<string>youtubemusic</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
@@ -70,10 +70,10 @@
 	<dict>
 		<key>BASE_DEV_URL</key>
 		<string>$(BASE_DEV_URL)</string>
-		<key>BASE_IMAGE_URL</key>
-		<string>$(BASE_IMAGE_URL)</string>
 		<key>BASE_PROD_URL</key>
 		<string>$(BASE_PROD_URL)</string>
+        <key>CDN_DOMAIN_URL</key>
+        <string>$(CDN_DOMAIN_URL)</string>
 		<key>GOOGLE_CLIENT_ID</key>
 		<string>$(GOOGLE_CLIENT_ID)</string>
 		<key>GOOGLE_URL_SCHEME</key>
@@ -100,22 +100,6 @@
 		<string>$(WMDOMAIN_FAQ)</string>
 		<key>WMDOMAIN_IMAGE</key>
 		<string>$(WMDOMAIN_IMAGE)</string>
-		<key>WMDOMAIN_IMAGE_ARTIST_ROUND</key>
-		<string>$(WMDOMAIN_IMAGE_ARTIST_ROUND)</string>
-		<key>WMDOMAIN_IMAGE_ARTIST_SQUARE</key>
-		<string>$(WMDOMAIN_IMAGE_ARTIST_SQUARE)</string>
-		<key>WMDOMAIN_IMAGE_NEWS</key>
-		<string>$(WMDOMAIN_IMAGE_NEWS)</string>
-		<key>WMDOMAIN_IMAGE_NOTICE</key>
-		<string>$(WMDOMAIN_IMAGE_NOTICE)</string>
-		<key>WMDOMAIN_IMAGE_PLAYLIST</key>
-		<string>$(WMDOMAIN_IMAGE_PLAYLIST)</string>
-		<key>WMDOMAIN_IMAGE_PROFILE</key>
-		<string>$(WMDOMAIN_IMAGE_PROFILE)</string>
-		<key>WMDOMAIN_IMAGE_RECOMMEND_PLAYLIST_ROUND</key>
-		<string>$(WMDOMAIN_IMAGE_RECOMMEND_PLAYLIST_ROUND)</string>
-		<key>WMDOMAIN_IMAGE_RECOMMEND_PLAYLIST_SQUARE</key>
-		<string>$(WMDOMAIN_IMAGE_RECOMMEND_PLAYLIST_SQUARE)</string>
 		<key>WMDOMAIN_LIKE</key>
 		<string>$(WMDOMAIN_LIKE)</string>
 		<key>WMDOMAIN_NOTICE</key>
@@ -185,10 +169,5 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
-	<key>LSApplicationQueriesSchemes</key>
-    <array>
-        <string>youtube</string>
-        <string>youtubemusic</string>
-    </array>
 </dict>
 </plist>

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/ContractViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/ContractViewController.swift
@@ -34,9 +34,9 @@ extension ContractType {
     var url: String {
         switch self {
         case .privacy:
-            return "\(BASE_IMAGE_URL())/static/document/privacy.pdf"
+            return "\(CDN_DOMAIN_URL())/document/privacy.pdf"
         case .service:
-            return "\(BASE_IMAGE_URL())/static/document/terms.pdf"
+            return "\(CDN_DOMAIN_URL())/document/terms.pdf"
         }
     }
 }

--- a/Projects/Modules/Utility/Sources/Utils/Secrets.swift
+++ b/Projects/Modules/Utility/Sources/Utils/Secrets.swift
@@ -15,42 +15,9 @@ public func config(key: String) -> String {
     return secrets[key] as? String ?? "not found key"
 }
 
-// MARK: - BASE_IMAGE_URL
-public func BASE_IMAGE_URL() -> String {
-    return config(key: "BASE_IMAGE_URL")
-}
-
-// MARK: - WMDomain > Image
-public func WMDOMAIN_IMAGE_NEWS() -> String {
-    return config(key: "WMDOMAIN_IMAGE_NEWS")
-}
-
-public func WMDOMAIN_IMAGE_ARTIST_ROUND() -> String {
-    return config(key: "WMDOMAIN_IMAGE_ARTIST_ROUND")
-}
-
-public func WMDOMAIN_IMAGE_ARTIST_SQUARE() -> String {
-    return config(key: "WMDOMAIN_IMAGE_ARTIST_SQUARE")
-}
-
-public func WMDOMAIN_IMAGE_PROFILE() -> String {
-    return config(key: "WMDOMAIN_IMAGE_PROFILE")
-}
-
-public func WMDOMAIN_IMAGE_PLAYLIST() -> String {
-    return config(key: "WMDOMAIN_IMAGE_PLAYLIST")
-}
-
-public func WMDOMAIN_IMAGE_RECOMMEND_PLAYLIST_SQUARE() -> String {
-    return config(key: "WMDOMAIN_IMAGE_RECOMMEND_PLAYLIST_SQUARE")
-}
-
-public func WMDOMAIN_IMAGE_RECOMMEND_PLAYLIST_ROUND() -> String {
-    return config(key: "WMDOMAIN_IMAGE_RECOMMEND_PLAYLIST_ROUND")
-}
-
-public func WMDOMAIN_IMAGE_NOTICE() -> String {
-    return config(key: "WMDOMAIN_IMAGE_NOTICE")
+// MARK: - CDN Domain
+public func CDN_DOMAIN_URL() -> String {
+    return config(key: "CDN_DOMAIN_URL")
 }
 
 // MARK: - NAVER


### PR DESCRIPTION
## 💡 배경 및 개요
- 개인정보 처리방침, 서비스 이용약관 pdf 로드 주소가 변경 됨

Resolves: #1287 

## 📃 작업내용
- CDN 도메인 Secrets.xcconfig에 추가 (노션 업데이트)
- 미사용 도메인 경로 Secrets.xcconfig에서 제거 (노션 업데이트)
- privacy, terms 주소 변경

## 🙋‍♂️ 리뷰노트
x

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (Secrets.xcconfig 노션 업데이트)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
