### PR TITLE
🔀 :: (#1293) 중복 닉네임 에러 캐치 등

### DIFF
--- a/Projects/Domains/UserDomain/Sources/API/UserAPI.swift
+++ b/Projects/Domains/UserDomain/Sources/API/UserAPI.swift
@@ -141,7 +141,9 @@ extension UserAPI: WMAPI {
             return [
                 400: .badRequest,
                 401: .tokenExpired,
+                403: .forbidden,
                 404: .notFound,
+                409: .conflict,
                 429: .tooManyRequest,
                 500: .internalServerError
             ]

--- a/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
+++ b/Projects/Features/BaseFeature/Sources/ViewControllers/MultiPurposePopupViewController.swift
@@ -117,8 +117,6 @@ private extension MultiPurposePopupViewController {
 
 private extension MultiPurposePopupViewController {
     func configureUI() {
-        limitLabel.text = "/\(viewModel.type.textLimitCount)"
-
         titleLabel.text = viewModel.type.title
         titleLabel.font = DesignSystemFontFamily.Pretendard.medium.font(size: 18)
         titleLabel.textColor = DesignSystemAsset.BlueGrayColor.gray900.color
@@ -155,6 +153,7 @@ private extension MultiPurposePopupViewController {
         confirmLabel.font = DesignSystemFontFamily.Pretendard.light.font(size: 12)
         confirmLabel.isHidden = true
 
+        limitLabel.text = "/\(viewModel.type.textLimitCount)자"
         limitLabel.font = DesignSystemFontFamily.Pretendard.light.font(size: 12)
         limitLabel.textColor = DesignSystemAsset.BlueGrayColor.gray500.color
 

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -296,7 +296,7 @@ private extension MyInfoReactor {
             .catch { error in
                 let error = error.asWMError
                 if error == .conflict {
-                    return .just(.showToast("키워드 혹은 중복된 닉네임은 사용할 수 없습니다."))
+                    return .just(.showToast("키워드 또는 중복된 닉네임은 사용할 수 없습니다."))
                 } else {
                     return .concat(
                         .just(.showToast(error.errorDescription ?? LocalizationStrings.unknownErrorWarning)),

--- a/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
+++ b/Projects/Features/MyInfoFeature/Sources/Reactors/MyInfoReactor.swift
@@ -295,10 +295,14 @@ private extension MyInfoReactor {
             )
             .catch { error in
                 let error = error.asWMError
-                return .concat(
-                    .just(.showToast(error.errorDescription ?? LocalizationStrings.unknownErrorWarning)),
-                    .just(.dismissEditSheet)
-                )
+                if error == .conflict {
+                    return .just(.showToast("키워드 혹은 중복된 닉네임은 사용할 수 없습니다."))
+                } else {
+                    return .concat(
+                        .just(.showToast(error.errorDescription ?? LocalizationStrings.unknownErrorWarning)),
+                        .just(.dismissEditSheet)
+                    )
+                }
             }
     }
 


### PR DESCRIPTION
## 💡 배경 및 개요
- 키워드, 중복 닉네임에 대한 처리 미흡

Resolves: #1293 

## 📃 작업내용
- '자' 텍스트 추가된 UI 수정: (n자/12 > n자/12자)
- 409 conflict 에러 캐치

## 🙋‍♂️ 리뷰노트
- 이제 develop으로 머지

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
