### PR TITLE
🔀  ::  (#1289) 누락된 열매함 바로가기 기능 추가

### DIFF
--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -242,10 +242,14 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
+        myInfoView.rx.fruitStorageButtonDidTap
+            .do(onNext: { LogManager.analytics(MyInfoAnalyticsLog.clickFruitStorageButton) })
+            .map { MyInfoReactor.Action.fruitNavigationDidTap }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         myInfoView.rx.drawButtonDidTap
-            .do(onNext: {
-                LogManager.analytics(MyInfoAnalyticsLog.clickFruitDrawEntryButton(location: .myPage))
-            })
+            .do(onNext: { LogManager.analytics(MyInfoAnalyticsLog.clickFruitDrawEntryButton(location: .myPage)) })
             .map { MyInfoReactor.Action.drawButtonDidTap }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)

--- a/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
+++ b/Projects/Features/MyInfoFeature/Sources/ViewControllers/MyInfo/MyInfoViewController.swift
@@ -247,7 +247,7 @@ final class MyInfoViewController: BaseReactorViewController<MyInfoReactor>, Edit
             .map { MyInfoReactor.Action.fruitNavigationDidTap }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
-        
+
         myInfoView.rx.drawButtonDidTap
             .do(onNext: { LogManager.analytics(MyInfoAnalyticsLog.clickFruitDrawEntryButton(location: .myPage)) })
             .map { MyInfoReactor.Action.drawButtonDidTap }

--- a/Projects/Features/MyInfoFeature/Sources/Views/FruitDrawButtonView.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/FruitDrawButtonView.swift
@@ -40,9 +40,9 @@ final class FruitDrawButtonView: UIView {
         lineHeight: UIFont.WMFontSystem.t5().lineHeight,
         kernValue: -0.5
     )
-    
+
     let fruitStorageButton = UIButton()
-    
+
     let drawButton = UIButton().then {
         $0.titleLabel?.font = DesignSystemFontFamily.Pretendard.medium.font(size: 14)
         $0.setTitle("뽑기", for: .normal)
@@ -94,7 +94,7 @@ extension FruitDrawButtonView {
             $0.leading.equalTo(backgroundView.snp.leading)
             $0.trailing.equalTo(drawButton.snp.leading)
         }
-        
+
         drawButton.snp.makeConstraints {
             $0.verticalEdges.equalTo(backgroundView.snp.verticalEdges)
             $0.trailing.equalTo(backgroundView.snp.trailing)

--- a/Projects/Features/MyInfoFeature/Sources/Views/FruitDrawButtonView.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/FruitDrawButtonView.swift
@@ -10,6 +10,7 @@ private protocol FruitDrawStateProtocol {
 }
 
 private protocol FruitDrawActionProtocol {
+    var fruitStorageButtonDidTap: Observable<Void> { get }
     var drawButtonDidTap: Observable<Void> { get }
 }
 
@@ -39,7 +40,9 @@ final class FruitDrawButtonView: UIView {
         lineHeight: UIFont.WMFontSystem.t5().lineHeight,
         kernValue: -0.5
     )
-
+    
+    let fruitStorageButton = UIButton()
+    
     let drawButton = UIButton().then {
         $0.titleLabel?.font = DesignSystemFontFamily.Pretendard.medium.font(size: 14)
         $0.setTitle("뽑기", for: .normal)
@@ -66,6 +69,7 @@ extension FruitDrawButtonView {
             backgroundView,
             titleLabel,
             countLabel,
+            fruitStorageButton,
             drawButton
         )
     }
@@ -85,6 +89,12 @@ extension FruitDrawButtonView {
             $0.left.equalTo(titleLabel.snp.right).offset(8)
         }
 
+        fruitStorageButton.snp.makeConstraints {
+            $0.verticalEdges.equalTo(backgroundView.snp.verticalEdges)
+            $0.leading.equalTo(backgroundView.snp.leading)
+            $0.trailing.equalTo(drawButton.snp.leading)
+        }
+        
         drawButton.snp.makeConstraints {
             $0.verticalEdges.equalTo(backgroundView.snp.verticalEdges)
             $0.trailing.equalTo(backgroundView.snp.trailing)
@@ -100,5 +110,6 @@ extension FruitDrawButtonView: FruitDrawStateProtocol {
 }
 
 extension Reactive: FruitDrawActionProtocol where Base: FruitDrawButtonView {
+    var fruitStorageButtonDidTap: Observable<Void> { base.fruitStorageButton.rx.tap.asObservable() }
     var drawButtonDidTap: Observable<Void> { base.drawButton.rx.tap.asObservable() }
 }

--- a/Projects/Features/MyInfoFeature/Sources/Views/MyInfoView.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Views/MyInfoView.swift
@@ -17,6 +17,7 @@ private protocol MyInfoActionProtocol {
     var scrollViewDidTap: Observable<Void> { get }
     var loginButtonDidTap: Observable<Void> { get }
     var profileImageDidTap: Observable<Void> { get }
+    var fruitStorageButtonDidTap: Observable<Void> { get }
     var drawButtonDidTap: Observable<Void> { get }
     var fruitNavigationButtonDidTap: Observable<Void> { get }
     var qnaNavigationButtonDidTap: Observable<Void> { get }
@@ -204,6 +205,7 @@ extension Reactive: MyInfoActionProtocol where Base: MyInfoView {
 
     var loginButtonDidTap: Observable<Void> { base.loginWarningView.rx.loginButtonDidTap }
     var profileImageDidTap: Observable<Void> { base.profileView.rx.profileImageDidTap }
+    var fruitStorageButtonDidTap: Observable<Void> { base.fruitDrawButtonView.rx.fruitStorageButtonDidTap }
     var drawButtonDidTap: Observable<Void> { base.fruitDrawButtonView.rx.drawButtonDidTap }
     var fruitNavigationButtonDidTap: Observable<Void> { base.fruitNavigationButton.rx.tap.asObservable() }
     var qnaNavigationButtonDidTap: Observable<Void> { base.qnaNavigationButton.rx.tap.asObservable() }


### PR DESCRIPTION
## 💡 배경 및 개요

기능 누락

Resolves: #1289

## 📃 작업내용

- 열매함 바로가기 투명 버튼 추가

<img width="439" alt="스크린샷 2024-09-04 오후 11 24 56" src="https://github.com/user-attachments/assets/f06632b7-0680-4768-9a62-82ada6657373">



## 🙋‍♂️ 리뷰노트

<!--
> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!
-->

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
