### PR TITLE
🔀 :: (#1323) 마이 플리 재생 시 플리 제목이 '왁타버스 뮤직'으로 노출됨

### DIFF
--- a/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
+++ b/Projects/Features/PlaylistFeature/Sources/ViewControllers/MyPlaylistDetailViewController.swift
@@ -596,9 +596,9 @@ extension MyPlaylistDetailViewController: PlayButtonGroupViewDelegate {
         PlayState.shared.append(contentsOf: songs.map { PlaylistItem(id: $0.id, title: $0.title, artist: $0.artist) })
 
         if songs.allSatisfy({ $0.title.isContainShortsTagTitle }) {
-            WakmusicYoutubePlayer(ids: songs.map { $0.id }, title: "왁타버스 뮤직", playPlatform: .youtube).play()
+            WakmusicYoutubePlayer(ids: songs.map { $0.id }, title: title, playPlatform: .youtube).play()
         } else {
-            WakmusicYoutubePlayer(ids: songs.map { $0.id }, title: "왁타버스 뮤직").play()
+            WakmusicYoutubePlayer(ids: songs.map { $0.id }, title: title).play()
         }
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요

<!--
> PR을 하게 된 문제상황, 배경 등 개요에 대해서 작성해주세요!
>
> 퍼블리싱의 경우 스크린샷/동영상도 추가해주면 좋아요!
-->

<!-- resolved issue 넘버 표기 방식 변경 시 '.github/actions/Auto_close_associate_issue/main.js' 또한 변경 필요 -->

마이 플리 재생 시 플리 제목이 '왁타버스 뮤직'으로 노출됨

Resolves: #1323

## 📃 작업내용

<!--
> PR에서 한 작업을 자세히 작성해주세요!
-->

마이 플리 재생 시 플리 제목이 '왁타버스 뮤직'으로 노출되는 이슈 해결

## ✅ PR 체크리스트

<!--
> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!
-->

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `XCConfig`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"XCConfig 값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
